### PR TITLE
Plugin for checking the PR size

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -5,6 +5,9 @@ require:
 AllCops:
   NewCops: enable
 
+Style/HashSyntax:
+  EnforcedShorthandSyntax: either
+
 ########## Gemspec Rules
 
 # Disabling this as all the gem publishing will be done within CI and doesn't allow for user input such as an MFA code.
@@ -57,3 +60,6 @@ RSpec/ExampleLength:
 # Same for number of let/subject
 RSpec/MultipleMemoizedHelpers:
   Enabled: false
+
+RSpec/MultipleExpectations:
+  Max: 2

--- a/lib/danger_plugin.rb
+++ b/lib/danger_plugin.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
 
 require 'dangermattic/plugins/manifest_pr_checker'
+require 'dangermattic/plugins/pr_size_checker'
 require 'dangermattic/plugins/view_changes_need_screenshots'

--- a/lib/dangermattic/plugins/pr_size_checker.rb
+++ b/lib/dangermattic/plugins/pr_size_checker.rb
@@ -1,0 +1,84 @@
+# frozen_string_literal: true
+
+module Danger
+  # Plugin to check the size of a Pull Request content and text body.
+  class PRSizeChecker < Plugin
+    DEFAULT_MAX_DIFF_SIZE = 500
+    DEFAULT_DIFF_SIZE_MESSAGE = 'Please keep the Pull Request small, breaking it down into multiple ones if necessary'
+    DEFAULT_MIN_PR_BODY_MESSAGE = 'Please provide a summary of the changes in the Pull Request description'
+    DEFAULT_MIN_PR_BODY = 10
+
+    # Check the size of the PR diff against a specified maximum size.
+    #
+    # @param file_selector [Proc] Optional closure to filter the files in the diff to be used for size calculation.
+    # @param type [:insertions, :deletions, :all] The type of diff size to check. (default: :all)
+    # @param max_size [Integer] The maximum allowed size for the diff. (default: DEFAULT_MAX_DIFF_SIZE)
+    # @param message [String] The message to display if the diff size exceeds the maximum. (default: DEFAULT_DIFF_SIZE_MESSAGE)
+    # @param fail_on_error [Boolean] If true, fail the PR check when the diff size exceeds the maximum (default: false).
+    def check_diff_size(file_selector: nil, type: :all, max_size: DEFAULT_MAX_DIFF_SIZE, message: DEFAULT_DIFF_SIZE_MESSAGE, fail_on_error: false)
+      case type
+      when :insertions
+        if insertions_size(file_selector: file_selector) > max_size
+          fail_on_error ? failure(message) : warn(message)
+        end
+      when :deletions
+        if deletions_size(file_selector: file_selector) > max_size
+          fail_on_error ? failure(message) : warn(message)
+        end
+      when :all
+        if diff_size(file_selector: file_selector) > max_size
+          fail_on_error ? failure(message) : warn(message)
+        end
+      end
+    end
+
+    # Check the size of the Pull Request description (PR body) against a specified minimum size.
+    #
+    # @param min_length [Integer] The minimum allowed length for the PR body. (default: DEFAULT_MIN_PR_BODY)
+    # @param fail_on_error [Boolean] If true, fail the PR check when the PR body length is too small. (default: false)
+    def check_pr_body(min_length: DEFAULT_MIN_PR_BODY, message: DEFAULT_MIN_PR_BODY_MESSAGE, fail_on_error: false)
+      return if danger.github.pr_body.length > min_length
+
+      fail_on_error ? failure(message) : warn(message)
+    end
+
+    # Calculate the total size of insertions in modified files that match the file selector.
+    #
+    # @param file_selector [Proc] Select the files to be used for the insertions calculation.
+    # @return [Integer] The total size of insertions in the selected modified files.
+    def insertions_size(file_selector:)
+      return danger.git.insertions unless file_selector
+
+      filtered_files = all_modified_files.select(&file_selector)
+      filtered_files.sum { |file| danger.git.info_for_file(file)[:insertions].to_i }
+    end
+
+    # Calculate the total size of deletions in modified files that match the file selector.
+    #
+    # @param file_selector [Proc] Select the files to be used for the deletions calculation.
+    # @return [Integer] The total size of deletions in the selected modified files.
+    def deletions_size(file_selector:)
+      return danger.git.deletions unless file_selector
+
+      filtered_files = all_modified_files.select(&file_selector)
+      filtered_files.sum { |file| danger.git.info_for_file(file)[:deletions].to_i }
+    end
+
+    # Calculate the total size of changes (insertions and deletions) in modified files that match the file selector.
+    #
+    # @param file_selector [Proc] Select the files to be used for the total insertions and deletions calculation.
+    # @return [Integer] The total size of changes in the selected modified files.
+    def diff_size(file_selector:)
+      return danger.git.lines_of_code unless file_selector
+
+      filtered_files = all_modified_files.select(&file_selector)
+      filtered_files.sum { |file| danger.git.info_for_file(file)[:deletions].to_i + danger.git.info_for_file(file)[:insertions].to_i }
+    end
+
+    private
+
+    def all_modified_files
+      danger.git.added_files + danger.git.modified_files + danger.git.deleted_files
+    end
+  end
+end

