### PR TITLE
Improve RuboCop Setup

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,7 @@
+require:
+  - rubocop-rake
+  - rubocop-rspec
+
+
+AllCops:
+  NewCops: enable

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -2,6 +2,52 @@ require:
   - rubocop-rake
   - rubocop-rspec
 
-
 AllCops:
   NewCops: enable
+
+Gemspec/DevelopmentDependencies:
+  EnforcedStyle: gemspec
+
+########## Metrics / Max Lengths Rules
+
+Layout/LineLength:
+  Max: 300
+
+Metrics/AbcSize:
+  Max: 140
+
+Metrics/BlockLength:
+  Max: 80
+  Exclude:
+   - spec/**/*_spec.rb
+   - spec/**/shared_examples_*.rb
+
+Metrics/ClassLength:
+  Max: 300
+
+Metrics/MethodLength:
+  Max: 150
+
+Metrics/ModuleLength:
+  Max: 300
+
+Metrics/ParameterLists:
+  Max: 10
+
+########## Metrics / Complexity
+
+Metrics/CyclomaticComplexity:
+  Max: 20
+
+Metrics/PerceivedComplexity:
+  Max: 20
+
+########## RSpec Rules
+
+# We are not strict to the point that we want to enforce super-short `it '…' do … end` blocks in our specs.
+RSpec/ExampleLength:
+  Enabled: false
+
+# Same for number of let/subject
+RSpec/MultipleMemoizedHelpers:
+  Enabled: false

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -5,6 +5,12 @@ require:
 AllCops:
   NewCops: enable
 
+########## Gemspec Rules
+
+# Disabling this as all the gem publishing will be done within CI and doesn't allow for user input such as an MFA code.
+Gemspec/RequireMFA:
+  Enabled: false
+
 Gemspec/DevelopmentDependencies:
   EnforcedStyle: gemspec
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -140,6 +140,16 @@ GEM
       unicode-display_width (>= 2.4.0, < 3.0)
     rubocop-ast (1.29.0)
       parser (>= 3.2.1.0)
+    rubocop-capybara (2.18.0)
+      rubocop (~> 1.41)
+    rubocop-factory_bot (2.23.1)
+      rubocop (~> 1.33)
+    rubocop-rake (0.6.0)
+      rubocop (~> 1.0)
+    rubocop-rspec (2.22.0)
+      rubocop (~> 1.33)
+      rubocop-capybara (~> 2.17)
+      rubocop-factory_bot (~> 2.22)
     ruby-progressbar (1.13.0)
     ruby2_keywords (0.0.5)
     sawyer (0.9.2)
@@ -164,6 +174,8 @@ DEPENDENCIES
   pry
   rake (~> 13.0)
   rspec (~> 3.4)
+  rubocop-rake
+  rubocop-rspec
   yard
 
 BUNDLED WITH

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,7 +7,7 @@ PATH
       danger-plugin-api (~> 1.0)
       danger-swiftlint (~> 0.29)
       danger-xcode_summary (~> 1.0)
-      rubocop (~> 1.53)
+      rubocop (~> 1.54)
 
 GEM
   remote: https://rubygems.org/
@@ -127,7 +127,7 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.12.0)
     rspec-support (3.12.0)
-    rubocop (1.53.1)
+    rubocop (1.54.2)
       json (~> 2.3)
       language_server-protocol (>= 3.17.0)
       parallel (~> 1.10)

--- a/Rakefile
+++ b/Rakefile
@@ -8,6 +8,7 @@ RSpec::Core::RakeTask.new(:specs)
 
 task default: :specs
 
+desc 'Runs all tasks: :specs, :rubocop and :spec_docs'
 task :spec do
   Rake::Task['specs'].invoke
   Rake::Task['rubocop'].invoke
@@ -15,9 +16,7 @@ task :spec do
 end
 
 desc 'Run RuboCop on the lib/specs directory'
-RuboCop::RakeTask.new(:rubocop) do |task|
-  task.patterns = ['lib/**/*.rb', 'spec/**/*.rb']
-end
+RuboCop::RakeTask.new(:rubocop)
 
 desc 'Ensure that the plugin passes `danger plugins lint`'
 task :spec_docs do

