### PR TITLE
Plugin for iOS and Android Release Checks

### DIFF
--- a/lib/danger_plugin.rb
+++ b/lib/danger_plugin.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
 
 Dir[File.join(__dir__, 'dangermattic/plugins', '*.rb')].each { |file| require file }
-
-require 'dangermattic/plugins/common/git_utils'
+Dir[File.join(__dir__, 'dangermattic/plugins/common', '*.rb')].each { |file| require file }

--- a/lib/dangermattic/plugins/android_release_check.rb
+++ b/lib/dangermattic/plugins/android_release_check.rb
@@ -19,7 +19,7 @@ module Danger
     def check_release_notes_and_play_store_strings
       common_release_checks.check_release_notes_and_store_strings(
         release_notes_file: 'metadata/release_notes.txt',
-        store_strings_file: 'metadata/PlayStoreStrings.po'
+        po_file: 'metadata/PlayStoreStrings.po'
       )
     end
 

--- a/lib/dangermattic/plugins/android_release_check.rb
+++ b/lib/dangermattic/plugins/android_release_check.rb
@@ -13,6 +13,8 @@ module Danger
   # @tags android, process, release
   #
   class AndroidReleaseCheck < Plugin
+    STRINGS_FILE = 'strings.xml'
+
     # Checks if changes made to the release notes are also followed by changes in the Play Store strings file.
     #
     # @return [void]
@@ -20,6 +22,18 @@ module Danger
       common_release_checks.check_release_notes_and_store_strings(
         release_notes_file: 'metadata/release_notes.txt',
         po_file: 'metadata/PlayStoreStrings.po'
+      )
+    end
+
+    # Checks if any strings file (values*/strings.xml) has been modified on a release branch, otherwise reporting a warning / error.
+    #
+    # @return [void]
+    def check_modified_strings_on_release(fail_on_error: false)
+      common_release_checks.check_file_changed(
+        file_comparison: ->(path) { File.basename(path) == STRINGS_FILE },
+        message: "`#{STRINGS_FILE}` files should only be updated on release branches, when the translations are downloaded by our automation.",
+        on_release_branch: false,
+        fail_on_error: fail_on_error
       )
     end
 

--- a/lib/dangermattic/plugins/android_release_check.rb
+++ b/lib/dangermattic/plugins/android_release_check.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module Danger
+  # Plugin with checks for Android releases.
+  class AndroidReleaseCheck < Plugin
+    # Checks if changes made to the release notes are also followed by changes in the Play Store strings file.
+    def check_release_notes_and_play_store_strings
+      common_release_checks.check_release_notes_and_store_strings(
+        release_notes_file: 'metadata/release_notes.txt',
+        store_strings_file: 'metadata/PlayStoreStrings.po'
+      )
+    end
+
+    # Check if there are changes to the internal release notes file RELEASE-NOTES.txt and emit a warning message if that's the case.
+    def check_internal_release_notes_changed
+      common_release_checks.check_internal_release_notes_changed
+    end
+  end
+end

--- a/lib/dangermattic/plugins/android_release_check.rb
+++ b/lib/dangermattic/plugins/android_release_check.rb
@@ -1,9 +1,21 @@
 # frozen_string_literal: true
 
 module Danger
-  # Plugin with checks for Android releases.
+  # Plugin for performing Android release-related checks in a pull request.
+  #
+  # @example Checking Android release notes and Play Store strings:
+  #          android_release_check.check_release_notes_and_play_store_strings
+  #
+  # @example Checking for changes in internal release notes:
+  #          android_release_check.check_internal_release_notes_changed
+  #
+  # @see Automattic/dangermattic
+  # @tags android, process, release
+  #
   class AndroidReleaseCheck < Plugin
     # Checks if changes made to the release notes are also followed by changes in the Play Store strings file.