--- a/lib/dangermattic/plugins/pr_size_checker.rb
+++ b/lib/dangermattic/plugins/pr_size_checker.rb
@@ -4,9 +4,9 @@ module Danger
   # Plugin to check the size of a Pull Request content and text body.
   class PRSizeChecker < Plugin
     DEFAULT_MAX_DIFF_SIZE = 500
-    DEFAULT_DIFF_SIZE_MESSAGE = "This PR is larger than #{DEFAULT_MAX_DIFF_SIZE} lines of changes. Please consider splitting it into smaller PRs for easier and faster reviews.".freeze
+    DEFAULT_DIFF_SIZE_MESSAGE_FORMAT = 'This PR is larger than %d lines of changes. Please consider splitting it into smaller PRs for easier and faster reviews.'
     DEFAULT_MIN_PR_BODY = 10
-    DEFAULT_MIN_PR_BODY_MESSAGE = "The PR description appears very short, less than #{DEFAULT_MIN_PR_BODY} characters long. Please provide a summary of your changes in the PR description.".freeze
+    DEFAULT_MIN_PR_BODY_MESSAGE_FORMAT = 'The PR description appears very short, less than %d characters long. Please provide a summary of your changes in the PR description.'
 
     # Check the size of the PR diff against a specified maximum size.
     #
@@ -15,7 +15,7 @@ module Danger
     # @param max_size [Integer] The maximum allowed size for the diff. (default: DEFAULT_MAX_DIFF_SIZE)
     # @param message [String] The message to display if the diff size exceeds the maximum. (default: DEFAULT_DIFF_SIZE_MESSAGE)
     # @param fail_on_error [Boolean] If true, fail the PR check when the diff size exceeds the maximum (default: false).
-    def check_diff_size(file_selector: nil, type: :all, max_size: DEFAULT_MAX_DIFF_SIZE, message: DEFAULT_DIFF_SIZE_MESSAGE, fail_on_error: false)
+    def check_diff_size(file_selector: nil, type: :all, max_size: DEFAULT_MAX_DIFF_SIZE, message: format(DEFAULT_DIFF_SIZE_MESSAGE_FORMAT, max_size), fail_on_error: false)
       case type
       when :insertions
         if insertions_size(file_selector: file_selector) > max_size
@@ -36,7 +36,7 @@ module Danger
     #
     # @param min_length [Integer] The minimum allowed length for the PR body. (default: DEFAULT_MIN_PR_BODY)
     # @param fail_on_error [Boolean] If true, fail the PR check when the PR body length is too small. (default: false)
-    def check_pr_body(min_length: DEFAULT_MIN_PR_BODY, message: DEFAULT_MIN_PR_BODY_MESSAGE, fail_on_error: false)
+    def check_pr_body(min_length: DEFAULT_MIN_PR_BODY, message: format(DEFAULT_MIN_PR_BODY_MESSAGE_FORMAT, min_length), fail_on_error: false)
       return if danger.github.pr_body.length > min_length
 
       fail_on_error ? failure(message) : warn(message)

--- a/lib/dangermattic/plugins/pr_size_checker.rb
+++ b/lib/dangermattic/plugins/pr_size_checker.rb
@@ -4,9 +4,9 @@ module Danger
   # Plugin to check the size of a Pull Request content and text body.
   class PRSizeChecker < Plugin
     DEFAULT_MAX_DIFF_SIZE = 500
-    DEFAULT_DIFF_SIZE_MESSAGE = 'Please keep the Pull Request small, breaking it down into multiple ones if necessary'
-    DEFAULT_MIN_PR_BODY_MESSAGE = 'Please provide a summary of the changes in the Pull Request description'
+    DEFAULT_DIFF_SIZE_MESSAGE = "This PR is larger than #{DEFAULT_MAX_DIFF_SIZE} lines of changes. Please consider splitting it into smaller PRs for easier and faster reviews.".freeze
     DEFAULT_MIN_PR_BODY = 10