--- a/dangermattic.gemspec
+++ b/dangermattic.gemspec
@@ -17,7 +17,6 @@ Gem::Specification.new do |spec|
   spec.license       = 'MPL-2.0'
   spec.files         = `git ls-files`.split($INPUT_RECORD_SEPARATOR)
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
-  spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ['lib']
 
   spec.required_ruby_version = '~> 3.2'

--- a/dangermattic.gemspec
+++ b/dangermattic.gemspec
@@ -39,6 +39,8 @@ Gem::Specification.new do |spec|
 
   # Linting code and docs
   spec.add_dependency 'rubocop', '~> 1.53'
+  spec.add_development_dependency 'rubocop-rake'
+  spec.add_development_dependency 'rubocop-rspec'
   spec.add_development_dependency 'yard'
 
   # Makes testing easy via `bundle exec guard`

--- a/dangermattic.gemspec
+++ b/dangermattic.gemspec
@@ -54,5 +54,4 @@ Gem::Specification.new do |spec|
   #
   # This will stop test execution and let you inspect the results
   spec.add_development_dependency 'pry'
-  spec.metadata['rubygems_mfa_required'] = 'true'
 end

--- a/dangermattic.gemspec
+++ b/dangermattic.gemspec
@@ -55,4 +55,5 @@ Gem::Specification.new do |spec|
   #
   # This will stop test execution and let you inspect the results
   spec.add_development_dependency 'pry'
+  spec.metadata['rubygems_mfa_required'] = 'true'
 end

--- a/dangermattic.gemspec
+++ b/dangermattic.gemspec
@@ -37,7 +37,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rspec', '~> 3.4'
 
   # Linting code and docs
-  spec.add_dependency 'rubocop', '~> 1.53'
+  spec.add_dependency 'rubocop', '~> 1.54'
   spec.add_development_dependency 'rubocop-rake'
   spec.add_development_dependency 'rubocop-rspec'
   spec.add_development_dependency 'yard'

