### PR TITLE
Add Danger plugin to check if a manifest change has a corresponding lock change

### DIFF
--- a/lib/danger_plugin.rb
+++ b/lib/danger_plugin.rb
@@ -1,3 +1,4 @@
 # frozen_string_literal: true
 
+require 'dangermattic/plugins/manifest_pr_checker'
 require 'dangermattic/plugins/view_changes_need_screenshots'

--- a/lib/dangermattic/plugins/manifest_pr_checker.rb
+++ b/lib/dangermattic/plugins/manifest_pr_checker.rb
@@ -13,6 +13,15 @@ module Danger
       )
     end
 
+      # Check if the `Podfile` file was modified without a corresponding `Podfile.lock` update 
+      def check_podfile_lock_updated
+        check_manifest_lock_updated(
+          file_name: 'Podfile',
+          lock_file_name: 'Podfile.lock',
+          instruction: 'Please run `bundle exec pod install`'
+        )
+      end
+    
     # Check if the `Package.swift` file was modified without a corresponding `Package.resolved` update 
     def check_swift_package_resolved_updated
       check_manifest_lock_updated(

--- a/lib/dangermattic/plugins/manifest_pr_checker.rb
+++ b/lib/dangermattic/plugins/manifest_pr_checker.rb
@@ -38,7 +38,7 @@ module Danger
       lock_modified = git.modified_files.include?(lock_file_name)
       
       if manifest_modified && !lock_modified
-        failure("#{file_name} was changed without updating #{lock_file_name}. #{instruction}.")
+        warn("#{file_name} was changed without updating #{lock_file_name}. #{instruction}.")
       end
     end
   end

--- a/lib/dangermattic/plugins/manifest_pr_checker.rb
+++ b/lib/dangermattic/plugins/manifest_pr_checker.rb
@@ -3,6 +3,15 @@
 module Danger
   # Plugin to check if the Gemfile.lock was updated when changing the Gemfile in a PR.
   class ManifestPRChecker < Plugin
+
+    # Performs all the checks, asserting that changes on `Gemfile`, `Podfile` and `Package.swift` must have corresponding
+    # lock file changes.
+    def check_all_manifest_lock_updated
+      check_gemfile_lock_updated
+      check_podfile_lock_updated
+      check_swift_package_resolved_updated
+    end
+
     # Check if the `Gemfile` file was modified without a corresponding `Gemfile.lock` update
     def check_gemfile_lock_updated
       check_manifest_lock_updated(

--- a/lib/dangermattic/plugins/manifest_pr_checker.rb
+++ b/lib/dangermattic/plugins/manifest_pr_checker.rb
@@ -3,7 +3,6 @@
 module Danger
   # Plugin to check if the Gemfile.lock was updated when changing the Gemfile in a PR.
   class ManifestPRChecker < Plugin
-
     # Performs all the checks, asserting that changes on `Gemfile`, `Podfile` and `Package.swift` must have corresponding
     # lock file changes.
     def check_all_manifest_lock_updated
@@ -42,10 +41,10 @@ module Danger
     private
 
     def check_manifest_lock_updated(file_name:, lock_file_name:, instruction:)
-      manifest_modified = git.modified_files.include?(file_name)
-      lock_modified = git.modified_files.include?(lock_file_name)
+      manifest_modified_file = git.modified_files.find { |f| f.end_with?(file_name) }
+      lock_modified = git.modified_files.any? { |f| f.end_with?(lock_file_name) && manifest_modified_file && File.dirname(f) == File.dirname(manifest_modified_file) }
 
-      return unless manifest_modified && !lock_modified
+      return unless manifest_modified_file && !lock_modified
 
       warn("#{file_name} was changed without updating #{lock_file_name}. #{instruction}.")
     end

--- a/lib/dangermattic/plugins/manifest_pr_checker.rb
+++ b/lib/dangermattic/plugins/manifest_pr_checker.rb
@@ -3,8 +3,7 @@
 module Danger
   # Plugin to check if the Gemfile.lock was updated when changing the Gemfile in a PR.
   class ManifestPRChecker < Plugin
-
-    # Check if the `Gemfile` file was modified without a corresponding `Gemfile.lock` update 
+    # Check if the `Gemfile` file was modified without a corresponding `Gemfile.lock` update
     def check_gemfile_lock_updated
       check_manifest_lock_updated(
         file_name: 'Gemfile',
@@ -13,16 +12,16 @@ module Danger
       )
     end
 
-      # Check if the `Podfile` file was modified without a corresponding `Podfile.lock` update 
-      def check_podfile_lock_updated
-        check_manifest_lock_updated(
-          file_name: 'Podfile',
-          lock_file_name: 'Podfile.lock',
-          instruction: 'Please run `bundle exec pod install`'
-        )
-      end
-    
-    # Check if the `Package.swift` file was modified without a corresponding `Package.resolved` update 
+    # Check if the `Podfile` file was modified without a corresponding `Podfile.lock` update
+    def check_podfile_lock_updated
+      check_manifest_lock_updated(
+        file_name: 'Podfile',
+        lock_file_name: 'Podfile.lock',
+        instruction: 'Please run `bundle exec pod install`'
+      )
+    end
+
+    # Check if the `Package.swift` file was modified without a corresponding `Package.resolved` update
     def check_swift_package_resolved_updated
       check_manifest_lock_updated(
         file_name: 'Package.swift',
@@ -36,10 +35,10 @@ module Danger
     def check_manifest_lock_updated(file_name:, lock_file_name:, instruction:)
       manifest_modified = git.modified_files.include?(file_name)
       lock_modified = git.modified_files.include?(lock_file_name)
-      
-      if manifest_modified && !lock_modified
-        warn("#{file_name} was changed without updating #{lock_file_name}. #{instruction}.")
-      end
+
+      return unless manifest_modified && !lock_modified
+
+      warn("#{file_name} was changed without updating #{lock_file_name}. #{instruction}.")
     end
   end
 end

--- a/lib/dangermattic/plugins/manifest_pr_checker.rb
+++ b/lib/dangermattic/plugins/manifest_pr_checker.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+module Danger
+  # Plugin to check if the Gemfile.lock was updated when changing the Gemfile in a PR.
+  class ManifestPRChecker < Plugin
+
+    # Check if the `Gemfile` file was modified without a corresponding `Gemfile.lock` update 
+    def check_gemfile_lock_updated
+      check_manifest_lock_updated(
+        file_name: 'Gemfile',
+        lock_file_name: 'Gemfile.lock',
+        instruction: 'Please run `bundle install` or `bundle update <updated_gem>`'
+      )
+    end
+
+    # Check if the `Package.swift` file was modified without a corresponding `Package.resolved` update 
+    def check_swift_package_resolved_updated
+      check_manifest_lock_updated(
+        file_name: 'Package.swift',
+        lock_file_name: 'Package.resolved',
+        instruction: 'Please resolve the Swift packages in Xcode'
+      )
+    end
+
+    private
+
+    def check_manifest_lock_updated(file_name:, lock_file_name:, instruction:)
+      manifest_modified = git.modified_files.include?(file_name)
+      lock_modified = git.modified_files.include?(lock_file_name)
+      
+      if manifest_modified && !lock_modified
+        failure("#{file_name} was changed without updating #{lock_file_name}. #{instruction}.")
+      end
+    end
+  end
+end

--- a/spec/manifest_pr_checker_spec.rb
+++ b/spec/manifest_pr_checker_spec.rb
@@ -32,6 +32,24 @@ module Danger
         expect(@dangerfile.status_report[:errors]).to be_empty
       end
 
+      it 'returns an error when a PR changed the Podfile but not the Podfile.lock' do
+        modified_files = ['Podfile']
+        allow(@plugin.git).to receive(:modified_files).and_return(modified_files)
+
+        @plugin.check_podfile_lock_updated
+
+        expect(@dangerfile.status_report[:errors].count).to eq 1
+      end
+
+      it 'returns no errors when both the Podfile and the Podfile.lock were updated' do
+        modified_files = ['Podfile', 'Podfile.lock']
+        allow(@plugin.git).to receive(:modified_files).and_return(modified_files)
+
+        @plugin.check_podfile_lock_updated
+
+        expect(@dangerfile.status_report[:errors]).to be_empty
+      end
+
       it 'returns an error when a PR changed the Package.swift but not the Package.resolved' do
         modified_files = ['Package.swift']
         allow(@plugin.git).to receive(:modified_files).and_return(modified_files)

--- a/spec/manifest_pr_checker_spec.rb
+++ b/spec/manifest_pr_checker_spec.rb
@@ -11,41 +11,41 @@ module Danger
     describe 'with Dangerfile' do
       before do
         @dangerfile = testing_dangerfile
-        @my_plugin = @dangerfile.manifest_pr_checker
+        @plugin = @dangerfile.manifest_pr_checker
       end
 
-      it 'returns an error when a PR changed the Gemfile but not Gemfile.lock' do
+      it 'returns an error when a PR changed the Gemfile but not the Gemfile.lock' do
         modified_files = ['Gemfile']
-        allow(@my_plugin.git).to receive(:modified_files).and_return(modified_files)
+        allow(@plugin.git).to receive(:modified_files).and_return(modified_files)
 
-        @my_plugin.check_gemfile_lock_updated
+        @plugin.check_gemfile_lock_updated
 
         expect(@dangerfile.status_report[:errors].count).to eq 1
       end
 
-      it 'returns no errors when both Gemfile and Gemfile.lock were updated' do
+      it 'returns no errors when both the Gemfile and the Gemfile.lock were updated' do
         modified_files = ['Gemfile', 'Gemfile.lock']
-        allow(@my_plugin.git).to receive(:modified_files).and_return(modified_files)
+        allow(@plugin.git).to receive(:modified_files).and_return(modified_files)
 
-        @my_plugin.check_gemfile_lock_updated
+        @plugin.check_gemfile_lock_updated
 
         expect(@dangerfile.status_report[:errors]).to be_empty
       end
 
-      it 'returns an error when a PR changed the Package.swift but not Package.resolved' do
+      it 'returns an error when a PR changed the Package.swift but not the Package.resolved' do
         modified_files = ['Package.swift']
-        allow(@my_plugin.git).to receive(:modified_files).and_return(modified_files)
+        allow(@plugin.git).to receive(:modified_files).and_return(modified_files)
 
-        @my_plugin.check_swift_package_resolved_updated
+        @plugin.check_swift_package_resolved_updated
 
         expect(@dangerfile.status_report[:errors].count).to eq 1
       end
 
-      it 'returns no errors when both Package.swift and Package.resolved were updated' do
+      it 'returns no errors when both the Package.swift and the Package.resolved were updated' do
         modified_files = ['Package.swift', 'Package.resolved']
-        allow(@my_plugin.git).to receive(:modified_files).and_return(modified_files)
+        allow(@plugin.git).to receive(:modified_files).and_return(modified_files)
 
-        @my_plugin.check_swift_package_resolved_updated
+        @plugin.check_swift_package_resolved_updated
 
         expect(@dangerfile.status_report[:errors]).to be_empty
       end

--- a/spec/manifest_pr_checker_spec.rb
+++ b/spec/manifest_pr_checker_spec.rb
@@ -64,6 +64,26 @@ module Danger
           expect(@dangerfile.status_report[:warnings]).to be_empty
         end
 
+        it 'returns a warning when a PR changed a custom located Podfile but not the corresponding Podfile.lock' do
+          modified_files = ['./path/to/Podfile', './my/Podfile.lock']
+          allow(@plugin.git).to receive(:modified_files).and_return(modified_files)
+
+          @plugin.check_podfile_lock_updated
+
+          expected_warning = ['Podfile was changed without updating Podfile.lock. Please run `bundle exec pod install`.']
+          expect(@dangerfile.status_report[:warnings]).to eq expected_warning
+        end
+
+        it 'returns no warnings when both custom located Podfile and the Podfile.lock were updated' do
+          modified_files = ['./my/path/to/Podfile', './my/path/to/Podfile.lock']
+          allow(@plugin.git).to receive(:modified_files).and_return(modified_files)
+
+          @plugin.check_podfile_lock_updated
+
+          expect(@dangerfile.status_report[:warnings]).to be_empty
+        end
+
+
         it 'returns no warnings when only the Podfile.lock was updated' do
           modified_files = ['Podfile.lock']
           allow(@plugin.git).to receive(:modified_files).and_return(modified_files)

--- a/spec/manifest_pr_checker_spec.rb
+++ b/spec/manifest_pr_checker_spec.rb
@@ -20,11 +20,21 @@ module Danger
 
         @plugin.check_gemfile_lock_updated
 
-        expect(@dangerfile.status_report[:warnings].count).to eq 1
+        expected_warning = ['Gemfile was changed without updating Gemfile.lock. Please run `bundle install` or `bundle update <updated_gem>`.']
+        expect(@dangerfile.status_report[:warnings]).to eq expected_warning
       end
 
       it 'returns no warnings when both the Gemfile and the Gemfile.lock were updated' do
         modified_files = ['Gemfile', 'Gemfile.lock']
+        allow(@plugin.git).to receive(:modified_files).and_return(modified_files)
+
+        @plugin.check_gemfile_lock_updated
+
+        expect(@dangerfile.status_report[:warnings]).to be_empty
+      end
+
+      it 'returns no warnings when only the Gemfile.lock was updated' do
+        modified_files = ['Gemfile.lock']
         allow(@plugin.git).to receive(:modified_files).and_return(modified_files)
 
         @plugin.check_gemfile_lock_updated
@@ -38,11 +48,21 @@ module Danger
 
         @plugin.check_podfile_lock_updated
 
-        expect(@dangerfile.status_report[:warnings].count).to eq 1
+        expected_warning = ['Podfile was changed without updating Podfile.lock. Please run `bundle exec pod install`.']
+        expect(@dangerfile.status_report[:warnings]).to eq expected_warning
       end
 
       it 'returns no warnings when both the Podfile and the Podfile.lock were updated' do
         modified_files = ['Podfile', 'Podfile.lock']
+        allow(@plugin.git).to receive(:modified_files).and_return(modified_files)
+
+        @plugin.check_podfile_lock_updated
+
+        expect(@dangerfile.status_report[:warnings]).to be_empty
+      end
+
+      it 'returns no warnings when only the Podfile.lock was updated' do
+        modified_files = ['Podfile.lock']
         allow(@plugin.git).to receive(:modified_files).and_return(modified_files)
 
         @plugin.check_podfile_lock_updated
@@ -56,11 +76,21 @@ module Danger
 
         @plugin.check_swift_package_resolved_updated
 
-        expect(@dangerfile.status_report[:warnings].count).to eq 1
+        expected_warning = ['Package.swift was changed without updating Package.resolved. Please resolve the Swift packages in Xcode.']
+        expect(@dangerfile.status_report[:warnings]).to eq expected_warning
       end
 
       it 'returns no warnings when both the Package.swift and the Package.resolved were updated' do
         modified_files = ['Package.swift', 'Package.resolved']
+        allow(@plugin.git).to receive(:modified_files).and_return(modified_files)
+
+        @plugin.check_swift_package_resolved_updated
+
+        expect(@dangerfile.status_report[:warnings]).to be_empty
+      end
+
+      it 'returns no warnings when only the Package.resolved was updated' do
+        modified_files = ['Package.resolved']
         allow(@plugin.git).to receive(:modified_files).and_return(modified_files)
 
         @plugin.check_swift_package_resolved_updated

--- a/spec/manifest_pr_checker_spec.rb
+++ b/spec/manifest_pr_checker_spec.rb
@@ -14,58 +14,58 @@ module Danger
         @plugin = @dangerfile.manifest_pr_checker
       end
 
-      it 'returns an error when a PR changed the Gemfile but not the Gemfile.lock' do
+      it 'returns a warning when a PR changed the Gemfile but not the Gemfile.lock' do
         modified_files = ['Gemfile']
         allow(@plugin.git).to receive(:modified_files).and_return(modified_files)
 
         @plugin.check_gemfile_lock_updated
 
-        expect(@dangerfile.status_report[:errors].count).to eq 1
+        expect(@dangerfile.status_report[:warnings].count).to eq 1
       end
 
-      it 'returns no errors when both the Gemfile and the Gemfile.lock were updated' do
+      it 'returns no warnings when both the Gemfile and the Gemfile.lock were updated' do
         modified_files = ['Gemfile', 'Gemfile.lock']
         allow(@plugin.git).to receive(:modified_files).and_return(modified_files)
 
         @plugin.check_gemfile_lock_updated
 
-        expect(@dangerfile.status_report[:errors]).to be_empty
+        expect(@dangerfile.status_report[:warnings]).to be_empty
       end
 
-      it 'returns an error when a PR changed the Podfile but not the Podfile.lock' do
+      it 'returns a warning when a PR changed the Podfile but not the Podfile.lock' do
         modified_files = ['Podfile']
         allow(@plugin.git).to receive(:modified_files).and_return(modified_files)
 
         @plugin.check_podfile_lock_updated
 
-        expect(@dangerfile.status_report[:errors].count).to eq 1
+        expect(@dangerfile.status_report[:warnings].count).to eq 1
       end
 
-      it 'returns no errors when both the Podfile and the Podfile.lock were updated' do
+      it 'returns no warnings when both the Podfile and the Podfile.lock were updated' do
         modified_files = ['Podfile', 'Podfile.lock']
         allow(@plugin.git).to receive(:modified_files).and_return(modified_files)
 
         @plugin.check_podfile_lock_updated
 
-        expect(@dangerfile.status_report[:errors]).to be_empty
+        expect(@dangerfile.status_report[:warnings]).to be_empty
       end
 
-      it 'returns an error when a PR changed the Package.swift but not the Package.resolved' do
+      it 'returns a warning when a PR changed the Package.swift but not the Package.resolved' do
         modified_files = ['Package.swift']
         allow(@plugin.git).to receive(:modified_files).and_return(modified_files)
 
         @plugin.check_swift_package_resolved_updated
 
-        expect(@dangerfile.status_report[:errors].count).to eq 1
+        expect(@dangerfile.status_report[:warnings].count).to eq 1
       end
 
-      it 'returns no errors when both the Package.swift and the Package.resolved were updated' do
+      it 'returns no warnings when both the Package.swift and the Package.resolved were updated' do
         modified_files = ['Package.swift', 'Package.resolved']
         allow(@plugin.git).to receive(:modified_files).and_return(modified_files)
 
         @plugin.check_swift_package_resolved_updated
 
-        expect(@dangerfile.status_report[:errors]).to be_empty
+        expect(@dangerfile.status_report[:warnings]).to be_empty
       end
     end
   end

--- a/spec/manifest_pr_checker_spec.rb
+++ b/spec/manifest_pr_checker_spec.rb
@@ -14,88 +14,94 @@ module Danger
         @plugin = @dangerfile.manifest_pr_checker
       end
 
-      it 'returns a warning when a PR changed the Gemfile but not the Gemfile.lock' do
-        modified_files = ['Gemfile']
-        allow(@plugin.git).to receive(:modified_files).and_return(modified_files)
+      describe 'Bundler' do
+        it 'returns a warning when a PR changed the Gemfile but not the Gemfile.lock' do
+          modified_files = ['Gemfile']
+          allow(@plugin.git).to receive(:modified_files).and_return(modified_files)
 
-        @plugin.check_gemfile_lock_updated
+          @plugin.check_gemfile_lock_updated
 
-        expected_warning = ['Gemfile was changed without updating Gemfile.lock. Please run `bundle install` or `bundle update <updated_gem>`.']
-        expect(@dangerfile.status_report[:warnings]).to eq expected_warning
+          expected_warning = ['Gemfile was changed without updating Gemfile.lock. Please run `bundle install` or `bundle update <updated_gem>`.']
+          expect(@dangerfile.status_report[:warnings]).to eq expected_warning
+        end
+
+        it 'returns no warnings when both the Gemfile and the Gemfile.lock were updated' do
+          modified_files = ['Gemfile', 'Gemfile.lock']
+          allow(@plugin.git).to receive(:modified_files).and_return(modified_files)
+
+          @plugin.check_gemfile_lock_updated
+
+          expect(@dangerfile.status_report[:warnings]).to be_empty
+        end
+
+        it 'returns no warnings when only the Gemfile.lock was updated' do
+          modified_files = ['Gemfile.lock']
+          allow(@plugin.git).to receive(:modified_files).and_return(modified_files)
+
+          @plugin.check_gemfile_lock_updated
+
+          expect(@dangerfile.status_report[:warnings]).to be_empty
+        end
       end
 
-      it 'returns no warnings when both the Gemfile and the Gemfile.lock were updated' do
-        modified_files = ['Gemfile', 'Gemfile.lock']
-        allow(@plugin.git).to receive(:modified_files).and_return(modified_files)
+      describe 'CocoaPods' do
+        it 'returns a warning when a PR changed the Podfile but not the Podfile.lock' do
+          modified_files = ['Podfile']
+          allow(@plugin.git).to receive(:modified_files).and_return(modified_files)
 
-        @plugin.check_gemfile_lock_updated
+          @plugin.check_podfile_lock_updated
 
-        expect(@dangerfile.status_report[:warnings]).to be_empty
+          expected_warning = ['Podfile was changed without updating Podfile.lock. Please run `bundle exec pod install`.']
+          expect(@dangerfile.status_report[:warnings]).to eq expected_warning
+        end
+
+        it 'returns no warnings when both the Podfile and the Podfile.lock were updated' do
+          modified_files = ['Podfile', 'Podfile.lock']
+          allow(@plugin.git).to receive(:modified_files).and_return(modified_files)
+
+          @plugin.check_podfile_lock_updated
+
+          expect(@dangerfile.status_report[:warnings]).to be_empty
+        end
+
+        it 'returns no warnings when only the Podfile.lock was updated' do
+          modified_files = ['Podfile.lock']
+          allow(@plugin.git).to receive(:modified_files).and_return(modified_files)
+
+          @plugin.check_podfile_lock_updated
+
+          expect(@dangerfile.status_report[:warnings]).to be_empty
+        end
       end
 
-      it 'returns no warnings when only the Gemfile.lock was updated' do
-        modified_files = ['Gemfile.lock']
-        allow(@plugin.git).to receive(:modified_files).and_return(modified_files)
+      describe 'Swift Package Manager' do
+        it 'returns a warning when a PR changed the Package.swift but not the Package.resolved' do
+          modified_files = ['Package.swift']
+          allow(@plugin.git).to receive(:modified_files).and_return(modified_files)
 
-        @plugin.check_gemfile_lock_updated
+          @plugin.check_swift_package_resolved_updated
 
-        expect(@dangerfile.status_report[:warnings]).to be_empty
-      end
+          expected_warning = ['Package.swift was changed without updating Package.resolved. Please resolve the Swift packages in Xcode.']
+          expect(@dangerfile.status_report[:warnings]).to eq expected_warning
+        end
 
-      it 'returns a warning when a PR changed the Podfile but not the Podfile.lock' do
-        modified_files = ['Podfile']
-        allow(@plugin.git).to receive(:modified_files).and_return(modified_files)
+        it 'returns no warnings when both the Package.swift and the Package.resolved were updated' do
+          modified_files = ['Package.swift', 'Package.resolved']
+          allow(@plugin.git).to receive(:modified_files).and_return(modified_files)
 
-        @plugin.check_podfile_lock_updated
+          @plugin.check_swift_package_resolved_updated
 
-        expected_warning = ['Podfile was changed without updating Podfile.lock. Please run `bundle exec pod install`.']
-        expect(@dangerfile.status_report[:warnings]).to eq expected_warning
-      end
+          expect(@dangerfile.status_report[:warnings]).to be_empty
+        end
 
-      it 'returns no warnings when both the Podfile and the Podfile.lock were updated' do
-        modified_files = ['Podfile', 'Podfile.lock']
-        allow(@plugin.git).to receive(:modified_files).and_return(modified_files)
+        it 'returns no warnings when only the Package.resolved was updated' do
+          modified_files = ['Package.resolved']
+          allow(@plugin.git).to receive(:modified_files).and_return(modified_files)
 
-        @plugin.check_podfile_lock_updated
+          @plugin.check_swift_package_resolved_updated
 
-        expect(@dangerfile.status_report[:warnings]).to be_empty
-      end
-
-      it 'returns no warnings when only the Podfile.lock was updated' do
-        modified_files = ['Podfile.lock']
-        allow(@plugin.git).to receive(:modified_files).and_return(modified_files)
-
-        @plugin.check_podfile_lock_updated
-
-        expect(@dangerfile.status_report[:warnings]).to be_empty
-      end
-
-      it 'returns a warning when a PR changed the Package.swift but not the Package.resolved' do
-        modified_files = ['Package.swift']
-        allow(@plugin.git).to receive(:modified_files).and_return(modified_files)
-
-        @plugin.check_swift_package_resolved_updated
-
-        expected_warning = ['Package.swift was changed without updating Package.resolved. Please resolve the Swift packages in Xcode.']
-        expect(@dangerfile.status_report[:warnings]).to eq expected_warning
-      end
-
-      it 'returns no warnings when both the Package.swift and the Package.resolved were updated' do
-        modified_files = ['Package.swift', 'Package.resolved']
-        allow(@plugin.git).to receive(:modified_files).and_return(modified_files)
-
-        @plugin.check_swift_package_resolved_updated
-
-        expect(@dangerfile.status_report[:warnings]).to be_empty
-      end
-
-      it 'returns no warnings when only the Package.resolved was updated' do
-        modified_files = ['Package.resolved']
-        allow(@plugin.git).to receive(:modified_files).and_return(modified_files)
-
-        @plugin.check_swift_package_resolved_updated
-
-        expect(@dangerfile.status_report[:warnings]).to be_empty
+          expect(@dangerfile.status_report[:warnings]).to be_empty
+        end
       end
     end
   end

--- a/spec/manifest_pr_checker_spec.rb
+++ b/spec/manifest_pr_checker_spec.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+require_relative 'spec_helper'
+
+module Danger
+  describe Danger::ManifestPRChecker do
+    it 'should be a plugin' do
+      expect(Danger::ManifestPRChecker.new(nil)).to be_a Danger::Plugin
+    end
+
+    describe 'with Dangerfile' do
+      before do
+        @dangerfile = testing_dangerfile
+        @my_plugin = @dangerfile.manifest_pr_checker
+      end
+
+      it 'returns an error when a PR changed the Gemfile but not Gemfile.lock' do
+        modified_files = ['Gemfile']
+        allow(@my_plugin.git).to receive(:modified_files).and_return(modified_files)
+
+        @my_plugin.check_gemfile_lock_updated
+
+        expect(@dangerfile.status_report[:errors].count).to eq 1
+      end
+
+      it 'returns no errors when both Gemfile and Gemfile.lock were updated' do
+        modified_files = ['Gemfile', 'Gemfile.lock']
+        allow(@my_plugin.git).to receive(:modified_files).and_return(modified_files)
+
+        @my_plugin.check_gemfile_lock_updated
+
+        expect(@dangerfile.status_report[:errors]).to be_empty
+      end
+
+      it 'returns an error when a PR changed the Package.swift but not Package.resolved' do
+        modified_files = ['Package.swift']
+        allow(@my_plugin.git).to receive(:modified_files).and_return(modified_files)
+
+        @my_plugin.check_swift_package_resolved_updated
+
+        expect(@dangerfile.status_report[:errors].count).to eq 1
+      end
+
+      it 'returns no errors when both Package.swift and Package.resolved were updated' do
+        modified_files = ['Package.swift', 'Package.resolved']
+        allow(@my_plugin.git).to receive(:modified_files).and_return(modified_files)
+
+        @my_plugin.check_swift_package_resolved_updated
+
+        expect(@dangerfile.status_report[:errors]).to be_empty
+      end
+    end
+  end
+end

--- a/spec/manifest_pr_checker_spec.rb
+++ b/spec/manifest_pr_checker_spec.rb
@@ -5,7 +5,7 @@ require_relative 'spec_helper'
 module Danger
   describe Danger::ManifestPRChecker do
     it 'should be a plugin' do
-      expect(Danger::ManifestPRChecker.new(nil)).to be_a Danger::Plugin
+      expect(described_class.new(nil)).to be_a Danger::Plugin
     end
 
     describe 'with Dangerfile' do

--- a/spec/manifest_pr_checker_spec.rb
+++ b/spec/manifest_pr_checker_spec.rb
@@ -74,7 +74,7 @@ module Danger
           expect(@dangerfile.status_report[:warnings]).to eq expected_warning
         end
 
-        it 'returns multiple warnings when a PR changed a custom located Podfile but not the corresponding Podfile.lock' do
+        it 'returns multiple warnings when a PR changed multiple custom located Podfiles but not the corresponding Podfile.lock' do
           modified_files = ['./dir1/Podfile', './dir2/Podfile', './dir3/Podfile', './dir1/Podfile.lock']
           allow(@plugin.git).to receive(:modified_files).and_return(modified_files)
 

--- a/spec/manifest_pr_checker_spec.rb
+++ b/spec/manifest_pr_checker_spec.rb
@@ -4,7 +4,7 @@ require_relative 'spec_helper'
 
 module Danger
   describe Danger::ManifestPRChecker do
-    it 'should be a plugin' do
+    it 'is a plugin' do
       expect(described_class.new(nil)).to be_a Danger::Plugin
     end
 


### PR DESCRIPTION
This PR adds a Danger plugin to check if a Pull Request containing a change in a manifest file such as `Gemfile` or `Package.swift` have a corresponding change on a lock file (`Gemfile.lock` or `Package.resolved`).