+    DEFAULT_MIN_PR_BODY_MESSAGE = "The PR description appears very short, less than #{DEFAULT_MIN_PR_BODY} characters long. Please provide a summary of your changes in the PR description.".freeze
 
     # Check the size of the PR diff against a specified maximum size.
     #

--- a/spec/pr_size_checker_spec.rb
+++ b/spec/pr_size_checker_spec.rb
@@ -71,33 +71,35 @@ module Danger
         end
 
         shared_examples 'using a file selector to filter and count the changes in a diff' do |type, max_sizes|
-          it 'reports a warning when using a files filter that will result in a diff that is too large' do
-            prepare_diff_with_test_files
+          context 'when using a files filter that will regard the diff as too large' do
+            it 'reports a warning' do
+              prepare_diff_with_test_files
 
-            @plugin.check_diff_size(
-              file_selector: ->(path) { File.dirname(path).start_with?('src/test/java') },
-              type: type,
-              max_size: max_sizes[0]
-            )
+              @plugin.check_diff_size(
+                file_selector: ->(path) { File.dirname(path).start_with?('src/test/java') },
+                type: type,
+                max_size: max_sizes[0]
+              )
 
-            expect(@dangerfile.status_report[:errors]).to be_empty
-            expect(@dangerfile.status_report[:warnings]).to eq ['This PR is larger than 500 lines of changes. Please consider splitting it into smaller PRs for easier and faster reviews.']
-          end
+              expect(@dangerfile.status_report[:errors]).to be_empty
+              expect(@dangerfile.status_report[:warnings]).to eq ['This PR is larger than 500 lines of changes. Please consider splitting it into smaller PRs for easier and faster reviews.']
+            end
 
-          it 'reports an error when using a files filter that will result in a diff that is too large, with a custom error' do
-            prepare_diff_with_test_files
+            it 'reports a custom error' do
+              prepare_diff_with_test_files
 
-            custom_message = 'diff size too large custom file filter and error message'
-            @plugin.check_diff_size(
-              file_selector: ->(path) { File.extname(path) == '.java' },
-              type: type,
-              max_size: max_sizes[1],
-              message: custom_message,
-              fail_on_error: true
-            )
+              custom_message = 'diff size too large custom file filter and error message'
+              @plugin.check_diff_size(
+                file_selector: ->(path) { File.extname(path) == '.java' },
+                type: type,
+                max_size: max_sizes[1],
+                message: custom_message,
+                fail_on_error: true
+              )
 
-            expect(@dangerfile.status_report[:warnings]).to be_empty
-            expect(@dangerfile.status_report[:errors]).to eq [custom_message]
+              expect(@dangerfile.status_report[:warnings]).to be_empty
+              expect(@dangerfile.status_report[:errors]).to eq [custom_message]
+            end
           end
 
           it 'does nothing when a files filter is used but the max size is greater than or equal to the diff size' do