+    #
+    # @return [void]
     def check_release_notes_and_play_store_strings
       common_release_checks.check_release_notes_and_store_strings(
         release_notes_file: 'metadata/release_notes.txt',
@@ -12,6 +24,8 @@ module Danger
     end
 
     # Check if there are changes to the internal release notes file RELEASE-NOTES.txt and emit a warning message if that's the case.
+    #
+    # @return [void]
     def check_internal_release_notes_changed
       common_release_checks.check_internal_release_notes_changed
     end

--- a/lib/dangermattic/plugins/common/common_release_checks.rb
+++ b/lib/dangermattic/plugins/common/common_release_checks.rb
@@ -14,7 +14,7 @@ module Danger
   # @example Checking if release notes and store strings have changed:
   #          common_release_checks.check_release_notes_and_store_strings(
   #            release_notes_file: 'metadata/release_notes.txt',
-  #            store_strings_file: 'metadata/PlayStoreStrings.po'
+  #            po_file: 'metadata/PlayStoreStrings.po'
   #          )
   #
   # @example Checking for changes in internal release notes:
@@ -69,20 +69,20 @@ module Danger
     # @param release_notes_file [String] The name of the release notes file that should be checked for modifications.
     #   Example: 'metadata/release_notes.txt'
     #
-    # @param store_strings_file [String] The name of the store strings file that should be checked for modifications.
+    # @param po_file [String] The name of the store strings file that should be checked for modifications.
     #   Example: 'metadata/PlayStoreStrings.po'
     #
     # @example Check if the release notes file 'release_notes.txt' is modified, and the 'PlayStoreStrings.po' file is not modified, posting a message:
-    #          check_release_notes_and_store_strings(release_notes_file: 'release_notes.txt', store_strings_file: 'PlayStoreStrings.po')
+    #          check_release_notes_and_store_strings(release_notes_file: 'release_notes.txt', po_file: 'PlayStoreStrings.po')
     #
     # @return [void]
-    def check_release_notes_and_store_strings(release_notes_file:, store_strings_file:)
-      has_modified_release_notes = danger.git.modified_files.any? { |f| f.end_with?(release_notes_file) }
-      has_modified_app_store_strings = danger.git.modified_files.any? { |f| f.end_with?(store_strings_file) }
+    def check_release_notes_and_store_strings(release_notes_file:, po_file:)
+      has_modified_release_notes = danger.git.modified_files.any? { |f| f == release_notes_file }
+      has_modified_app_store_strings = danger.git.modified_files.any? { |f| f == po_file }
 
       return unless has_modified_release_notes && !has_modified_app_store_strings
 
-      report_message = "The `#{store_strings_file}` file should be updated if the editorialised release notes file `#{release_notes_file}` is being changed."
+      report_message = "The `#{po_file}` file should be updated if the editorialised release notes file `#{release_notes_file}` is being changed."
       message(report_message)
     end
 

--- a/lib/dangermattic/plugins/common/common_release_checks.rb
+++ b/lib/dangermattic/plugins/common/common_release_checks.rb
@@ -1,0 +1,100 @@
+# frozen_string_literal: true
+
+module Danger
+  # Plugin performing a generic checks related to releases. Can be used directly or via specialised plugins as `AndroidReleaseCheck` and `IosReleaseCheck`.
+  class CommonReleaseChecks < Plugin
+    INTERNAL_RELEASE_NOTES = 'RELEASE-NOTES.txt'
+
+    # Check if certain files have been modified, returning a warning or failure message based on the branch type.
+    #
+    # @param file_comparison A closure used to compare modified file paths.
+    #   The closure should take a single argument, which is the path to a modified file,
+    #   and return true if the file matches the desired condition.
+    #   Example: `file_comparison = ->(file_path) { file_path.include?('app/') }`
+    #
+    # @param message [String] The message to display in the warning or failure output if the condition is met.
+    #
+    # @param on_release [Boolean] If true, the check will only run on release branches, otherwise on non-release branches.
+    #
+    # @param fail_on_error [Boolean] If true, a failure message will be displayed instead of a warning.
+    #
+    # @example Check if any modified file is under the 'app/' directory and emit a warning on release branches:
+    #   check_file_changed(file_comparison: ->(file_path) { file_path.include?('app/') },
+    #                      message: 'Some files in the "app/" directory have been modified. Please review the changes.',
+    #                      on_release: true
+    #   )
+    #
+    # @example Check if a specific file has been modified and emit a failure on non-release branches:
+    #   check_file_changed(file_comparison: ->(file_path) { file_path == 'path/to/file/DoNotChange.java' },
+    #                      message: 'The "DoNotChange.java" file has been modified. This change is not allowed on non-release branches.',
+    #                      on_release: false,
+    #                      fail_on_error: true)
+    #
+    def check_file_changed(file_comparison:, message:, on_release:, fail_on_error: false)
+      has_modified_file = all_modified_files.any?(&file_comparison)
+
+      should_be_changed = on_release ? release_branch? : !release_branch?
+      return unless should_be_changed && has_modified_file
+
+      if fail_on_error
+        failure(message)
+      else
+        warn(message)
+      end
+    end
+
+    # Check if the release notes and store strings files are correctly updated after a modification to the release notes.
+    #
+    # @param release_notes_file [String] The name of the release notes file that should be checked for modifications.
+    #   Example: 'metadata/release_notes.txt'
+    #
+    # @param store_strings_file [String] The name of the store strings file that should be checked for modifications.
+    #   Example: 'metadata/PlayStoreStrings.po'
+    #
+    # @param fail_on_error [Boolean] If true, a failure message will be emitted instead of a warning.
+    #
+    # @example Check if the release notes file 'release_notes.txt' is modified, and the 'PlayStoreStrings.po' file is not modified:
+    #   check_release_notes_and_store_strings(release_notes_file: 'release_notes.txt', store_strings_file: 'PlayStoreStrings.po', fail_on_error: false)
+    #
+    def check_release_notes_and_store_strings(release_notes_file:, store_strings_file:, fail_on_error: false)
+      has_modified_release_notes = danger.git.modified_files.any? { |f| f.end_with?(release_notes_file) }
+      has_modified_app_store_strings = danger.git.modified_files.any? { |f| f.end_with?(store_strings_file) }
+
+      return unless has_modified_release_notes && !has_modified_app_store_strings
+
+      message = "The #{File.basename(store_strings_file)} file must be updated any time changes are made to the release notes."
+
+      if fail_on_error
+        failure(message)
+      else
+        warn(message)
+      end
+    end
+
+    # Check if there are changes to the internal release notes file in the release branch and emit a warning.
+    def check_internal_release_notes_changed
+      warning = <<~WARNING
+        This PR contains changes to `RELEASE-NOTES.txt`.
+        Note that these changes won't affect the final version of the release notes as this version is in code freeze.
+        Please, get in touch with a release manager if you want to update the final release notes.
+      WARNING
+
+      check_file_changed(
+        file_comparison: ->(path) { path.end_with?(INTERNAL_RELEASE_NOTES) },
+        message: warning,
+        on_release: true,
+        fail_on_error: false
+      )
+    end
+
+    private
+
+    def all_modified_files
+      danger.git.added_files + danger.git.modified_files + danger.git.deleted_files
+    end
+
+    def release_branch?
+      danger.github.branch_for_base.start_with?('release/') || danger.github.branch_for_base.start_with?('hotfix/')
+    end
+  end
+end

--- a/lib/dangermattic/plugins/common/common_release_checks.rb
+++ b/lib/dangermattic/plugins/common/common_release_checks.rb
@@ -1,14 +1,35 @@
 # frozen_string_literal: true
 
 module Danger
-  # Plugin performing a generic checks related to releases. Can be used directly or via specialised plugins as `AndroidReleaseCheck` and `IosReleaseCheck`.
+  # Plugin to perform generic checks related to releases.
+  # It can be used directly or via the specialised plugins `AndroidReleaseCheck` and `IosReleaseCheck`.
+  #
+  # @example Checking if a specific file has changed on a release branch:
+  #          common_release_checks.check_file_changed(
+  #            file_comparison: ->(path) { path == 'metadata/full_release_notes.txt' },
+  #            message: 'Release notes have been modified on a release branch.',
+  #            on_release: true
+  #          )
+  #
+  # @example Checking if release notes and store strings have changed:
+  #          common_release_checks.check_release_notes_and_store_strings(
+  #            release_notes_file: 'metadata/release_notes.txt',
+  #            store_strings_file: 'metadata/PlayStoreStrings.po'
+  #          )
+  #
+  # @example Checking for changes in internal release notes:
+  #          common_release_checks.check_internal_release_notes_changed
+  #
+  # @see Automattic/dangermattic
+  # @tags util, process, release
+  #
   class CommonReleaseChecks < Plugin
     DEFAULT_INTERNAL_RELEASE_NOTES = 'RELEASE-NOTES.txt'
 
     # Check if certain files have been modified, returning a warning or failure message based on the branch type.
     #
-    # @param file_comparison A closure used to compare modified file paths.
-    #   The closure should take a single argument, which is the path to a modified file,
+    # @param file_comparison [Proc] Function used to compare modified file paths.
+    #   It should take a single argument, which is the path to a modified file,
     #   and return true if the file matches the desired condition.
     #   Example: `file_comparison = ->(file_path) { file_path.include?('app/') }`
     #
@@ -30,6 +51,7 @@ module Danger
     #                      on_release: false,
     #                      fail_on_error: true)
     #
+    # @return [void]
     def check_file_changed(file_comparison:, message:, on_release:, fail_on_error: false)
       has_modified_file = all_modified_files.any?(&file_comparison)
 
@@ -56,6 +78,7 @@ module Danger
     # @example Check if the release notes file 'release_notes.txt' is modified, and the 'PlayStoreStrings.po' file is not modified:
     #   check_release_notes_and_store_strings(release_notes_file: 'release_notes.txt', store_strings_file: 'PlayStoreStrings.po', fail_on_error: false)
     #
+    # @return [void]
     def check_release_notes_and_store_strings(release_notes_file:, store_strings_file:, fail_on_error: false)
       has_modified_release_notes = danger.git.modified_files.any? { |f| f.end_with?(release_notes_file) }
       has_modified_app_store_strings = danger.git.modified_files.any? { |f| f.end_with?(store_strings_file) }
@@ -82,6 +105,7 @@ module Danger
     # @example Checking for changes in a custom internal release notes file at a specific path:
     #   check_internal_release_notes_changed(release_notes_file: '/path/to/internal_release_notes.txt')
     #
+    # @return [void]
     def check_internal_release_notes_changed(release_notes_file: DEFAULT_INTERNAL_RELEASE_NOTES)
       warning = <<~WARNING
         This PR contains changes to `#{release_notes_file}`.

--- a/lib/dangermattic/plugins/common/common_release_checks.rb
+++ b/lib/dangermattic/plugins/common/common_release_checks.rb
@@ -54,7 +54,7 @@ module Danger
     def check_file_changed(file_comparison:, message:, on_release_branch:, fail_on_error: false)
       has_modified_file = git_utils.all_changed_files.any?(&file_comparison)
 
-      should_be_changed = on_release_branch ? release_branch? : !release_branch?
+      should_be_changed = (on_release_branch == release_branch?)
       return unless should_be_changed && has_modified_file
 
       if fail_on_error

--- a/lib/dangermattic/plugins/common/common_release_checks.rb
+++ b/lib/dangermattic/plugins/common/common_release_checks.rb
@@ -3,7 +3,7 @@
 module Danger
   # Plugin performing a generic checks related to releases. Can be used directly or via specialised plugins as `AndroidReleaseCheck` and `IosReleaseCheck`.
   class CommonReleaseChecks < Plugin
-    INTERNAL_RELEASE_NOTES = 'RELEASE-NOTES.txt'
+    DEFAULT_INTERNAL_RELEASE_NOTES = 'RELEASE-NOTES.txt'
 
     # Check if certain files have been modified, returning a warning or failure message based on the branch type.
     #
@@ -71,16 +71,26 @@ module Danger
       end
     end
 
-    # Check if there are changes to the internal release notes file in the release branch and emit a warning.
-    def check_internal_release_notes_changed
+    # Check if there are changes to the internal release notes file in the release branch and emit a warning if that's the case.
+    #
+    # @param release_notes_file [String] (optional) The path to the internal release notes file.
+    #        Defaults to the `DEFAULT_INTERNAL_RELEASE_NOTES` constant if not provided.
+    #
+    # @example Checking for changes in the default internal release notes file:
+    #   check_internal_release_notes_changed
+    #
+    # @example Checking for changes in a custom internal release notes file at a specific path:
+    #   check_internal_release_notes_changed(release_notes_file: '/path/to/internal_release_notes.txt')
+    #
+    def check_internal_release_notes_changed(release_notes_file: DEFAULT_INTERNAL_RELEASE_NOTES)
       warning = <<~WARNING
-        This PR contains changes to `RELEASE-NOTES.txt`.
+        This PR contains changes to `#{release_notes_file}`.
         Note that these changes won't affect the final version of the release notes as this version is in code freeze.
         Please, get in touch with a release manager if you want to update the final release notes.
       WARNING
 
       check_file_changed(
-        file_comparison: ->(path) { path.end_with?(INTERNAL_RELEASE_NOTES) },
+        file_comparison: ->(path) { path == release_notes_file },
         message: warning,
         on_release: true,
         fail_on_error: false

--- a/lib/dangermattic/plugins/common/common_release_checks.rb
+++ b/lib/dangermattic/plugins/common/common_release_checks.rb
@@ -8,7 +8,7 @@ module Danger
   #          common_release_checks.check_file_changed(
   #            file_comparison: ->(path) { path == 'metadata/full_release_notes.txt' },
   #            message: 'Release notes have been modified on a release branch.',
-  #            on_release: true
+  #            on_release_branch: true
   #          )
   #
   # @example Checking if release notes and store strings have changed:
@@ -42,19 +42,19 @@ module Danger
     # @example Check if any modified file is under the 'app/' directory and emit a warning on release branches:
     #   check_file_changed(file_comparison: ->(file_path) { file_path.include?('app/') },
     #                      message: 'Some files in the "app/" directory have been modified. Please review the changes.',
-    #                      on_release: true)
+    #                      on_release_branch: true)
     #
     # @example Check if a specific file has been modified and emit a failure on non-release branches:
     #   check_file_changed(file_comparison: ->(file_path) { file_path == 'path/to/file/DoNotChange.java' },
     #                      message: 'The "DoNotChange.java" file has been modified. This change is not allowed on non-release branches.',
-    #                      on_release: false,
+    #                      on_release_branch: false,
     #                      fail_on_error: true)
     #
     # @return [void]
-    def check_file_changed(file_comparison:, message:, on_release:, fail_on_error: false)
+    def check_file_changed(file_comparison:, message:, on_release_branch:, fail_on_error: false)
       has_modified_file = git_utils.all_changed_files.any?(&file_comparison)
 
-      should_be_changed = on_release ? release_branch? : !release_branch?
+      should_be_changed = on_release_branch ? release_branch? : !release_branch?
       return unless should_be_changed && has_modified_file
 
       if fail_on_error
@@ -108,7 +108,7 @@ module Danger
       check_file_changed(
         file_comparison: ->(path) { path == release_notes_file },
         message: warning,
-        on_release: true,
+        on_release_branch: true,
         fail_on_error: false
       )
     end

--- a/lib/dangermattic/plugins/common/common_release_checks.rb
+++ b/lib/dangermattic/plugins/common/common_release_checks.rb
@@ -42,8 +42,7 @@ module Danger
     # @example Check if any modified file is under the 'app/' directory and emit a warning on release branches:
     #   check_file_changed(file_comparison: ->(file_path) { file_path.include?('app/') },
     #                      message: 'Some files in the "app/" directory have been modified. Please review the changes.',
-    #                      on_release: true
-    #   )
+    #                      on_release: true)
     #
     # @example Check if a specific file has been modified and emit a failure on non-release branches:
     #   check_file_changed(file_comparison: ->(file_path) { file_path == 'path/to/file/DoNotChange.java' },
@@ -73,25 +72,18 @@ module Danger
     # @param store_strings_file [String] The name of the store strings file that should be checked for modifications.
     #   Example: 'metadata/PlayStoreStrings.po'
     #
-    # @param fail_on_error [Boolean] If true, a failure message will be emitted instead of a warning.
-    #
-    # @example Check if the release notes file 'release_notes.txt' is modified, and the 'PlayStoreStrings.po' file is not modified:
-    #   check_release_notes_and_store_strings(release_notes_file: 'release_notes.txt', store_strings_file: 'PlayStoreStrings.po', fail_on_error: false)
+    # @example Check if the release notes file 'release_notes.txt' is modified, and the 'PlayStoreStrings.po' file is not modified, posting a message:
+    #          check_release_notes_and_store_strings(release_notes_file: 'release_notes.txt', store_strings_file: 'PlayStoreStrings.po')
     #
     # @return [void]
-    def check_release_notes_and_store_strings(release_notes_file:, store_strings_file:, fail_on_error: false)
+    def check_release_notes_and_store_strings(release_notes_file:, store_strings_file:)
       has_modified_release_notes = danger.git.modified_files.any? { |f| f.end_with?(release_notes_file) }
       has_modified_app_store_strings = danger.git.modified_files.any? { |f| f.end_with?(store_strings_file) }
 
       return unless has_modified_release_notes && !has_modified_app_store_strings
 
-      message = "The #{File.basename(store_strings_file)} file must be updated any time changes are made to the release notes."
-
-      if fail_on_error
-        failure(message)
-      else
-        warn(message)
-      end
+      report_message = "The `#{store_strings_file}` file should be updated if the editorialised release notes file `#{release_notes_file}` is being changed."
+      message(report_message)
     end
 
     # Check if there are changes to the internal release notes file in the release branch and emit a warning if that's the case.

--- a/lib/dangermattic/plugins/common/common_release_checks.rb
+++ b/lib/dangermattic/plugins/common/common_release_checks.rb
@@ -52,7 +52,7 @@ module Danger
     #
     # @return [void]
     def check_file_changed(file_comparison:, message:, on_release:, fail_on_error: false)
-      has_modified_file = all_modified_files.any?(&file_comparison)
+      has_modified_file = git_utils.all_changed_files.any?(&file_comparison)
 
       should_be_changed = on_release ? release_branch? : !release_branch?
       return unless should_be_changed && has_modified_file
@@ -114,10 +114,6 @@ module Danger
     end
 
     private
-
-    def all_modified_files
-      danger.git.added_files + danger.git.modified_files + danger.git.deleted_files
-    end
 
     def release_branch?
       danger.github.branch_for_base.start_with?('release/') || danger.github.branch_for_base.start_with?('hotfix/')

--- a/lib/dangermattic/plugins/ios_release_check.rb
+++ b/lib/dangermattic/plugins/ios_release_check.rb
@@ -49,7 +49,7 @@ module Danger
     # @return [void]
     def check_modified_en_strings_on_regular_branch
       common_release_checks.check_file_changed(
-        file_comparison: ->(path) { path.end_with?(BASE_STRINGS_FILE) },
+        file_comparison: ->(path) { base_strings_file?(path: path) },
         message: "The `#{BASE_STRINGS_FILE}` file should only be updated before creating a release branch.",
         on_release_branch: true
       )
@@ -60,7 +60,7 @@ module Danger
     # @return [void]
     def check_modified_translations_on_release_branch
       common_release_checks.check_file_changed(
-        file_comparison: ->(path) { !path.end_with?(BASE_STRINGS_FILE) && File.basename(path) == LOCALIZABLE_STRINGS_FILE },
+        file_comparison: ->(path) { !base_strings_file?(path: path) && File.basename(path) == LOCALIZABLE_STRINGS_FILE },
         message: "Translation files `*.lproj/#{LOCALIZABLE_STRINGS_FILE}` should only be updated on a release branch.",
         on_release_branch: false
       )
@@ -74,6 +74,18 @@ module Danger
         release_notes_file: 'Resources/release_notes.txt',
         po_file: 'Resources/AppStoreStrings.po'
       )
+    end
+
+    private
+
+    # Checks if a given path corresponds to the base (English) strings file, en.lproj/Localizable.strings.
+    #
+    # @return [true] if path is the base strings file
+    def base_strings_file?(path:)
+      base_strings_path_components = Pathname.new(BASE_STRINGS_FILE).each_filename.to_a
+      path_components = Pathname.new(path).each_filename.to_a
+
+      base_strings_path_components == path_components.last(base_strings_path_components.length)
     end
   end
 end

--- a/lib/dangermattic/plugins/ios_release_check.rb
+++ b/lib/dangermattic/plugins/ios_release_check.rb
@@ -29,7 +29,7 @@ module Danger
       common_release_checks.check_file_changed(
         file_comparison: ->(path) { File.extname(path) == '.xcdatamodeld' },
         message: warning,
-        on_release: true
+        on_release_branch: true
       )
     end
 
@@ -40,7 +40,7 @@ module Danger
       common_release_checks.check_file_changed(
         file_comparison: ->(path) { File.basename(path) == LOCALIZABLE_STRINGS_FILE },
         message: "The `#{LOCALIZABLE_STRINGS_FILE}` files should only be updated on release branches, when the translations are downloaded by our automation.",
-        on_release: false
+        on_release_branch: false
       )
     end
 
@@ -51,7 +51,7 @@ module Danger
       common_release_checks.check_file_changed(
         file_comparison: ->(path) { path.end_with?(BASE_STRINGS_FILE) },
         message: "The `#{BASE_STRINGS_FILE}` file should only be updated before creating a release branch.",
-        on_release: true
+        on_release_branch: true
       )
     end
 
@@ -62,7 +62,7 @@ module Danger
       common_release_checks.check_file_changed(
         file_comparison: ->(path) { !path.end_with?(BASE_STRINGS_FILE) && File.basename(path) == LOCALIZABLE_STRINGS_FILE },
         message: "Translation files `*.lproj/#{LOCALIZABLE_STRINGS_FILE}` should only be updated on a release branch.",
-        on_release: false
+        on_release_branch: false
       )
     end
 

--- a/lib/dangermattic/plugins/ios_release_check.rb
+++ b/lib/dangermattic/plugins/ios_release_check.rb
@@ -30,15 +30,27 @@ module Danger
       )
     end
 
