### PR TITLE
Make RuboCop setup stricter

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,7 @@
+require:
+  - rubocop-rake
+  - rubocop-rspec
+
+
+AllCops:
+  NewCops: enable

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -140,6 +140,16 @@ GEM
       unicode-display_width (>= 2.4.0, < 3.0)
     rubocop-ast (1.29.0)
       parser (>= 3.2.1.0)
+    rubocop-capybara (2.18.0)
+      rubocop (~> 1.41)
+    rubocop-factory_bot (2.23.1)
+      rubocop (~> 1.33)
+    rubocop-rake (0.6.0)
+      rubocop (~> 1.0)
+    rubocop-rspec (2.22.0)
+      rubocop (~> 1.33)
+      rubocop-capybara (~> 2.17)
+      rubocop-factory_bot (~> 2.22)
     ruby-progressbar (1.13.0)
     ruby2_keywords (0.0.5)
     sawyer (0.9.2)
@@ -164,6 +174,8 @@ DEPENDENCIES
   pry
   rake (~> 13.0)
   rspec (~> 3.4)
+  rubocop-rake
+  rubocop-rspec
   yard
 
 BUNDLED WITH

--- a/dangermattic.gemspec
+++ b/dangermattic.gemspec
@@ -18,7 +18,6 @@ Gem::Specification.new do |spec|
 
   spec.files         = `git ls-files`.split($INPUT_RECORD_SEPARATOR)
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
-  spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ['lib']
 
   spec.add_dependency 'danger', '~> 9.3'

--- a/dangermattic.gemspec
+++ b/dangermattic.gemspec
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'English'
+
 lib = File.expand_path('lib', __dir__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'dangermattic/gem_version'
@@ -14,7 +16,7 @@ Gem::Specification.new do |spec|
   spec.homepage      = 'https://github.com/Automattic/dangermattic'
   spec.license       = 'MPL-2.0'
 
-  spec.files         = `git ls-files`.split($/)
+  spec.files         = `git ls-files`.split($INPUT_RECORD_SEPARATOR)
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ['lib']
@@ -52,4 +54,5 @@ Gem::Specification.new do |spec|
   #
   # This will stop test execution and let you inspect the results
   spec.add_development_dependency 'pry'
+  spec.metadata['rubygems_mfa_required'] = 'true'
 end

--- a/dangermattic.gemspec
+++ b/dangermattic.gemspec
@@ -36,6 +36,8 @@ Gem::Specification.new do |spec|
 
   # Linting code and docs
   spec.add_dependency 'rubocop', '~> 1.53'
+  spec.add_development_dependency 'rubocop-rake'
+  spec.add_development_dependency 'rubocop-rspec'
   spec.add_development_dependency 'yard'
 
   # Makes testing easy via `bundle exec guard`

--- a/lib/danger_plugin.rb
+++ b/lib/danger_plugin.rb
@@ -1,2 +1,1 @@
 # frozen_string_literal: true
-


### PR DESCRIPTION
There are eleven violations left to address, but I wanted to get some thoughts on this PR before moving forward with them.

@iangmaia I noticed Rake runs RuboCop only on lib and spec. I'm curious about your rationale for this.

Personally, I think we should run it on every file we can, and that's the assumption on which I based these changes.

### Remaining violations

```
Inspecting 8 files
..CW....

Offenses:

Rakefile:11:1: C: Rake/Desc: Describe the task with desc method.
task :spec do
^^^^^^^^^^
dangermattic.gemspec:1:1: W: Gemspec/RequiredRubyVersion: required_ruby_version should be specified.
dangermattic.gemspec:32:3: C: Gemspec/DevelopmentDependencies: Specify development dependencies in Gemfile.
  spec.add_development_dependency 'bundler', '~> 2.0'
  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
dangermattic.gemspec:33:3: C: Gemspec/DevelopmentDependencies: Specify development dependencies in Gemfile.
  spec.add_development_dependency 'rake', '~> 13.0'
  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
dangermattic.gemspec:36:3: C: Gemspec/DevelopmentDependencies: Specify development dependencies in Gemfile.
  spec.add_development_dependency 'rspec', '~> 3.4'
  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
dangermattic.gemspec:40:3: C: Gemspec/DevelopmentDependencies: Specify development dependencies in Gemfile.
  spec.add_development_dependency 'rubocop-rake'
  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
dangermattic.gemspec:41:3: C: Gemspec/DevelopmentDependencies: Specify development dependencies in Gemfile.
  spec.add_development_dependency 'rubocop-rspec'
  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
dangermattic.gemspec:42:3: C: Gemspec/DevelopmentDependencies: Specify development dependencies in Gemfile.
  spec.add_development_dependency 'yard'
  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
dangermattic.gemspec:45:3: C: Gemspec/DevelopmentDependencies: Specify development dependencies in Gemfile.
  spec.add_development_dependency 'guard', '~> 2.14'
  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
dangermattic.gemspec:46:3: C: Gemspec/DevelopmentDependencies: Specify development dependencies in Gemfile.
  spec.add_development_dependency 'guard-rspec', '~> 4.7'
  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
dangermattic.gemspec:55:3: C: Gemspec/DevelopmentDependencies: Specify development dependencies in Gemfile.
  spec.add_development_dependency 'pry'
  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

8 files inspected, 11 offenses detected
```