--- a/spec/pr_size_checker_spec.rb
+++ b/spec/pr_size_checker_spec.rb
@@ -1,0 +1,194 @@
+# frozen_string_literal: true
+
+require_relative 'spec_helper'
+
+module Danger
+  describe Danger::PRSizeChecker do
+    it 'is a plugin' do
+      expect(described_class.new(nil)).to be_a Danger::Plugin
+    end
+
+    describe 'with Dangerfile' do
+      before do
+        @dangerfile = testing_dangerfile
+        @plugin = @dangerfile.pr_size_checker
+      end
+
+      context 'when checking a PR diff size' do
+        before do
+          allow(@plugin.git).to receive(:added_files).and_return([])
+          allow(@plugin.git).to receive(:modified_files).and_return([])
+          allow(@plugin.git).to receive(:deleted_files).and_return([])
+        end
+
+        shared_examples 'using the default diff size counter without a file selector' do |type|
+          let(:diff_counter_for_type) do
+            type_hash = {
+              insertions: :insertions,
+              deletions: :deletions,
+              all: :lines_of_code
+            }
+
+            type_hash[type]
+          end
+
+          it 'returns a warning when using default parameters in a PR that has larger diff than the default maximum' do
+            allow(@plugin.git).to receive(diff_counter_for_type).and_return(501)
+
+            @plugin.check_diff_size(type: type)
+
+            expect(@dangerfile.status_report[:warnings]).to eq ['Please keep the Pull Request small, breaking it down into multiple ones if necessary']
+          end
+
+          it 'does nothing when using default parameters in a PR that has equal diff than the default maximum' do
+            allow(@plugin.git).to receive(diff_counter_for_type).and_return(500)
+
+            @plugin.check_diff_size(type: type)
+
+            expect(@dangerfile.status_report[:errors]).to be_empty
+            expect(@dangerfile.status_report[:warnings]).to be_empty
+          end
+
+          it 'does nothing when using default parameters in a PR that has smaller diff than the default maximum' do
+            allow(@plugin.git).to receive(diff_counter_for_type).and_return(499)
+
+            @plugin.check_diff_size(type: type)
+
+            expect(@dangerfile.status_report[:errors]).to be_empty
+            expect(@dangerfile.status_report[:warnings]).to be_empty
+          end
+
+          it 'returns an error using a custom message and a custom pr body size' do
+            allow(@plugin.git).to receive(diff_counter_for_type).and_return(600)
+
+            custom_message = 'diff size custom message'
+            @plugin.check_diff_size(type: type, max_size: 599, message: custom_message, fail_on_error: true)
+
+            expect(@dangerfile.status_report[:errors]).to eq [custom_message]
+          end
+        end
+
+        shared_examples 'using a file selector to filter and count the changes in a diff' do |type, max_sizes|
+          it 'returns a warning when using a files filter that will result in a diff that is too large' do
+            prepare_diff_with_test_files
+
+            @plugin.check_diff_size(
+              file_selector: ->(path) { File.dirname(path).start_with?('src/test/java') },
+              type: type,
+              max_size: max_sizes[0]
+            )
+
+            expect(@dangerfile.status_report[:warnings]).to eq ['Please keep the Pull Request small, breaking it down into multiple ones if necessary']
+          end
+
+          it 'returns a warning when using a files filter that will result in a diff that is too large, with a custom error' do
+            prepare_diff_with_test_files
+
+            custom_message = 'diff size too large custom file filter and error message'
+            @plugin.check_diff_size(
+              file_selector: ->(path) { File.extname(path) == '.java' },
+              type: type,
+              max_size: max_sizes[1],
+              message: custom_message,
+              fail_on_error: true
+            )
+
+            expect(@dangerfile.status_report[:warnings]).to be_empty
+            expect(@dangerfile.status_report[:errors]).to eq [custom_message]
+          end
+
+          it 'does nothing when a files filter is used but the max size is greater than or equal to the diff size' do
+            prepare_diff_with_test_files
+
+            @plugin.check_diff_size(
+              file_selector: ->(path) { File.extname(path).match(/^(.java|.kt)$/) },
+              type: type,
+              max_size: max_sizes[2]
+            )
+
+            expect(@dangerfile.status_report[:warnings]).to be_empty
+          end
+        end
+
+        context 'with the entire diff' do
+          include_examples 'using the default diff size counter without a file selector', :all
+          include_examples 'using a file selector to filter and count the changes in a diff', :all, [422, 520, 1541]
+        end
+
+        context 'with the insertions in the diff' do
+          include_examples 'using the default diff size counter without a file selector', :insertions
+          include_examples 'using a file selector to filter and count the changes in a diff', :insertions, [200, 139, 384]
+        end
+
+        context 'with the deletions in the diff' do
+          include_examples 'using the default diff size counter without a file selector', :deletions
+          include_examples 'using a file selector to filter and count the changes in a diff', :deletions, [221, 380, 1157]
+        end
+
+        def prepare_diff_with_test_files
+          added_test_file = 'src/test/java/org/magic/MagicTests.kt'
+          added_config = 'config.xml'
+          added_file = 'MyNewSorcery.java'
+          modified_file1 = 'src/java/PotionIngredients.java'
+          modified_file2 = 'src/java/Potion.kt'
+          modified_strings = 'src/main/res/values/strings.xml'
+          deleted_file1 = 'src/java/org/Fire.kt'
+          deleted_file2 = 'BlackCat.kt'
+          deleted_test_file = 'src/test/java/org/magic/Power.java'
+          deleted_strings = 'src/main/res/values-de/strings.xml'
+
+          allow(@plugin.git).to receive(:added_files).and_return([added_config, added_file])
+          allow(@plugin.git).to receive(:modified_files).and_return([modified_file1, modified_file2, added_test_file, modified_strings])
+          allow(@plugin.git).to receive(:deleted_files).and_return([deleted_file1, deleted_test_file, deleted_strings, deleted_file2])
+
+          allow(@plugin.git).to receive(:info_for_file).with(added_test_file).and_return({ insertions: 201 })
+          allow(@plugin.git).to receive(:info_for_file).with(added_config).and_return({ insertions: 311 })
+          allow(@plugin.git).to receive(:info_for_file).with(added_file).and_return({ insertions: 13 })
+          allow(@plugin.git).to receive(:info_for_file).with(modified_file1).and_return({ insertions: 127, deletions: 159 })
+          allow(@plugin.git).to receive(:info_for_file).with(modified_file2).and_return({ insertions: 43, deletions: 37 })
+          allow(@plugin.git).to receive(:info_for_file).with(modified_strings).and_return({ insertions: 432, deletions: 297 })
+          allow(@plugin.git).to receive(:info_for_file).with(deleted_file1).and_return({ deletions: 246 })
+          allow(@plugin.git).to receive(:info_for_file).with(deleted_file2).and_return({ deletions: 493 })
+          allow(@plugin.git).to receive(:info_for_file).with(deleted_test_file).and_return({ deletions: 222 })
+          allow(@plugin.git).to receive(:info_for_file).with(deleted_strings).and_return({ deletions: 593 })
+        end
+      end
+
+      context 'when checking a PR body size' do
+        it 'returns a warning when using default parameters in a PR that has a smaller body text length than the default minimum' do
+          allow(@plugin.github).to receive(:pr_body).and_return('pr body')
+
+          @plugin.check_pr_body
+
+          expect(@dangerfile.status_report[:warnings]).to eq ['Please provide a summary of the changes in the Pull Request description']
+        end
+
+        it 'does nothing when using default parameters in a PR that has a bigger pr body text length than the default minimum' do
+          allow(@plugin.github).to receive(:pr_body).and_return('some test pr body')
+
+          @plugin.check_pr_body
+
+          expect(@dangerfile.status_report[:warnings]).to be_empty
+        end
+
+        it 'returns an error when using default parameters in a PR that has an equal pr body text length than the default minimum' do
+          allow(@plugin.github).to receive(:pr_body).and_return('some test-')
+
+          @plugin.check_pr_body
+
+          expect(@dangerfile.status_report[:warnings]).to eq ['Please provide a summary of the changes in the Pull Request description']
+        end
+
+        it 'returns an error when using a custom message and a custom minimum pr body text length' do
+          allow(@plugin.github).to receive(:pr_body).and_return('still too short message')
+
+          custom_message = 'Custom error message'
+          @plugin.check_pr_body(min_length: 25, message: custom_message, fail_on_error: true)
+
+          expect(@dangerfile.status_report[:warnings]).to be_empty
+          expect(@dangerfile.status_report[:errors]).to eq [custom_message]
+        end
+      end
+    end
+  end
+end