-    # Checks if any Localizable.strings file has been modified on a regular branch, emiting a warning if that's the case.
+    # Checks if any Localizable.strings file has been modified on a release branch, otherwise reporting a warning.
     #
     # @return [void]
     def check_modified_localizable_strings_on_release
       strings_file = 'Localizable.strings'
       common_release_checks.check_file_changed(
-        file_comparison: ->(path) { File.basename(path) == strings_file  },
-        message: "`#{strings_file}` files should only be updated on release branches, when the translations are downloaded.",
+        file_comparison: ->(path) { File.basename(path) == strings_file },
+        message: "The `#{strings_file}` files should only be updated on release branches, when the translations are downloaded.",
         on_release: false
+      )
+    end
+
+    # Checks if the en.lproj/Localizable.strings file has been modified on a regular branch, otherwise reporting a warning.
+    #
+    # @return [void]
+    def check_modified_en_strings_on_regular_branch
+      strings_file = 'en.lproj/Localizable.strings'
+      common_release_checks.check_file_changed(
+        file_comparison: ->(path) { path.end_with?(strings_file) },
+        message: "The `#{strings_file}` file should only be updated before creating a release branch.",
+        on_release: true
       )
     end
 

--- a/lib/dangermattic/plugins/ios_release_check.rb
+++ b/lib/dangermattic/plugins/ios_release_check.rb
@@ -1,9 +1,24 @@
 # frozen_string_literal: true
 
 module Danger
-  # Plugin for miscellaneous checks for iOS / macOS releases.
+  # Plugin for performing iOS / macOS release-related checks in a pull request.
+  #
+  # @example Checking for changes in Core Data models on a release branch:
+  #          ios_release_check.check_core_data_model_changed
+  #
+  # @example Checking for modified Localizable.strings on a regular branch:
+  #          ios_release_check.check_modified_localizable_strings
+  #
+  # @example Checking for synchronization between release notes and App Store strings:
+  #          ios_release_check.check_release_notes_and_app_store_strings
+  #
+  # @see Automattic/dangermattic
+  # @tags ios, macos, process, release
+  #
   class IosReleaseCheck < Plugin
     # Checks if an existing Core Data model has been edited in a release branch.
+    #
+    # @return [void]
     def check_core_data_model_changed
       warning = 'Do not edit an existing Core Data model in a release branch unless it hasn\'t been released to testers yet. ' \
                 'Instead create a new model version and merge back to develop soon.'
@@ -16,6 +31,8 @@ module Danger
     end
 
     # Checks if the Localizable.strings file has been modified on a regular branch, emiting a warning if that's the case.