--- a/lib/dangermattic/plugins/view_changes_need_screenshots.rb
+++ b/lib/dangermattic/plugins/view_changes_need_screenshots.rb
@@ -15,8 +15,8 @@ module Danger
       pr_has_screenshots = github.pr_body =~ %r{https?://\S*\.(gif|jpg|jpeg|png|svg)}
       pr_has_screenshots ||= github.pr_body =~ /!\[(.*?)\]\((.*?)\)/
 
-      warning = 'View files have been modified, but no screenshot is included in the pull request.' \
-                ' Consider adding some for clarity.'
+      warning = 'View files have been modified, but no screenshot is included in the pull request. ' \
+                'Consider adding some for clarity.'
       warn(warning) if view_files_modified && !pr_has_screenshots
     end
   end

--- a/spec/view_changes_need_screenshots_spec.rb
+++ b/spec/view_changes_need_screenshots_spec.rb
@@ -49,61 +49,65 @@ module Danger
         @plugin = @dangerfile.view_changes_need_screenshots
       end
 
-      context 'with an iOS PR having view code changes in Swift files' do
-        include_examples 'PR with view code changes', ['TestView.swift', 'SimpleViewHelper.m']
+      context 'when checking an iOS PR' do
+        context 'with view code changes in Swift files' do
+          include_examples 'PR with view code changes', ['TestView.swift', 'SimpleViewHelper.m']
+        end
+
+        context 'with button changes in Swift files' do
+          include_examples 'PR with view code changes', ['SimpleViewHelper.m', 'MyAwesomeButton.swift']
+        end
+
+        context 'with view code changes in ObjC files' do
+          include_examples 'PR with view code changes', ['TestView.m', 'SimpleViewHelper.m']
+        end
+
+        context 'with button changes in ObjC files' do
+          include_examples 'PR with view code changes', ['SimpleViewHelper.m', 'MyAwesomeButton.m']
+        end
+
+        context 'with changes in a .xib file' do
+          include_examples 'PR with view code changes', ['SimpleViewHelper.m', 'top_bar.xib']
+        end
+
+        context 'with changes in a Storyboard' do
+          include_examples 'PR with view code changes', ['SimpleViewHelper.m', 'main_screen.storyboard']
+        end
+
+        context 'with no view changes' do
+          include_examples 'PR without view code changes',
+                           ['SimpleViewHelper.m', 'MyButtonTester.swift', 'Version.xcconfig']
+        end
       end
 
-      context 'with an iOS PR having button changes in Swift files' do
-        include_examples 'PR with view code changes', ['SimpleViewHelper.m', 'MyAwesomeButton.swift']
-      end
+      context 'when checking an Android PR' do
+        context 'with view code changes in Kotlin files' do
+          include_examples 'PR with view code changes', ['SimpleViewHelper.kt', 'MySimpleView.kt']
+        end
 
-      context 'with an iOS PR having view code changes in ObjC files' do
-        include_examples 'PR with view code changes', ['TestView.m', 'SimpleViewHelper.m']
-      end
+        context 'with button changes in Kotlin files' do
+          include_examples 'PR with view code changes', ['MyAwesomeButton.kt', 'SimpleViewHelper.java']
+        end
 
-      context 'with an iOS PR having button changes in ObjC files' do
-        include_examples 'PR with view code changes', ['SimpleViewHelper.m', 'MyAwesomeButton.m']
-      end
+        context 'with view code changes in Java files' do
+          include_examples 'PR with view code changes', ['TestView.java', 'SimpleViewHelper.kt']
+        end
 
-      context 'with an iOS PR having changes in a .xib file' do
-        include_examples 'PR with view code changes', ['SimpleViewHelper.m', 'top_bar.xib']
-      end
+        context 'with button changes in Java files' do
+          include_examples 'PR with view code changes', ['SimpleViewHelper.kt', 'MyAwesomeButton.java']
+        end
 
-      context 'with an iOS PR having changes in a Storyboard' do
-        include_examples 'PR with view code changes', ['SimpleViewHelper.m', 'main_screen.storyboard']
-      end
+        context 'with view code changes in a XML file' do
+          include_examples 'PR with view code changes', ['test_view.xml', 'SimpleViewHelper.kt', 'strings.xml']
+        end
 
-      context 'with an iOS PR having no view changes' do
-        include_examples 'PR without view code changes',
-                         ['SimpleViewHelper.m', 'MyButtonTester.swift', 'Version.xcconfig']
-      end
+        context 'with button changes in a XML file' do
+          include_examples 'PR with view code changes', ['SimpleViewHelper.kt', 'strings.xml', 'my_awesome_button.xml']
+        end
 
-      context 'with an Android PR having view code changes in Kotlin files' do
-        include_examples 'PR with view code changes', ['SimpleViewHelper.kt', 'MySimpleView.kt']
-      end
-
-      context 'with an Android PR having button changes in Kotlin files' do
-        include_examples 'PR with view code changes', ['MyAwesomeButton.kt', 'SimpleViewHelper.java']
-      end
-
-      context 'with an Android PR having view code changes in Java files' do
-        include_examples 'PR with view code changes', ['TestView.java', 'SimpleViewHelper.kt']
-      end
-
-      context 'with an Android PR having button changes in Java files' do
-        include_examples 'PR with view code changes', ['SimpleViewHelper.kt', 'MyAwesomeButton.java']
-      end
-
-      context 'with an Android PR having view code changes in a XML file' do
-        include_examples 'PR with view code changes', ['test_view.xml', 'SimpleViewHelper.kt', 'strings.xml']
-      end
-
-      context 'with an Android PR having button changes in a XML file' do
-        include_examples 'PR with view code changes', ['SimpleViewHelper.kt', 'strings.xml', 'my_awesome_button.xml']
-      end
-
-      context 'with an Android PR having no view changes' do
-        include_examples 'PR without view code changes', ['SimpleViewHelper.java', 'values.xml', 'MyButtonTester.kt']
+        context 'with no view changes' do
+          include_examples 'PR without view code changes', ['SimpleViewHelper.java', 'values.xml', 'MyButtonTester.kt']
+        end
       end
     end
   end

--- a/spec/view_changes_need_screenshots_spec.rb
+++ b/spec/view_changes_need_screenshots_spec.rb
@@ -49,60 +49,60 @@ module Danger
         @plugin = @dangerfile.view_changes_need_screenshots
       end
 
-      context 'iOS PR has view code changes in Swift files' do
+      context 'with an iOS PR having view code changes in Swift files' do
         include_examples 'PR with view code changes', ['TestView.swift', 'SimpleViewHelper.m']
       end
 
-      context 'iOS PR has button changes in Swift files' do
+      context 'with an iOS PR having button changes in Swift files' do
         include_examples 'PR with view code changes', ['SimpleViewHelper.m', 'MyAwesomeButton.swift']
       end
 
-      context 'iOS PR has view code changes in ObjC files' do
+      context 'with an iOS PR having view code changes in ObjC files' do
         include_examples 'PR with view code changes', ['TestView.m', 'SimpleViewHelper.m']
       end
 
-      context 'iOS PR has button changes in ObjC files' do
+      context 'with an iOS PR having button changes in ObjC files' do
         include_examples 'PR with view code changes', ['SimpleViewHelper.m', 'MyAwesomeButton.m']
       end
 
-      context 'iOS PR has changes in a .xib file' do
+      context 'with an iOS PR having changes in a .xib file' do
         include_examples 'PR with view code changes', ['SimpleViewHelper.m', 'top_bar.xib']
       end
 
-      context 'iOS PR has changes in a Storyboard' do
+      context 'with an iOS PR having changes in a Storyboard' do
         include_examples 'PR with view code changes', ['SimpleViewHelper.m', 'main_screen.storyboard']
       end
 
-      context 'iOS PR has no view changes' do
+      context 'with an iOS PR having no view changes' do
         include_examples 'PR without view code changes',
                          ['SimpleViewHelper.m', 'MyButtonTester.swift', 'Version.xcconfig']
       end
 
-      context 'Android PR has view code changes in Kotlin files' do
+      context 'with an Android PR having view code changes in Kotlin files' do
         include_examples 'PR with view code changes', ['SimpleViewHelper.kt', 'MySimpleView.kt']
       end
 
-      context 'Android PR has button changes in Kotlin files' do
+      context 'with an Android PR having button changes in Kotlin files' do
         include_examples 'PR with view code changes', ['MyAwesomeButton.kt', 'SimpleViewHelper.java']
       end
 
-      context 'Android PR has view code changes in Java files' do
+      context 'with an Android PR having view code changes in Java files' do
         include_examples 'PR with view code changes', ['TestView.java', 'SimpleViewHelper.kt']
       end
 
-      context 'Android PR has button changes in Java files' do
+      context 'with an Android PR having button changes in Java files' do
         include_examples 'PR with view code changes', ['SimpleViewHelper.kt', 'MyAwesomeButton.java']
       end
 
-      context 'Android PR has view code changes in a XML file' do
+      context 'with an Android PR having view code changes in a XML file' do
         include_examples 'PR with view code changes', ['test_view.xml', 'SimpleViewHelper.kt', 'strings.xml']
       end
 
-      context 'Android PR has button changes in a XML file' do
+      context 'with an Android PR having button changes in a XML file' do
         include_examples 'PR with view code changes', ['SimpleViewHelper.kt', 'strings.xml', 'my_awesome_button.xml']
       end
 
-      context 'Android PR has no view changes' do
+      context 'with an Android PR having no view changes' do
         include_examples 'PR without view code changes', ['SimpleViewHelper.java', 'values.xml', 'MyButtonTester.kt']
       end
     end

--- a/spec/view_changes_need_screenshots_spec.rb
+++ b/spec/view_changes_need_screenshots_spec.rb
@@ -4,7 +4,7 @@ require_relative 'spec_helper'
 
 module Danger
   describe Danger::ViewChangesNeedScreenshots do
-    it 'should be a plugin' do
+    it 'is a plugin' do
       expect(described_class.new(nil)).to be_a Danger::Plugin
     end
 


### PR DESCRIPTION
This PR is an iteration over @mokagio's PR: https://github.com/Automattic/dangermattic/pull/5.

I've brought over some RuboCop rules configs from [release-toolkit](https://github.com/wordpress-mobile/release-toolkit/blob/trunk/.rubocop.yml) that seemed sensible and fixed a few RuboCop offences in what was already merged to `trunk`.