--- a/spec/pr_size_checker_spec.rb
+++ b/spec/pr_size_checker_spec.rb
@@ -21,7 +21,7 @@ module Danger
           allow(@plugin.git).to receive(:deleted_files).and_return([])
         end
 
-        shared_examples 'using the default diff size counter without a file selector' do |type|
+        shared_examples 'using the default diff size counter, without a file selector' do |type|
           let(:diff_counter_for_type) do
             type_hash = {
               insertions: :insertions,
@@ -38,7 +38,7 @@ module Danger
             @plugin.check_diff_size(type: type)
 
             expect(@dangerfile.status_report[:errors]).to be_empty
-            expect(@dangerfile.status_report[:warnings]).to eq ['This PR is larger than 500 lines of changes. Please consider splitting it into smaller PRs for easier and faster reviews.']
+            expect(@dangerfile.status_report[:warnings]).to eq [described_class::DEFAULT_DIFF_SIZE_MESSAGE]
           end
 
           it 'does nothing when using default parameters in a PR that has equal diff than the default maximum' do
@@ -59,14 +59,38 @@ module Danger
             expect(@dangerfile.status_report[:warnings]).to be_empty
           end
 
-          it 'reports an error using a custom message and a custom PR body size' do
-            allow(@plugin.git).to receive(diff_counter_for_type).and_return(600)
+          context 'when reporting a custom error or warning with a custom max_size' do
+            shared_examples 'reporting diff size custom warnings or errors' do |fail_on_error, message|
+              it 'reports an error using a custom message and a custom PR body size' do
+                allow(@plugin.git).to receive(diff_counter_for_type).and_return(600)
 
-            custom_message = 'diff size custom message'
-            @plugin.check_diff_size(type: type, max_size: 599, message: custom_message, fail_on_error: true)
+                if message
+                  @plugin.check_diff_size(type: type, max_size: 599, message: message, fail_on_error: fail_on_error)
+                else
+                  @plugin.check_diff_size(type: type, max_size: 599, fail_on_error: fail_on_error)
+                end
 
-            expect(@dangerfile.status_report[:warnings]).to be_empty
-            expect(@dangerfile.status_report[:errors]).to eq [custom_message]
+                message ||= described_class::DEFAULT_DIFF_SIZE_MESSAGE
+
+                expect_warning_or_error(fail_on_error: fail_on_error, message: message)
+              end
+            end
+
+            context 'when fail on error is false and a custom message is given' do
+              include_examples 'reporting diff size custom warnings or errors', false, 'this is my custom warning message'
+            end
+
+            context 'when fail on error is false' do
+              include_examples 'reporting diff size custom warnings or errors', false
+            end
+
+            context 'when fail on error is true' do
+              include_examples 'reporting diff size custom warnings or errors', true
+            end
+
+            context 'when a custom error message is given and fail on error is true' do
+              include_examples 'reporting diff size custom warnings or errors', true, 'this is my custom error message'
+            end
           end
         end
 
@@ -82,7 +106,7 @@ module Danger
               )
 
               expect(@dangerfile.status_report[:errors]).to be_empty