+    #
+    # @return [void]
     def check_modified_localizable_strings
       common_release_checks.check_file_changed(
         file_comparison: ->(path) { path.end_with?('Resources/en.lproj/Localizable.strings') },
@@ -25,6 +42,8 @@ module Danger
     end
 
     # Checks if changes made to the release notes are also followed by changes in the App Store strings file.
+    #
+    # @return [void]
     def check_release_notes_and_app_store_strings
       common_release_checks.check_release_notes_and_store_strings(
         release_notes_file: 'Resources/release_notes.txt',

--- a/lib/dangermattic/plugins/ios_release_check.rb
+++ b/lib/dangermattic/plugins/ios_release_check.rb
@@ -39,7 +39,7 @@ module Danger
     def check_modified_localizable_strings_on_release
       common_release_checks.check_file_changed(
         file_comparison: ->(path) { File.basename(path) == LOCALIZABLE_STRINGS_FILE },
-        message: "The `#{LOCALIZABLE_STRINGS_FILE}` files should only be updated on release branches, when the translations are downloaded.",
+        message: "The `#{LOCALIZABLE_STRINGS_FILE}` files should only be updated on release branches, when the translations are downloaded by our automation.",
         on_release: false
       )
     end

--- a/lib/dangermattic/plugins/ios_release_check.rb
+++ b/lib/dangermattic/plugins/ios_release_check.rb
@@ -80,7 +80,7 @@ module Danger
 
     # Checks if a given path corresponds to the base (English) strings file, en.lproj/Localizable.strings.
     #
-    # @return [true] if path is the base strings file
+    # @return [Boolean] true if path is the base strings file
     def base_strings_file?(path:)
       base_strings_path_components = Pathname.new(BASE_STRINGS_FILE).each_filename.to_a
       path_components = Pathname.new(path).each_filename.to_a

--- a/lib/dangermattic/plugins/ios_release_check.rb
+++ b/lib/dangermattic/plugins/ios_release_check.rb
@@ -30,13 +30,14 @@ module Danger
       )
     end
 
-    # Checks if the Localizable.strings file has been modified on a regular branch, emiting a warning if that's the case.
+    # Checks if any Localizable.strings file has been modified on a regular branch, emiting a warning if that's the case.
     #
     # @return [void]
-    def check_modified_localizable_strings
+    def check_modified_localizable_strings_on_release
+      strings_file = 'Localizable.strings'
       common_release_checks.check_file_changed(
-        file_comparison: ->(path) { path.end_with?('Resources/en.lproj/Localizable.strings') },
-        message: 'Localizable.strings should only be updated on release branches because it is generated automatically.',
+        file_comparison: ->(path) { File.basename(path) == strings_file  },
+        message: "`#{strings_file}` files should only be updated on release branches, when the translations are downloaded.",
         on_release: false
       )
     end
@@ -47,7 +48,7 @@ module Danger
     def check_release_notes_and_app_store_strings
       common_release_checks.check_release_notes_and_store_strings(
         release_notes_file: 'Resources/release_notes.txt',
-        store_strings_file: 'Resources/AppStoreStrings.po'
+        po_file: 'Resources/AppStoreStrings.po'
       )
     end
   end

--- a/lib/dangermattic/plugins/ios_release_check.rb
+++ b/lib/dangermattic/plugins/ios_release_check.rb
@@ -9,7 +9,7 @@ module Danger
                 'Instead create a new model version and merge back to develop soon.'
 
       common_release_checks.check_file_changed(
-        file_comparison: ->(path) { path.end_with?('.xcdatamodeld') },
+        file_comparison: ->(path) { File.extname(path) == '.xcdatamodeld' },
         message: warning,
         on_release: true
       )

--- a/lib/dangermattic/plugins/ios_release_check.rb
+++ b/lib/dangermattic/plugins/ios_release_check.rb
@@ -16,6 +16,9 @@ module Danger
   # @tags ios, macos, process, release
   #
   class IosReleaseCheck < Plugin
+    LOCALIZABLE_STRINGS_FILE = 'Localizable.strings'
+    BASE_STRINGS_FILE = "en.lproj/#{LOCALIZABLE_STRINGS_FILE}".freeze
+
     # Checks if an existing Core Data model has been edited in a release branch.
     #
     # @return [void]
@@ -34,10 +37,9 @@ module Danger
     #
     # @return [void]
     def check_modified_localizable_strings_on_release
-      strings_file = 'Localizable.strings'
       common_release_checks.check_file_changed(
-        file_comparison: ->(path) { File.basename(path) == strings_file },
-        message: "The `#{strings_file}` files should only be updated on release branches, when the translations are downloaded.",
+        file_comparison: ->(path) { File.basename(path) == LOCALIZABLE_STRINGS_FILE },
+        message: "The `#{LOCALIZABLE_STRINGS_FILE}` files should only be updated on release branches, when the translations are downloaded.",
         on_release: false
       )
     end
@@ -46,11 +48,21 @@ module Danger
     #
     # @return [void]
     def check_modified_en_strings_on_regular_branch
-      strings_file = 'en.lproj/Localizable.strings'
       common_release_checks.check_file_changed(
-        file_comparison: ->(path) { path.end_with?(strings_file) },
-        message: "The `#{strings_file}` file should only be updated before creating a release branch.",
+        file_comparison: ->(path) { path.end_with?(BASE_STRINGS_FILE) },
+        message: "The `#{BASE_STRINGS_FILE}` file should only be updated before creating a release branch.",
         on_release: true
+      )
+    end
+
+    # Checks if a translation file (*.lproj/Localizable.strings) has been modified on a release branch, otherwise reporting a warning.
+    #
+    # @return [void]
+    def check_modified_translations_on_release_branch
+      common_release_checks.check_file_changed(
+        file_comparison: ->(path) { !path.end_with?(BASE_STRINGS_FILE) && File.basename(path) == LOCALIZABLE_STRINGS_FILE },
+        message: "Translation files `*.lproj/#{LOCALIZABLE_STRINGS_FILE}` should only be updated on a release branch.",
+        on_release: false
       )
     end
 

--- a/lib/dangermattic/plugins/ios_release_check.rb
+++ b/lib/dangermattic/plugins/ios_release_check.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+module Danger
+  # Plugin for miscellaneous checks for iOS / macOS releases.
+  class IosReleaseCheck < Plugin
+    # Checks if an existing Core Data model has been edited in a release branch.
+    def check_core_data_model_changed
+      warning = 'Do not edit an existing Core Data model in a release branch unless it hasn\'t been released to testers yet. ' \
+                'Instead create a new model version and merge back to develop soon.'
+
+      common_release_checks.check_file_changed(
+        file_comparison: ->(path) { path.end_with?('.xcdatamodeld') },
+        message: warning,
+        on_release: true
+      )
+    end
+
+    # Checks if the Localizable.strings file has been modified on a regular branch, emiting a warning if that's the case.
+    def check_modified_localizable_strings
+      common_release_checks.check_file_changed(
+        file_comparison: ->(path) { path.end_with?('Resources/en.lproj/Localizable.strings') },
+        message: 'Localizable.strings should only be updated on release branches because it is generated automatically.',
+        on_release: false
+      )
+    end
+
+    # Checks if changes made to the release notes are also followed by changes in the App Store strings file.
+    def check_release_notes_and_app_store_strings
+      common_release_checks.check_release_notes_and_store_strings(
+        release_notes_file: 'Resources/release_notes.txt',
+        store_strings_file: 'Resources/AppStoreStrings.po'
+      )
+    end
+  end
+end

--- a/spec/android_release_check_spec.rb
+++ b/spec/android_release_check_spec.rb
@@ -17,7 +17,7 @@ module Danger
       end
 
       context 'when changing the release notes' do
-        it 'returns a warning when a PR changes the release notes but not the Play Store strings file' do
+        it 'reports a warning when a PR changes the release notes but not the Play Store strings file' do
           allow(@plugin.git).to receive(:modified_files).and_return(['metadata/release_notes.txt'])
 
           @plugin.check_release_notes_and_play_store_strings
@@ -37,6 +37,56 @@ module Danger
           allow(@plugin.git).to receive(:modified_files).and_return(['MyView.swift', 'Resources/AppStoreStrings.tmp'])
 
           @plugin.check_release_notes_and_play_store_strings
+
+          expect(@dangerfile).to not_report
+        end
+      end
+
+      describe '#check_modified_localizable_strings_on_release' do
+        it 'reports a warning when a PR on a regular branch changes the source strings.xml' do
+          allow(@plugin.git).to receive(:modified_files).and_return(['./src/main/res/values/strings.xml'])
+          allow(@plugin.github).to receive(:branch_for_base).and_return('develop')
+
+          @plugin.check_modified_strings_on_release
+
+          expected_message = '`strings.xml` files should only be updated on release branches, when the translations are downloaded by our automation.'
+          expect(@dangerfile).to report_warnings([expected_message])
+        end
+
+        it 'reports an error when a PR on a regular branch changes the source strings.xml' do
+          allow(@plugin.git).to receive(:modified_files).and_return(['./src/main/res/values/strings.xml'])
+          allow(@plugin.github).to receive(:branch_for_base).and_return('develop')
+
+          @plugin.check_modified_strings_on_release(fail_on_error: true)
+
+          expected_message = '`strings.xml` files should only be updated on release branches, when the translations are downloaded by our automation.'
+          expect(@dangerfile).to report_errors([expected_message])
+        end
+
+        it 'reports a warning when a PR on a regular branch changes a translated strings.xml' do
+          allow(@plugin.git).to receive(:modified_files).and_return(['src/main/res/values-fr/strings.xml'])
+          allow(@plugin.github).to receive(:branch_for_base).and_return('trunk')
+
+          @plugin.check_modified_strings_on_release
+
+          expected_message = '`strings.xml` files should only be updated on release branches, when the translations are downloaded by our automation.'
+          expect(@dangerfile).to report_warnings([expected_message])
+        end
+
+        it 'does nothing when a PR changes the strings.xml on a release branch' do
+          allow(@plugin.git).to receive(:modified_files).and_return(['src/main/res/values/strings.xml'])
+          allow(@plugin.github).to receive(:branch_for_base).and_return('release/30.6')
+
+          @plugin.check_modified_strings_on_release
+
+          expect(@dangerfile).to not_report
+        end
+
+        it 'does nothing when a PR does not change the strings.xml on a regular branch' do
+          allow(@plugin.git).to receive(:modified_files).and_return(['./path/to/view/model/MyViewModel.kt'])
+          allow(@plugin.github).to receive(:branch_for_base).and_return('develop')
+
+          @plugin.check_modified_strings_on_release
 
           expect(@dangerfile).to not_report
         end

--- a/spec/android_release_check_spec.rb
+++ b/spec/android_release_check_spec.rb
@@ -30,7 +30,7 @@ module Danger
 
           @plugin.check_release_notes_and_play_store_strings
 
-          expect(@dangerfile).to do_not_report
+          expect(@dangerfile).to not_report
         end
 
         it 'does nothing when a PR does not change the release notes or the AppStore strings file' do
@@ -38,7 +38,7 @@ module Danger
 
           @plugin.check_release_notes_and_play_store_strings
 
-          expect(@dangerfile).to do_not_report
+          expect(@dangerfile).to not_report
         end
       end
     end

--- a/spec/android_release_check_spec.rb
+++ b/spec/android_release_check_spec.rb
@@ -13,9 +13,7 @@ module Danger
         @dangerfile = testing_dangerfile
         @plugin = @dangerfile.android_release_check
 
-        allow(@plugin.git).to receive(:added_files).and_return([])
-        allow(@plugin.git).to receive(:modified_files).and_return([])
-        allow(@plugin.git).to receive(:deleted_files).and_return([])
+        allow(@plugin.git).to receive_messages(added_files: [], modified_files: [], deleted_files: [])
       end
 
       context 'when changing the release notes' do

--- a/spec/android_release_check_spec.rb
+++ b/spec/android_release_check_spec.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+require_relative 'spec_helper'
+
+module Danger
+  describe Danger::AndroidReleaseCheck do
+    it 'is a plugin' do
+      expect(described_class.new(nil)).to be_a Danger::Plugin
+    end
+
+    describe 'with Dangerfile' do
+      before do
+        @dangerfile = testing_dangerfile
+        @plugin = @dangerfile.android_release_check
+
+        allow(@plugin.git).to receive(:added_files).and_return([])
+        allow(@plugin.git).to receive(:modified_files).and_return([])
+        allow(@plugin.git).to receive(:deleted_files).and_return([])
+      end
+
+      context 'when changing the release notes' do
+        it 'returns a warning when a PR changes the release notes but not the Play Store strings file' do
+          allow(@plugin.git).to receive(:modified_files).and_return(['metadata/release_notes.txt'])
+
+          @plugin.check_release_notes_and_play_store_strings
+
+          expect(@dangerfile.status_report[:warnings]).to eq ['The PlayStoreStrings.po file must be updated any time changes are made to the release notes.']
+        end
+
+        it 'does nothing when a PR changes the release notes and the AppStore strings file' do
+          allow(@plugin.git).to receive(:modified_files).and_return(['Resources/release_notes.txt', 'Resources/AppStoreStrings.po'])
+
+          @plugin.check_release_notes_and_play_store_strings
+
+          expect(@dangerfile.status_report[:warnings]).to be_empty
+        end
+
+        it 'does nothing when a PR does not change the release notes or the AppStore strings file' do
+          allow(@plugin.git).to receive(:modified_files).and_return(['MyView.swift', 'Resources/AppStoreStrings.tmp'])
+
+          @plugin.check_release_notes_and_play_store_strings
+
+          expect(@dangerfile.status_report[:warnings]).to be_empty
+        end
+      end
+    end
+  end
+end

--- a/spec/android_release_check_spec.rb
+++ b/spec/android_release_check_spec.rb
@@ -22,7 +22,7 @@ module Danger
 
           @plugin.check_release_notes_and_play_store_strings
 
-          expect(@dangerfile.status_report[:warnings]).to eq ['The PlayStoreStrings.po file must be updated any time changes are made to the release notes.']
+          expect(@dangerfile).to report_messages(['The `metadata/PlayStoreStrings.po` file should be updated if the editorialised release notes file `metadata/release_notes.txt` is being changed.'])
         end
 
         it 'does nothing when a PR changes the release notes and the AppStore strings file' do
@@ -30,7 +30,7 @@ module Danger
 
           @plugin.check_release_notes_and_play_store_strings
 
-          expect(@dangerfile.status_report[:warnings]).to be_empty
+          expect(@dangerfile).to do_not_report
         end
 
         it 'does nothing when a PR does not change the release notes or the AppStore strings file' do
@@ -38,7 +38,7 @@ module Danger
 
           @plugin.check_release_notes_and_play_store_strings
 
-          expect(@dangerfile.status_report[:warnings]).to be_empty
+          expect(@dangerfile).to do_not_report
         end
       end
     end

--- a/spec/common_release_checks_spec.rb
+++ b/spec/common_release_checks_spec.rb
@@ -13,9 +13,7 @@ module Danger
         @dangerfile = testing_dangerfile
         @plugin = @dangerfile.common_release_checks
 
-        allow(@plugin.git).to receive(:added_files).and_return([])
-        allow(@plugin.git).to receive(:modified_files).and_return([])
-        allow(@plugin.git).to receive(:deleted_files).and_return([])
+        allow(@plugin.git).to receive_messages(added_files: [], modified_files: [], deleted_files: [])
       end
 
       context 'when changing the internal release notes' do

--- a/spec/common_release_checks_spec.rb
+++ b/spec/common_release_checks_spec.rb
@@ -20,13 +20,14 @@ module Danger
 
       context 'when changing the internal release notes' do
         it 'returns a warning when a PR on a release branch changes the internal release notes' do
-          allow(@plugin.git).to receive(:modified_files).and_return(['./path/to/model/RELEASE-NOTES.txt'])
+          notes_file = 'RELEASE-NOTES.txt'
+          allow(@plugin.git).to receive(:modified_files).and_return([notes_file])
           allow(@plugin.github).to receive(:branch_for_base).and_return('release/30.6')
 
           @plugin.check_internal_release_notes_changed
 
           expected_message = <<~WARNING
-            This PR contains changes to `RELEASE-NOTES.txt`.
+            This PR contains changes to `#{notes_file}`.
             Note that these changes won't affect the final version of the release notes as this version is in code freeze.
             Please, get in touch with a release manager if you want to update the final release notes.
           WARNING
@@ -34,8 +35,24 @@ module Danger
           expect(@dangerfile.status_report[:warnings]).to eq [expected_message]
         end
 
-        it 'does nothing when a PR changes a Core Data model on a regular branch' do
-          allow(@plugin.git).to receive(:modified_files).and_return(['./RELEASE-NOTES.txt'])
+        it 'returns a warning when a PR on a release branch changes the internal release notes using a custom filename' do
+          notes_file = 'MY-CUSTOM-RELEASE-NOTES.md'
+          allow(@plugin.git).to receive(:modified_files).and_return([notes_file])
+          allow(@plugin.github).to receive(:branch_for_base).and_return('release/30.6')
+
+          @plugin.check_internal_release_notes_changed(release_notes_file: notes_file)
+
+          expected_message = <<~WARNING
+            This PR contains changes to `#{notes_file}`.
+            Note that these changes won't affect the final version of the release notes as this version is in code freeze.
+            Please, get in touch with a release manager if you want to update the final release notes.
+          WARNING
+
+          expect(@dangerfile.status_report[:warnings]).to eq [expected_message]
+        end
+
+        it 'does nothing when a PR changes the release notes file on a regular branch' do
+          allow(@plugin.git).to receive(:modified_files).and_return(['RELEASE-NOTES.txt'])
           allow(@plugin.github).to receive(:branch_for_base).and_return('develop')
 
           @plugin.check_internal_release_notes_changed
@@ -43,7 +60,17 @@ module Danger
           expect(@dangerfile.status_report[:warnings]).to be_empty
         end
 
-        it 'does nothing when a PR ca warning when a PR does not change a Core Data model on the release branch' do
+        it 'does nothing when a PR changes a custom release notes file on a regular branch' do
+          notes_file = 'MY-CUSTOM-RELEASE-NOTES.md'
+          allow(@plugin.git).to receive(:modified_files).and_return([notes_file])
+          allow(@plugin.github).to receive(:branch_for_base).and_return('develop')
+
+          @plugin.check_internal_release_notes_changed(release_notes_file: notes_file)
+
+          expect(@dangerfile.status_report[:warnings]).to be_empty
+        end
+
+        it 'does nothing when a PR ca warning when a PR does not change the release notes file on the release branch' do
           allow(@plugin.git).to receive(:modified_files).and_return(['./path/to/view/MyView.swift'])
           allow(@plugin.github).to receive(:branch_for_base).and_return('release/30.6')
 

--- a/spec/common_release_checks_spec.rb
+++ b/spec/common_release_checks_spec.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+require_relative 'spec_helper'
+
+module Danger
+  describe Danger::CommonReleaseChecks do
+    it 'is a plugin' do
+      expect(described_class.new(nil)).to be_a Danger::Plugin
+    end
+
+    describe 'with the common_release_checks plugin' do
+      before do
+        @dangerfile = testing_dangerfile
+        @plugin = @dangerfile.common_release_checks
+
+        allow(@plugin.git).to receive(:added_files).and_return([])
+        allow(@plugin.git).to receive(:modified_files).and_return([])
+        allow(@plugin.git).to receive(:deleted_files).and_return([])
+      end
+
+      context 'when changing the internal release notes' do
+        it 'returns a warning when a PR on a release branch changes the internal release notes' do
+          allow(@plugin.git).to receive(:modified_files).and_return(['./path/to/model/RELEASE-NOTES.txt'])
+          allow(@plugin.github).to receive(:branch_for_base).and_return('release/30.6')
+
+          @plugin.check_internal_release_notes_changed
+
+          expected_message = <<~WARNING
+            This PR contains changes to `RELEASE-NOTES.txt`.
+            Note that these changes won't affect the final version of the release notes as this version is in code freeze.
+            Please, get in touch with a release manager if you want to update the final release notes.
+          WARNING
+
+          expect(@dangerfile.status_report[:warnings]).to eq [expected_message]
+        end
+
+        it 'does nothing when a PR changes a Core Data model on a regular branch' do
+          allow(@plugin.git).to receive(:modified_files).and_return(['./RELEASE-NOTES.txt'])
+          allow(@plugin.github).to receive(:branch_for_base).and_return('develop')
+
+          @plugin.check_internal_release_notes_changed
+
+          expect(@dangerfile.status_report[:warnings]).to be_empty
+        end
+
+        it 'does nothing when a PR ca warning when a PR does not change a Core Data model on the release branch' do
+          allow(@plugin.git).to receive(:modified_files).and_return(['./path/to/view/MyView.swift'])
+          allow(@plugin.github).to receive(:branch_for_base).and_return('release/30.6')
+
+          @plugin.check_internal_release_notes_changed
+
+          expect(@dangerfile.status_report[:warnings]).to be_empty
+        end
+      end
+    end
+  end
+end

--- a/spec/common_release_checks_spec.rb
+++ b/spec/common_release_checks_spec.rb
@@ -17,7 +17,7 @@ module Danger
       end
 
       context 'when changing the internal release notes' do
-        it 'returns a warning when a PR on a release branch changes the internal release notes' do
+        it 'reports a warning when a PR on a release branch changes the internal release notes' do
           notes_file = 'RELEASE-NOTES.txt'
           allow(@plugin.git).to receive(:modified_files).and_return([notes_file])
           allow(@plugin.github).to receive(:branch_for_base).and_return('release/30.6')
@@ -33,7 +33,7 @@ module Danger
           expect(@dangerfile.status_report[:warnings]).to eq [expected_message]
         end
 
-        it 'returns a warning when a PR on a release branch changes the internal release notes using a custom filename' do
+        it 'reports a warning when a PR on a release branch changes the internal release notes using a custom filename' do
           notes_file = 'MY-CUSTOM-RELEASE-NOTES.md'
           allow(@plugin.git).to receive(:modified_files).and_return([notes_file])
           allow(@plugin.github).to receive(:branch_for_base).and_return('release/30.6')

--- a/spec/ios_release_check_spec.rb
+++ b/spec/ios_release_check_spec.rb
@@ -47,43 +47,84 @@ module Danger
         end
       end
 
-      context 'when changing the Localizable.strings' do
-        it 'returns a warning when a PR on a regular branch changes the source Localizable.strings' do
-          allow(@plugin.git).to receive(:modified_files).and_return(['en.lproj/Localizable.strings'])
-          allow(@plugin.github).to receive(:branch_for_base).and_return('add/myfeature')
+      context 'when changing the Localizable.strings files' do
+        describe '#check_modified_localizable_strings_on_release' do
+          it 'returns a warning when a PR on a regular branch changes the source Localizable.strings' do
+            allow(@plugin.git).to receive(:modified_files).and_return(['en.lproj/Localizable.strings'])
+            allow(@plugin.github).to receive(:branch_for_base).and_return('develop')
 
-          @plugin.check_modified_localizable_strings_on_release
+            @plugin.check_modified_localizable_strings_on_release
 
-          expected_message = '`Localizable.strings` files should only be updated on release branches, when the translations are downloaded.'
-          expect(@dangerfile).to report_warnings([expected_message])
+            expected_message = 'The `Localizable.strings` files should only be updated on release branches, when the translations are downloaded.'
+            expect(@dangerfile).to report_warnings([expected_message])
+          end
+
+          it 'returns a warning when a PR on a regular branch changes a translated Localizable.strings' do
+            allow(@plugin.git).to receive(:modified_files).and_return(['nl.lproj/Localizable.strings'])
+            allow(@plugin.github).to receive(:branch_for_base).and_return('trunk')
+
+            @plugin.check_modified_localizable_strings_on_release
+
+            expected_message = 'The `Localizable.strings` files should only be updated on release branches, when the translations are downloaded.'
+            expect(@dangerfile).to report_warnings([expected_message])
+          end
+
+          it 'does nothing when a PR changes the Localizable.strings on a release branch' do
+            allow(@plugin.git).to receive(:modified_files).and_return(['en.lproj/Localizable.strings'])
+            allow(@plugin.github).to receive(:branch_for_base).and_return('release/30.6')
+
+            @plugin.check_modified_localizable_strings_on_release
+
+            expect(@dangerfile).to do_not_report
+          end
+
+          it 'does nothing when a PR does not change the Localizable.strings on a regular branch' do
+            allow(@plugin.git).to receive(:modified_files).and_return(['./path/to/view/model/MyViewModel.swift'])
+            allow(@plugin.github).to receive(:branch_for_base).and_return('develop')
+
+            @plugin.check_modified_localizable_strings_on_release
+
+            expect(@dangerfile).to do_not_report
+          end
         end
 
-        it 'returns a warning when a PR on a regular branch changes a translated Localizable.strings' do
-          allow(@plugin.git).to receive(:modified_files).and_return(['nl.lproj/Localizable.strings'])
-          allow(@plugin.github).to receive(:branch_for_base).and_return('add/myfeature1')
+        describe '#check_modified_en_strings_on_regular_branch' do
+          it 'reports a warning when a PR on a release branch changes the source Localizable.strings' do
+            allow(@plugin.git).to receive(:modified_files).and_return(['en.lproj/Localizable.strings'])
+            allow(@plugin.github).to receive(:branch_for_base).and_return('release/30.6')
 
-          @plugin.check_modified_localizable_strings_on_release
+            @plugin.check_modified_en_strings_on_regular_branch
 
-          expected_message = '`Localizable.strings` files should only be updated on release branches, when the translations are downloaded.'
-          expect(@dangerfile).to report_warnings([expected_message])
-        end
+            expected_message = 'The `en.lproj/Localizable.strings` file should only be updated before creating a release branch.'
+            expect(@dangerfile).to report_warnings([expected_message])
+          end
 
-        it 'does nothing when a PR changes the Localizable.strings on a release branch' do
-          allow(@plugin.git).to receive(:modified_files).and_return(['en.lproj/Localizable.strings'])
-          allow(@plugin.github).to receive(:branch_for_base).and_return('release/30.6')
+          it 'does nothing when a PR changes the Localizable.strings on a regular branch' do
+            allow(@plugin.git).to receive(:modified_files).and_return(['en.lproj/Localizable.strings'])
+            allow(@plugin.github).to receive(:branch_for_base).and_return('develop')
 
-          @plugin.check_modified_localizable_strings_on_release
+            @plugin.check_modified_en_strings_on_regular_branch
 
-          expect(@dangerfile).to do_not_report
-        end
+            expect(@dangerfile).to do_not_report
+          end
 
-        it 'does nothing when a PR ca warning when a PR does not change the Localizable.strings on a regular branch' do
-          allow(@plugin.git).to receive(:modified_files).and_return(['./path/to/view/model/MyViewModel.swift'])
-          allow(@plugin.github).to receive(:branch_for_base).and_return('add/myfeature')
+          it 'does nothing when a PR on a release branch changes a translated Localizable.strings' do
+            allow(@plugin.git).to receive(:modified_files).and_return(['nl.lproj/Localizable.strings'])
+            allow(@plugin.github).to receive(:branch_for_base).and_return('release/30.6')
 
-          @plugin.check_modified_localizable_strings_on_release
+            @plugin.check_modified_en_strings_on_regular_branch
 
-          expect(@dangerfile).to do_not_report
+            expect(@dangerfile).to do_not_report
+          end
+
+          it 'does nothing when a PR does not change the Localizable.strings on a release branch' do
+            allow(@plugin.git).to receive(:modified_files).and_return(['./path/to/view/model/MyViewModel2.swift'])
+            allow(@plugin.github).to receive(:branch_for_base).and_return('release/30.6')
+
+            @plugin.check_modified_en_strings_on_regular_branch
+
+            expect(@dangerfile).to do_not_report
+          end
         end
       end
 

--- a/spec/ios_release_check_spec.rb
+++ b/spec/ios_release_check_spec.rb
@@ -48,21 +48,31 @@ module Danger
       end
 
       context 'when changing the Localizable.strings' do
-        it 'returns a warning when a PR on a regular branch changes the Localizable.strings' do
-          allow(@plugin.git).to receive(:modified_files).and_return(['./Resources/en.lproj/Localizable.strings'])
+        it 'returns a warning when a PR on a regular branch changes the source Localizable.strings' do
+          allow(@plugin.git).to receive(:modified_files).and_return(['en.lproj/Localizable.strings'])
           allow(@plugin.github).to receive(:branch_for_base).and_return('add/myfeature')
 
-          @plugin.check_modified_localizable_strings
+          @plugin.check_modified_localizable_strings_on_release
 
-          expected_message = 'Localizable.strings should only be updated on release branches because it is generated automatically.'
+          expected_message = '`Localizable.strings` files should only be updated on release branches, when the translations are downloaded.'
+          expect(@dangerfile).to report_warnings([expected_message])
+        end
+
+        it 'returns a warning when a PR on a regular branch changes a translated Localizable.strings' do
+          allow(@plugin.git).to receive(:modified_files).and_return(['nl.lproj/Localizable.strings'])
+          allow(@plugin.github).to receive(:branch_for_base).and_return('add/myfeature1')
+
+          @plugin.check_modified_localizable_strings_on_release
+
+          expected_message = '`Localizable.strings` files should only be updated on release branches, when the translations are downloaded.'
           expect(@dangerfile).to report_warnings([expected_message])
         end
 
         it 'does nothing when a PR changes the Localizable.strings on a release branch' do
-          allow(@plugin.git).to receive(:modified_files).and_return(['./Resources/en.lproj/Localizable.strings'])
+          allow(@plugin.git).to receive(:modified_files).and_return(['en.lproj/Localizable.strings'])
           allow(@plugin.github).to receive(:branch_for_base).and_return('release/30.6')
 
-          @plugin.check_modified_localizable_strings
+          @plugin.check_modified_localizable_strings_on_release
 
           expect(@dangerfile).to do_not_report
         end
@@ -71,7 +81,7 @@ module Danger
           allow(@plugin.git).to receive(:modified_files).and_return(['./path/to/view/model/MyViewModel.swift'])
           allow(@plugin.github).to receive(:branch_for_base).and_return('add/myfeature')
 
-          @plugin.check_modified_localizable_strings
+          @plugin.check_modified_localizable_strings_on_release
 
           expect(@dangerfile).to do_not_report
         end

--- a/spec/ios_release_check_spec.rb
+++ b/spec/ios_release_check_spec.rb
@@ -1,0 +1,109 @@
+# frozen_string_literal: true
+
+require_relative 'spec_helper'
+
+module Danger
+  describe Danger::IosReleaseCheck do
+    it 'is a plugin' do
+      expect(described_class.new(nil)).to be_a Danger::Plugin
+    end
+
+    describe 'with Dangerfile' do
+      before do
+        @dangerfile = testing_dangerfile
+        @plugin = @dangerfile.ios_release_check
+
+        allow(@plugin.git).to receive(:added_files).and_return([])
+        allow(@plugin.git).to receive(:modified_files).and_return([])
+        allow(@plugin.git).to receive(:deleted_files).and_return([])
+      end
+
+      context 'when changing the Core Data model' do
+        it 'returns a warning when a PR on a release branch changes a Core Data model' do
+          allow(@plugin.git).to receive(:modified_files).and_return(['./path/to/model/Model.xcdatamodeld'])
+          allow(@plugin.github).to receive(:branch_for_base).and_return('release/30.6')
+
+          @plugin.check_core_data_model_changed
+
+          expected_message = 'Do not edit an existing Core Data model in a release branch unless it hasn\'t been released to testers yet. ' \
+                             'Instead create a new model version and merge back to develop soon.'
+          expect(@dangerfile.status_report[:warnings]).to eq [expected_message]
+        end
+
+        it 'does nothing when a PR changes a Core Data model on a regular branch' do
+          allow(@plugin.git).to receive(:modified_files).and_return(['./path/to/model/Model.xcdatamodeld'])
+          allow(@plugin.github).to receive(:branch_for_base).and_return('develop')
+
+          @plugin.check_core_data_model_changed
+
+          expect(@dangerfile.status_report[:warnings]).to be_empty
+        end
+
+        it 'does nothing when a PR ca warning when a PR does not change a Core Data model on the release branch' do
+          allow(@plugin.git).to receive(:modified_files).and_return(['./path/to/view/model/MyViewModel.swift'])
+          allow(@plugin.github).to receive(:branch_for_base).and_return('release/30.6')
+
+          @plugin.check_core_data_model_changed
+
+          expect(@dangerfile.status_report[:warnings]).to be_empty
+        end
+      end
+
+      context 'when changing the Localizable.strings' do
+        it 'returns a warning when a PR on a regular branch changes the Localizable.strings' do
+          allow(@plugin.git).to receive(:modified_files).and_return(['./Resources/en.lproj/Localizable.strings'])
+          allow(@plugin.github).to receive(:branch_for_base).and_return('add/myfeature')
+
+          @plugin.check_modified_localizable_strings
+
+          expected_message = 'Localizable.strings should only be updated on release branches because it is generated automatically.'
+          expect(@dangerfile.status_report[:warnings]).to eq [expected_message]
+        end
+
+        it 'does nothing when a PR changes the Localizable.strings on a release branch' do
+          allow(@plugin.git).to receive(:modified_files).and_return(['./Resources/en.lproj/Localizable.strings'])
+          allow(@plugin.github).to receive(:branch_for_base).and_return('release/30.6')
+
+          @plugin.check_modified_localizable_strings
+
+          expect(@dangerfile.status_report[:warnings]).to be_empty
+        end
+
+        it 'does nothing when a PR ca warning when a PR does not change the Localizable.strings on a regular branch' do
+          allow(@plugin.git).to receive(:modified_files).and_return(['./path/to/view/model/MyViewModel.swift'])
+          allow(@plugin.github).to receive(:branch_for_base).and_return('add/myfeature')
+
+          @plugin.check_modified_localizable_strings
+
+          expect(@dangerfile.status_report[:warnings]).to be_empty
+        end
+      end
+
+      context 'when changing the release notes' do
+        it 'returns a warning when a PR changes the release notes but not the AppStore strings file' do
+          allow(@plugin.git).to receive(:modified_files).and_return(['Resources/release_notes.txt'])
+
+          @plugin.check_release_notes_and_app_store_strings
+
+          expect(@dangerfile.status_report[:warnings]).to eq ['The AppStoreStrings.po file must be updated any time changes are made to the release notes.']
+        end
+
+        it 'does nothing when a PR changes the release notes and the AppStore strings file' do
+          allow(@plugin.git).to receive(:modified_files).and_return(['Resources/release_notes.txt', 'Resources/AppStoreStrings.po'])
+
+          @plugin.check_release_notes_and_app_store_strings
+
+          expect(@dangerfile.status_report[:warnings]).to be_empty
+        end
+
+        it 'does nothing when a PR does not change the release notes or the AppStore strings file' do
+          allow(@plugin.git).to receive(:modified_files).and_return(['MyView.swift', 'Resources/AppStoreStrings.tmp'])
+
+          @plugin.check_release_notes_and_app_store_strings
+
+          expect(@dangerfile.status_report[:warnings]).to be_empty
+        end
+      end
+    end
+  end
+end

--- a/spec/ios_release_check_spec.rb
+++ b/spec/ios_release_check_spec.rb
@@ -25,7 +25,7 @@ module Danger
 
           expected_message = 'Do not edit an existing Core Data model in a release branch unless it hasn\'t been released to testers yet. ' \
                              'Instead create a new model version and merge back to develop soon.'
-          expect(@dangerfile.status_report[:warnings]).to eq [expected_message]
+          expect(@dangerfile).to report_warnings([expected_message])
         end
 
         it 'does nothing when a PR changes a Core Data model on a regular branch' do
@@ -34,7 +34,7 @@ module Danger
 
           @plugin.check_core_data_model_changed
 
-          expect(@dangerfile.status_report[:warnings]).to be_empty
+          expect(@dangerfile).to do_not_report
         end
 
         it 'does nothing when a PR ca warning when a PR does not change a Core Data model on the release branch' do
@@ -43,7 +43,7 @@ module Danger
 
           @plugin.check_core_data_model_changed
 
-          expect(@dangerfile.status_report[:warnings]).to be_empty
+          expect(@dangerfile).to do_not_report
         end
       end
 
@@ -55,7 +55,7 @@ module Danger
           @plugin.check_modified_localizable_strings
 
           expected_message = 'Localizable.strings should only be updated on release branches because it is generated automatically.'
-          expect(@dangerfile.status_report[:warnings]).to eq [expected_message]
+          expect(@dangerfile).to report_warnings([expected_message])
         end
 
         it 'does nothing when a PR changes the Localizable.strings on a release branch' do
@@ -64,7 +64,7 @@ module Danger
 
           @plugin.check_modified_localizable_strings
 
-          expect(@dangerfile.status_report[:warnings]).to be_empty
+          expect(@dangerfile).to do_not_report
         end
 
         it 'does nothing when a PR ca warning when a PR does not change the Localizable.strings on a regular branch' do
@@ -73,7 +73,7 @@ module Danger
 
           @plugin.check_modified_localizable_strings
 
-          expect(@dangerfile.status_report[:warnings]).to be_empty
+          expect(@dangerfile).to do_not_report
         end
       end
 
@@ -83,7 +83,7 @@ module Danger
 
           @plugin.check_release_notes_and_app_store_strings
 
-          expect(@dangerfile.status_report[:warnings]).to eq ['The AppStoreStrings.po file must be updated any time changes are made to the release notes.']
+          expect(@dangerfile).to report_messages(['The `Resources/AppStoreStrings.po` file should be updated if the editorialised release notes file `Resources/release_notes.txt` is being changed.'])
         end
 
         it 'does nothing when a PR changes the release notes and the AppStore strings file' do
@@ -91,7 +91,7 @@ module Danger
 
           @plugin.check_release_notes_and_app_store_strings
 
-          expect(@dangerfile.status_report[:warnings]).to be_empty
+          expect(@dangerfile).to do_not_report
         end
 
         it 'does nothing when a PR does not change the release notes or the AppStore strings file' do
@@ -99,7 +99,7 @@ module Danger
 
           @plugin.check_release_notes_and_app_store_strings
 
-          expect(@dangerfile.status_report[:warnings]).to be_empty
+          expect(@dangerfile).to do_not_report
         end
       end
     end

--- a/spec/ios_release_check_spec.rb
+++ b/spec/ios_release_check_spec.rb
@@ -148,7 +148,7 @@ module Danger
           end
 
           it 'does nothing when a PR on a regular branch changes the source Localizable.strings' do
-            allow(@plugin.git).to receive(:modified_files).and_return(['en.lproj/Localizable.strings'])
+            allow(@plugin.git).to receive(:modified_files).and_return(['./en.lproj/Localizable.strings'])
             allow(@plugin.github).to receive(:branch_for_base).and_return('develop')
 
             @plugin.check_modified_translations_on_release_branch

--- a/spec/ios_release_check_spec.rb
+++ b/spec/ios_release_check_spec.rb
@@ -126,6 +126,45 @@ module Danger
             expect(@dangerfile).to do_not_report
           end
         end
+
+        describe '#check_modified_translations_on_release_branch' do
+          it 'reports a warning when a PR on a regular branch changes a translation file' do
+            allow(@plugin.git).to receive(:modified_files).and_return(['be.lproj/Localizable.strings'])
+            allow(@plugin.github).to receive(:branch_for_base).and_return('develop')
+
+            @plugin.check_modified_translations_on_release_branch
+
+            expected_message = 'Translation files `*.lproj/Localizable.strings` should only be updated on a release branch.'
+            expect(@dangerfile).to report_warnings([expected_message])
+          end
+
+          it 'does nothing when a PR changes a translation string on a release branch' do
+            allow(@plugin.git).to receive(:modified_files).and_return(['fr.lproj/Localizable.strings'])
+            allow(@plugin.github).to receive(:branch_for_base).and_return('release/30.6')
+
+            @plugin.check_modified_translations_on_release_branch
+
+            expect(@dangerfile).to do_not_report
+          end
+
+          it 'does nothing when a PR on a regular branch changes the source Localizable.strings' do
+            allow(@plugin.git).to receive(:modified_files).and_return(['en.lproj/Localizable.strings'])
+            allow(@plugin.github).to receive(:branch_for_base).and_return('develop')
+
+            @plugin.check_modified_translations_on_release_branch
+
+            expect(@dangerfile).to do_not_report
+          end
+
+          it 'does nothing when a PR does not change a translation file on a regular branch' do
+            allow(@plugin.git).to receive(:modified_files).and_return(['./path/to/view/model/MyViewModel3.swift'])
+            allow(@plugin.github).to receive(:branch_for_base).and_return('develop')
+
+            @plugin.check_modified_translations_on_release_branch
+
+            expect(@dangerfile).to do_not_report
+          end
+        end
       end
 
       context 'when changing the release notes' do

--- a/spec/ios_release_check_spec.rb
+++ b/spec/ios_release_check_spec.rb
@@ -55,7 +55,7 @@ module Danger
 
             @plugin.check_modified_localizable_strings_on_release
 
-            expected_message = 'The `Localizable.strings` files should only be updated on release branches, when the translations are downloaded.'
+            expected_message = 'The `Localizable.strings` files should only be updated on release branches, when the translations are downloaded by our automation.'
             expect(@dangerfile).to report_warnings([expected_message])
           end
 
@@ -65,7 +65,7 @@ module Danger
 
             @plugin.check_modified_localizable_strings_on_release
 
-            expected_message = 'The `Localizable.strings` files should only be updated on release branches, when the translations are downloaded.'
+            expected_message = 'The `Localizable.strings` files should only be updated on release branches, when the translations are downloaded by our automation.'
             expect(@dangerfile).to report_warnings([expected_message])
           end
 

--- a/spec/ios_release_check_spec.rb
+++ b/spec/ios_release_check_spec.rb
@@ -17,7 +17,7 @@ module Danger
       end
 
       context 'when changing the Core Data model' do
-        it 'returns a warning when a PR on a release branch changes a Core Data model' do
+        it 'reports a warning when a PR on a release branch changes a Core Data model' do
           allow(@plugin.git).to receive(:modified_files).and_return(['./path/to/model/Model.xcdatamodeld'])
           allow(@plugin.github).to receive(:branch_for_base).and_return('release/30.6')
 
@@ -49,7 +49,7 @@ module Danger
 
       context 'when changing the Localizable.strings files' do
         describe '#check_modified_localizable_strings_on_release' do
-          it 'returns a warning when a PR on a regular branch changes the source Localizable.strings' do
+          it 'reports a warning when a PR on a regular branch changes the source Localizable.strings' do
             allow(@plugin.git).to receive(:modified_files).and_return(['en.lproj/Localizable.strings'])
             allow(@plugin.github).to receive(:branch_for_base).and_return('develop')
 
@@ -59,7 +59,7 @@ module Danger
             expect(@dangerfile).to report_warnings([expected_message])
           end
 
-          it 'returns a warning when a PR on a regular branch changes a translated Localizable.strings' do
+          it 'reports a warning when a PR on a regular branch changes a translated Localizable.strings' do
             allow(@plugin.git).to receive(:modified_files).and_return(['nl.lproj/Localizable.strings'])
             allow(@plugin.github).to receive(:branch_for_base).and_return('trunk')
 
@@ -168,7 +168,7 @@ module Danger
       end
 
       context 'when changing the release notes' do
-        it 'returns a warning when a PR changes the release notes but not the AppStore strings file' do
+        it 'reports a warning when a PR changes the release notes but not the AppStore strings file' do
           allow(@plugin.git).to receive(:modified_files).and_return(['Resources/release_notes.txt'])
 
           @plugin.check_release_notes_and_app_store_strings

--- a/spec/ios_release_check_spec.rb
+++ b/spec/ios_release_check_spec.rb
@@ -34,7 +34,7 @@ module Danger
 
           @plugin.check_core_data_model_changed
 
-          expect(@dangerfile).to do_not_report
+          expect(@dangerfile).to not_report
         end
 
         it 'does nothing when a PR ca warning when a PR does not change a Core Data model on the release branch' do
@@ -43,7 +43,7 @@ module Danger
 
           @plugin.check_core_data_model_changed
 
-          expect(@dangerfile).to do_not_report
+          expect(@dangerfile).to not_report
         end
       end
 
@@ -75,7 +75,7 @@ module Danger
 
             @plugin.check_modified_localizable_strings_on_release
 
-            expect(@dangerfile).to do_not_report
+            expect(@dangerfile).to not_report
           end
 
           it 'does nothing when a PR does not change the Localizable.strings on a regular branch' do
@@ -84,7 +84,7 @@ module Danger
 
             @plugin.check_modified_localizable_strings_on_release
 
-            expect(@dangerfile).to do_not_report
+            expect(@dangerfile).to not_report
           end
         end
 
@@ -105,7 +105,7 @@ module Danger
 
             @plugin.check_modified_en_strings_on_regular_branch
 
-            expect(@dangerfile).to do_not_report
+            expect(@dangerfile).to not_report
           end
 
           it 'does nothing when a PR on a release branch changes a translated Localizable.strings' do
@@ -114,7 +114,7 @@ module Danger
 
             @plugin.check_modified_en_strings_on_regular_branch
 
-            expect(@dangerfile).to do_not_report
+            expect(@dangerfile).to not_report
           end
 
           it 'does nothing when a PR does not change the Localizable.strings on a release branch' do
@@ -123,7 +123,7 @@ module Danger
 
             @plugin.check_modified_en_strings_on_regular_branch
 
-            expect(@dangerfile).to do_not_report
+            expect(@dangerfile).to not_report
           end
         end
 
@@ -144,7 +144,7 @@ module Danger
 
             @plugin.check_modified_translations_on_release_branch
 
-            expect(@dangerfile).to do_not_report
+            expect(@dangerfile).to not_report
           end
 
           it 'does nothing when a PR on a regular branch changes the source Localizable.strings' do
@@ -153,7 +153,7 @@ module Danger
 
             @plugin.check_modified_translations_on_release_branch
 
-            expect(@dangerfile).to do_not_report
+            expect(@dangerfile).to not_report
           end
 
           it 'does nothing when a PR does not change a translation file on a regular branch' do
@@ -162,7 +162,7 @@ module Danger
 
             @plugin.check_modified_translations_on_release_branch
 
-            expect(@dangerfile).to do_not_report
+            expect(@dangerfile).to not_report
           end
         end
       end
@@ -181,7 +181,7 @@ module Danger
 
           @plugin.check_release_notes_and_app_store_strings
 
-          expect(@dangerfile).to do_not_report
+          expect(@dangerfile).to not_report
         end
 
         it 'does nothing when a PR does not change the release notes or the AppStore strings file' do
@@ -189,7 +189,7 @@ module Danger
 
           @plugin.check_release_notes_and_app_store_strings
 
-          expect(@dangerfile).to do_not_report
+          expect(@dangerfile).to not_report
         end
       end
     end

--- a/spec/ios_release_check_spec.rb
+++ b/spec/ios_release_check_spec.rb
@@ -13,9 +13,7 @@ module Danger
         @dangerfile = testing_dangerfile
         @plugin = @dangerfile.ios_release_check
 
-        allow(@plugin.git).to receive(:added_files).and_return([])
-        allow(@plugin.git).to receive(:modified_files).and_return([])
-        allow(@plugin.git).to receive(:deleted_files).and_return([])
+        allow(@plugin.git).to receive_messages(added_files: [], modified_files: [], deleted_files: [])
       end
 
       context 'when changing the Core Data model' do


### PR DESCRIPTION
This PR ports the rules related to releases that are currently implemented in the following Peril rules:
- https://github.com/Automattic/peril-settings/blob/master/org/pr/ios-macos.ts
- https://github.com/Automattic/peril-settings/blob/master/org/pr/android.ts
- https://github.com/Automattic/peril-settings/blob/master/org/pr/release-notes.ts

I tried to make them more generic along the way as some of them seem closely related to the conventions and general process for WordPress and WooCommerce.
There is a check for `Releases` in some of these Peril rules, which is a logic to prevent the checks to run. My idea is to have these checks performed either in the host project's `Dangerfile` or in a common `Dangerfile` provided by this repo that can be included in the host project's `Dangerfile`, in such a way that the plugins won't need more specific checks as this one.

This PR introduces the following plugins:
- `CommonReleaseChecks`: contains generic checks, in a process agnostic way so that it can be used independently.
- `AndroidReleaseCheck` and `IosReleaseCheck`: they both use `CommonReleaseChecks` to perform iOS/Android specific checks

The remainder rules from the files mentioned above will follow in another PR.