-              expect(@dangerfile.status_report[:warnings]).to eq ['This PR is larger than 500 lines of changes. Please consider splitting it into smaller PRs for easier and faster reviews.']
+              expect(@dangerfile.status_report[:warnings]).to eq [described_class::DEFAULT_DIFF_SIZE_MESSAGE]
             end
 
             it 'reports a custom error' do
@@ -114,49 +138,49 @@ module Danger
             expect(@dangerfile.status_report[:errors]).to be_empty
             expect(@dangerfile.status_report[:warnings]).to be_empty
           end
+
+          def prepare_diff_with_test_files
+            added_test_file = 'src/test/java/org/magic/MagicTests.kt'
+            added_config = 'config.xml'
+            added_file = 'MyNewSorcery.java'
+            modified_file1 = 'src/java/PotionIngredients.java'
+            modified_file2 = 'src/java/Potion.kt'
+            modified_strings = 'src/main/res/values/strings.xml'
+            deleted_file1 = 'src/java/org/Fire.kt'
+            deleted_file2 = 'BlackCat.kt'
+            deleted_test_file = 'src/test/java/org/magic/Power.java'
+            deleted_strings = 'src/main/res/values-de/strings.xml'
+
+            allow(@plugin.git).to receive(:added_files).and_return([added_config, added_file])
+            allow(@plugin.git).to receive(:modified_files).and_return([modified_file1, modified_file2, added_test_file, modified_strings])
+            allow(@plugin.git).to receive(:deleted_files).and_return([deleted_file1, deleted_test_file, deleted_strings, deleted_file2])
+
+            allow(@plugin.git).to receive(:info_for_file).with(added_test_file).and_return({ insertions: 201 })
+            allow(@plugin.git).to receive(:info_for_file).with(added_config).and_return({ insertions: 311 })
+            allow(@plugin.git).to receive(:info_for_file).with(added_file).and_return({ insertions: 13 })
+            allow(@plugin.git).to receive(:info_for_file).with(modified_file1).and_return({ insertions: 127, deletions: 159 })
+            allow(@plugin.git).to receive(:info_for_file).with(modified_file2).and_return({ insertions: 43, deletions: 37 })
+            allow(@plugin.git).to receive(:info_for_file).with(modified_strings).and_return({ insertions: 432, deletions: 297 })
+            allow(@plugin.git).to receive(:info_for_file).with(deleted_file1).and_return({ deletions: 246 })
+            allow(@plugin.git).to receive(:info_for_file).with(deleted_file2).and_return({ deletions: 493 })
+            allow(@plugin.git).to receive(:info_for_file).with(deleted_test_file).and_return({ deletions: 222 })
+            allow(@plugin.git).to receive(:info_for_file).with(deleted_strings).and_return({ deletions: 593 })
+          end
         end
 
         context 'with the entire diff' do
-          include_examples 'using the default diff size counter without a file selector', :all
+          include_examples 'using the default diff size counter, without a file selector', :all
           include_examples 'using a file selector to filter and count the changes in a diff', :all, [422, 520, 1541]
         end
 
         context 'with the insertions in the diff' do
-          include_examples 'using the default diff size counter without a file selector', :insertions
+          include_examples 'using the default diff size counter, without a file selector', :insertions
           include_examples 'using a file selector to filter and count the changes in a diff', :insertions, [200, 139, 384]
         end
 
         context 'with the deletions in the diff' do
-          include_examples 'using the default diff size counter without a file selector', :deletions
+          include_examples 'using the default diff size counter, without a file selector', :deletions
           include_examples 'using a file selector to filter and count the changes in a diff', :deletions, [221, 380, 1157]
-        end
-
-        def prepare_diff_with_test_files
-          added_test_file = 'src/test/java/org/magic/MagicTests.kt'
-          added_config = 'config.xml'
-          added_file = 'MyNewSorcery.java'
-          modified_file1 = 'src/java/PotionIngredients.java'
-          modified_file2 = 'src/java/Potion.kt'
-          modified_strings = 'src/main/res/values/strings.xml'
-          deleted_file1 = 'src/java/org/Fire.kt'
-          deleted_file2 = 'BlackCat.kt'
-          deleted_test_file = 'src/test/java/org/magic/Power.java'
-          deleted_strings = 'src/main/res/values-de/strings.xml'
-
-          allow(@plugin.git).to receive(:added_files).and_return([added_config, added_file])
-          allow(@plugin.git).to receive(:modified_files).and_return([modified_file1, modified_file2, added_test_file, modified_strings])
-          allow(@plugin.git).to receive(:deleted_files).and_return([deleted_file1, deleted_test_file, deleted_strings, deleted_file2])
-
-          allow(@plugin.git).to receive(:info_for_file).with(added_test_file).and_return({ insertions: 201 })
-          allow(@plugin.git).to receive(:info_for_file).with(added_config).and_return({ insertions: 311 })
-          allow(@plugin.git).to receive(:info_for_file).with(added_file).and_return({ insertions: 13 })
-          allow(@plugin.git).to receive(:info_for_file).with(modified_file1).and_return({ insertions: 127, deletions: 159 })
-          allow(@plugin.git).to receive(:info_for_file).with(modified_file2).and_return({ insertions: 43, deletions: 37 })
-          allow(@plugin.git).to receive(:info_for_file).with(modified_strings).and_return({ insertions: 432, deletions: 297 })
-          allow(@plugin.git).to receive(:info_for_file).with(deleted_file1).and_return({ deletions: 246 })
-          allow(@plugin.git).to receive(:info_for_file).with(deleted_file2).and_return({ deletions: 493 })
-          allow(@plugin.git).to receive(:info_for_file).with(deleted_test_file).and_return({ deletions: 222 })
-          allow(@plugin.git).to receive(:info_for_file).with(deleted_strings).and_return({ deletions: 593 })
         end
       end
 
@@ -167,7 +191,7 @@ module Danger
           @plugin.check_pr_body
 
           expect(@dangerfile.status_report[:errors]).to be_empty
-          expect(@dangerfile.status_report[:warnings]).to eq ['The PR description appears very short, less than 10 characters long. Please provide a summary of your changes in the PR description.']
+          expect(@dangerfile.status_report[:warnings]).to eq [described_class::DEFAULT_MIN_PR_BODY_MESSAGE]
         end
 
         it 'does nothing when using default parameters in a PR that has a bigger PR body text length than the default minimum' do
@@ -185,17 +209,51 @@ module Danger
           @plugin.check_pr_body
 
           expect(@dangerfile.status_report[:errors]).to be_empty
-          expect(@dangerfile.status_report[:warnings]).to eq ['The PR description appears very short, less than 10 characters long. Please provide a summary of your changes in the PR description.']
+          expect(@dangerfile.status_report[:warnings]).to eq [described_class::DEFAULT_MIN_PR_BODY_MESSAGE]
         end
 
-        it 'reports an error when using a custom message and a custom minimum PR body text length' do
-          allow(@plugin.github).to receive(:pr_body).and_return('still too short message')
+        context 'when reporting a custom error or warning with a custom min_length' do
+          shared_examples 'reporting PR length check custom warnings or errors' do |fail_on_error, message|
+            it 'reports an error when using a custom message and a custom minimum PR body text length' do
+              allow(@plugin.github).to receive(:pr_body).and_return('still too short message')
 
-          custom_message = 'Custom error message'
-          @plugin.check_pr_body(min_length: 25, message: custom_message, fail_on_error: true)
+              if message
+                @plugin.check_pr_body(min_length: 25, message: message, fail_on_error: fail_on_error)
+              else
+                @plugin.check_pr_body(min_length: 25, fail_on_error: fail_on_error)
+              end
 
+              message ||= described_class::DEFAULT_MIN_PR_BODY_MESSAGE
+
+              expect_warning_or_error(fail_on_error: fail_on_error, message: message)
+            end
+          end
+
+          context 'when fail on error is false and a custom message is given' do
+            include_examples 'reporting PR length check custom warnings or errors', false, 'this is my custom warning message'
+          end
+
+          context 'when fail on error is false' do
+            include_examples 'reporting PR length check custom warnings or errors', false
+          end
+
+          context 'when fail on error is true' do
+            include_examples 'reporting PR length check custom warnings or errors', true
+          end
+
+          context 'when a custom error message is given and fail on error is true' do
+            include_examples 'reporting PR length check custom warnings or errors', true, 'this is my custom error message'
+          end
+        end
+      end
+
+      def expect_warning_or_error(fail_on_error:, message:)
+        if fail_on_error
           expect(@dangerfile.status_report[:warnings]).to be_empty
-          expect(@dangerfile.status_report[:errors]).to eq [custom_message]
+          expect(@dangerfile.status_report[:errors]).to eq [message]
+        else
+          expect(@dangerfile.status_report[:warnings]).to eq [message]
+          expect(@dangerfile.status_report[:errors]).to be_empty
         end
       end
     end

--- a/spec/pr_size_checker_spec.rb
+++ b/spec/pr_size_checker_spec.rb
@@ -38,7 +38,7 @@ module Danger
             @plugin.check_diff_size(type: type)
 
             expect(@dangerfile.status_report[:errors]).to be_empty
-            expect(@dangerfile.status_report[:warnings]).to eq [described_class::DEFAULT_DIFF_SIZE_MESSAGE]
+            expect(@dangerfile.status_report[:warnings]).to eq [format(described_class::DEFAULT_DIFF_SIZE_MESSAGE_FORMAT, described_class::DEFAULT_MAX_DIFF_SIZE)]
           end
 
           it 'does nothing when using default parameters in a PR that has equal diff than the default maximum' do
@@ -70,7 +70,7 @@ module Danger
                   @plugin.check_diff_size(type: type, max_size: 599, fail_on_error: fail_on_error)
                 end
 
-                message ||= described_class::DEFAULT_DIFF_SIZE_MESSAGE
+                message ||= format(described_class::DEFAULT_DIFF_SIZE_MESSAGE_FORMAT, 599)
 
                 expect_warning_or_error(fail_on_error: fail_on_error, message: message)
               end
@@ -106,7 +106,7 @@ module Danger
               )
 
               expect(@dangerfile.status_report[:errors]).to be_empty
-              expect(@dangerfile.status_report[:warnings]).to eq [described_class::DEFAULT_DIFF_SIZE_MESSAGE]
+              expect(@dangerfile.status_report[:warnings]).to eq [format(described_class::DEFAULT_DIFF_SIZE_MESSAGE_FORMAT, max_sizes[0])]
             end
 
             it 'reports a custom error' do
@@ -191,7 +191,7 @@ module Danger
           @plugin.check_pr_body
 
           expect(@dangerfile.status_report[:errors]).to be_empty
-          expect(@dangerfile.status_report[:warnings]).to eq [described_class::DEFAULT_MIN_PR_BODY_MESSAGE]
+          expect(@dangerfile.status_report[:warnings]).to eq [format(described_class::DEFAULT_MIN_PR_BODY_MESSAGE_FORMAT, described_class::DEFAULT_MIN_PR_BODY)]
         end
 
         it 'does nothing when using default parameters in a PR that has a bigger PR body text length than the default minimum' do
@@ -209,7 +209,7 @@ module Danger
           @plugin.check_pr_body
 
           expect(@dangerfile.status_report[:errors]).to be_empty
-          expect(@dangerfile.status_report[:warnings]).to eq [described_class::DEFAULT_MIN_PR_BODY_MESSAGE]
+          expect(@dangerfile.status_report[:warnings]).to eq [format(described_class::DEFAULT_MIN_PR_BODY_MESSAGE_FORMAT, described_class::DEFAULT_MIN_PR_BODY)]
         end
 
         context 'when reporting a custom error or warning with a custom min_length' do
@@ -223,7 +223,7 @@ module Danger
                 @plugin.check_pr_body(min_length: 25, fail_on_error: fail_on_error)
               end
 
-              message ||= described_class::DEFAULT_MIN_PR_BODY_MESSAGE
+              message ||= format(described_class::DEFAULT_MIN_PR_BODY_MESSAGE_FORMAT, 25)
 
               expect_warning_or_error(fail_on_error: fail_on_error, message: message)
             end


### PR DESCRIPTION
This PR adds a plugin to perform checks on the PR diff size and body length.

It is based on the following Peril rules:
- https://github.com/Automattic/peril-settings/blob/master/org/pr/ios-diff-size.ts
- https://github.com/Automattic/peril-settings/blob/master/org/pr/android-diff-size.ts

The checks were made to cover a more general use case, such as ignoring certain files (for example, so that test files wouldn't count against a maximum size).