### PR TITLE
Plugin for checking the milestone in a pull request

### DIFF
--- a/lib/danger_plugin.rb
+++ b/lib/danger_plugin.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
 require 'dangermattic/plugins/manifest_pr_checker'
+require 'dangermattic/plugins/milestone_checker'
 require 'dangermattic/plugins/pr_size_checker'
 require 'dangermattic/plugins/view_changes_need_screenshots'

--- a/lib/dangermattic/plugins/milestone_checker.rb
+++ b/lib/dangermattic/plugins/milestone_checker.rb
@@ -10,7 +10,7 @@ module Danger
       warn('PR is not assigned to a milestone.', sticky: false) if milestone.nil?
     end
 
-    # Checks if the pull request's milestone is expiring within a certain number of days.
+    # Checks if the pull request's milestone is due to finish within a certain number of days.
     #
     # @param warning_days [Integer] Number of days to warn before the milestone due date (default: DEFAULT_WARNING_DAYS).
     def check_milestone_due_date(warning_days: DEFAULT_WARNING_DAYS)
@@ -26,13 +26,13 @@ module Danger
       time_before_due_date = due_date.to_time.to_i - today.to_time.to_i
       return unless time_before_due_date <= warning_threshold
 
-      message_text = "This PR is assigned to the milestone [#{milestone['title']}](#{milestone['html_url']}) "
+      message_text = "This PR is assigned to the milestone [#{milestone['title']}](#{milestone['html_url']}). "
       message_text += if time_before_due_date.positive?
-                        "which is expiring in less than #{warning_days} days.\n"
+                        "This milestone is due in less than #{warning_days} days.\n"
                       else
-                        "which has already expired.\n"
+                        "The due date for this milestone has already passed.\n"
                       end
-      message_text += 'Please make sure to get it merged by then or assign it to a later expiring milestone.'
+      message_text += 'Please make sure to get it merged by then or assign it to a milestone with a later deadline.'
 
       warn(message_text)
     end

--- a/lib/dangermattic/plugins/milestone_checker.rb
+++ b/lib/dangermattic/plugins/milestone_checker.rb
@@ -10,10 +10,11 @@ module Danger
       return unless milestone.nil?
 
       message = 'PR is not assigned to a milestone.'
+      sticky = false
       if fail_on_error
-        failure(message, sticky: false)
+        failure(message, sticky: sticky)
       else
-        warn(message, sticky: false)
+        warn(message, sticky: sticky)
       end
     end
 

--- a/lib/dangermattic/plugins/milestone_checker.rb
+++ b/lib/dangermattic/plugins/milestone_checker.rb
@@ -5,18 +5,16 @@ module Danger
   class MilestoneChecker < Plugin
     DEFAULT_WARNING_DAYS = 5
 
+    # Checks if the pull request is assigned to a milestone.
+    def check_milestone_set
+      warn('PR is not assigned to a milestone.', sticky: false) if milestone.nil?
+    end
+
     # Checks if the pull request's milestone is expiring within a certain number of days.
     #
-    # @param needs_milestone [Boolean] Whether a milestone is required for the pull request.
-    # If true, will report a warning when there is no milestone assigned to the pull request.
     # @param warning_days [Integer] Number of days to warn before the milestone due date (default: DEFAULT_WARNING_DAYS).
-    def check_milestone_due_date(needs_milestone: true, warning_days: DEFAULT_WARNING_DAYS)
-      milestone = github.pr_json['milestone']
-
-      if milestone.nil?
-        warn('PR is not assigned to a milestone.', sticky: false) if needs_milestone
-        return
-      end
+    def check_milestone_due_date(warning_days: DEFAULT_WARNING_DAYS)
+      return if milestone.nil?
 
       milestone_due_date = milestone['due_on']
       return unless github.pr_json['state'] != 'closed' && milestone_due_date
@@ -37,6 +35,10 @@ module Danger
       message_text += 'Please make sure to get it merged by then or assign it to a later expiring milestone.'
 
       warn(message_text)
+    end
+
+    def milestone
+      github.pr_json['milestone']
     end
   end
 end

--- a/lib/dangermattic/plugins/milestone_checker.rb
+++ b/lib/dangermattic/plugins/milestone_checker.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+module Danger
+  # Plugin for performing checks on a milestone associated with a pull request.
+  class MilestoneChecker < Plugin
+    DEFAULT_WARNING_DAYS = 5
+
+    # Checks if the pull request's milestone is expiring within a certain number of days.
+    #
+    # @param needs_milestone [Boolean] Whether a milestone is required for the pull request.
+    # If true, will report a warning when there is no milestone assigned to the pull request.
+    # @param warning_days [Integer] Number of days to warn before the milestone due date (default: DEFAULT_WARNING_DAYS).
+    def check_milestone_due_date(needs_milestone: true, warning_days: DEFAULT_WARNING_DAYS)
+      milestone = github.pr_json['milestone']
+
+      if milestone.nil?
+        warn('PR is not assigned to a milestone.', sticky: false) if needs_milestone
+        return
+      end
+
+      milestone_due_date = milestone['due_on']
+      return unless github.pr_json['state'] != 'closed' && milestone_due_date
+
+      today = DateTime.now
+      due_date = DateTime.parse(milestone_due_date)
+
+      warning_threshold = warning_days * 24 * 60 * 60
+      time_before_due_date = due_date.to_time.to_i - today.to_time.to_i
+      return unless time_before_due_date <= warning_threshold
+
+      message_text = "This PR is assigned to the milestone [#{milestone['title']}](#{milestone['html_url']}) "
+      message_text += if time_before_due_date.positive?
+                        "which is expiring in less than #{warning_days} days.\n"
+                      else
+                        "which has already expired.\n"
+                      end
+      message_text += 'Please make sure to get it merged by then or assign it to a later expiring milestone.'
+
+      warn(message_text)
+    end
+  end
+end

--- a/lib/dangermattic/plugins/milestone_checker.rb
+++ b/lib/dangermattic/plugins/milestone_checker.rb
@@ -26,7 +26,12 @@ module Danger
     #                 - :none or nil: Takes no action.
     def check_milestone_due_date(warning_days: DEFAULT_WARNING_DAYS, if_no_milestone: :warn)
       if milestone.nil?
-        check_milestone_set(fail_on_error: if_no_milestone == :error)
+        case if_no_milestone
+        when :warn
+          check_milestone_set(fail_on_error: false)
+        when :error
+          check_milestone_set(fail_on_error: true)
+        end
         return
       end
 

--- a/lib/dangermattic/plugins/milestone_checker.rb
+++ b/lib/dangermattic/plugins/milestone_checker.rb
@@ -3,7 +3,7 @@
 module Danger
   # Plugin for performing checks on a milestone associated with a pull request.
   class MilestoneChecker < Plugin
-    DEFAULT_WARNING_DAYS = 5
+    DEFAULT_DAYS_THRESHOLD = 5
 
     # Checks if the pull request is assigned to a milestone.
     def check_milestone_set(fail_on_error: false)
@@ -20,12 +20,12 @@ module Danger
 
     # Checks if the pull request's milestone is due to finish within a certain number of days.
     #
-    # @param warning_days [Integer] Number of days to warn before the milestone due date (default: DEFAULT_WARNING_DAYS).
+    # @param days_before_due [Integer] Number of days before the milestone due date for the check to apply (default: DEFAULT_DAYS_THRESHOLD).
     # @param if_no_milestone [Symbol] Action to take if the pull request is not assigned to a milestone. Possible values:
     #                 - :warn (default): Reports a warning.
     #                 - :error: Reports an error.
     #                 - :none or nil: Takes no action.
-    def check_milestone_due_date(warning_days: DEFAULT_WARNING_DAYS, if_no_milestone: :warn)
+    def check_milestone_due_date(days_before_due: DEFAULT_DAYS_THRESHOLD, if_no_milestone: :warn)
       if milestone.nil?
         case if_no_milestone
         when :warn
@@ -42,13 +42,13 @@ module Danger
       today = DateTime.now
       due_date = DateTime.parse(milestone_due_date)
 
-      warning_threshold = warning_days * 24 * 60 * 60
+      seconds_threshold = days_before_due * 24 * 60 * 60
       time_before_due_date = due_date.to_time.to_i - today.to_time.to_i
-      return unless time_before_due_date <= warning_threshold
+      return unless time_before_due_date <= seconds_threshold
 
       message_text = "This PR is assigned to the milestone [#{milestone['title']}](#{milestone['html_url']}). "
       message_text += if time_before_due_date.positive?
-                        "This milestone is due in less than #{warning_days} days.\n"
+                        "This milestone is due in less than #{days_before_due} days.\n"
                       else
                         "The due date for this milestone has already passed.\n"
                       end

--- a/spec/milestone_checker_spec.rb
+++ b/spec/milestone_checker_spec.rb
@@ -24,10 +24,10 @@ module Danger
           expect(@dangerfile.status_report[:warnings]).to eq expected_warning
         end
 
-        it "does nothing when a PR has a milestone set" do
+        it 'does nothing when a PR has a milestone set' do
           pr_json = {
             'milestone' => {
-              'title' => 'Release Day',
+              'title' => 'Release Day'
             }
           }
 
@@ -57,7 +57,7 @@ module Danger
 
           @plugin.check_milestone_due_date
 
-          expected_warning = ["This PR is assigned to the milestone [Release Day](https://wp.com) which is expiring in less than 5 days.\nPlease make sure to get it merged by then or assign it to a later expiring milestone."]
+          expected_warning = ["This PR is assigned to the milestone [Release Day](https://wp.com). This milestone is due in less than 5 days.\nPlease make sure to get it merged by then or assign it to a milestone with a later deadline."]
           expect(@dangerfile.status_report[:warnings]).to eq expected_warning
         end
 
@@ -98,7 +98,7 @@ module Danger
 
           @plugin.check_milestone_due_date
 
-          expected_warning = ["This PR is assigned to the milestone [Release Day](https://wp.com) which has already expired.\nPlease make sure to get it merged by then or assign it to a later expiring milestone."]
+          expected_warning = ["This PR is assigned to the milestone [Release Day](https://wp.com). The due date for this milestone has already passed.\nPlease make sure to get it merged by then or assign it to a milestone with a later deadline."]
           expect(@dangerfile.status_report[:warnings]).to eq expected_warning
         end
 
@@ -119,7 +119,7 @@ module Danger
 
           @plugin.check_milestone_due_date(warning_days: 10)
 
-          expected_warning = ["This PR is assigned to the milestone [Release Day](https://wp.com) which is expiring in less than 10 days.\nPlease make sure to get it merged by then or assign it to a later expiring milestone."]
+          expected_warning = ["This PR is assigned to the milestone [Release Day](https://wp.com). This milestone is due in less than 10 days.\nPlease make sure to get it merged by then or assign it to a milestone with a later deadline."]
           expect(@dangerfile.status_report[:warnings]).to eq expected_warning
         end
 

--- a/spec/milestone_checker_spec.rb
+++ b/spec/milestone_checker_spec.rb
@@ -156,12 +156,38 @@ module Danger
           expect(@dangerfile.status_report[:warnings]).to be_empty
         end
 
-        it "does nothing when a PR doesn't have a milestone" do
+        it "reports a warning when asked to do so when a PR doesn't have a milestone set" do
           allow(@plugin.github).to receive(:pr_json).and_return({})
 
-          @plugin.check_milestone_due_date
+          @plugin.check_milestone_due_date(if_no_milestone: :warn)
 
-          expect(@dangerfile.status_report[:warnings]).to be_empty
+          expected_warning = ['PR is not assigned to a milestone.']
+          expect(@dangerfile.status_report[:warnings]).to eq expected_warning
+        end
+
+        it "reports an error when asked to do so when a PR doesn't have a milestone set" do
+          allow(@plugin.github).to receive(:pr_json).and_return({})
+
+          @plugin.check_milestone_due_date(if_no_milestone: :error)
+
+          expected_error = ['PR is not assigned to a milestone.']
+          expect(@dangerfile.status_report[:errors]).to eq expected_error
+        end
+
+        it "does nothing when asked to do so when a PR doesn't have a milestone set" do
+          allow(@plugin.github).to receive(:pr_json).and_return({})
+
+          @plugin.check_milestone_due_date(if_no_milestone: :none)
+
+          expect(@dangerfile.status_report[:errors]).to be_empty
+        end
+
+        it "does nothing when nil is used and a PR doesn't have a milestone set" do
+          allow(@plugin.github).to receive(:pr_json).and_return({})
+
+          @plugin.check_milestone_due_date(if_no_milestone: nil)
+
+          expect(@dangerfile.status_report[:errors]).to be_empty
         end
       end
     end

--- a/spec/milestone_checker_spec.rb
+++ b/spec/milestone_checker_spec.rb
@@ -151,7 +151,7 @@ module Danger
           allow(@plugin.github).to receive(:pr_json).and_return(pr_json)
           allow(DateTime).to receive(:now).and_return(date_nine_days_before_due)
 
-          @plugin.check_milestone_due_date(warning_days: 10)
+          @plugin.check_milestone_due_date(days_before_due: 10)
 
           expected_warning = ["This PR is assigned to the milestone [Release Day](https://wp.com). This milestone is due in less than 10 days.\nPlease make sure to get it merged by then or assign it to a milestone with a later deadline."]
           expect(@dangerfile.status_report[:errors]).to be_empty

--- a/spec/milestone_checker_spec.rb
+++ b/spec/milestone_checker_spec.rb
@@ -1,0 +1,151 @@
+# frozen_string_literal: true
+
+require_relative 'spec_helper'
+
+module Danger
+  describe Danger::MilestoneChecker do
+    it 'is a plugin' do
+      expect(described_class.new(nil)).to be_a Danger::Plugin
+    end
+
+    describe 'with Dangerfile' do
+      before do
+        @dangerfile = testing_dangerfile
+        @plugin = @dangerfile.milestone_checker
+      end
+
+      it 'reports a warning when a PR has a milestone with due date within the warning days threshold' do
+        pr_json = {
+          'milestone' => {
+            'title' => 'Release Day',
+            'html_url' => 'https://wp.com',
+            'due_on' => '2023-06-30T23:59:01Z'
+          },
+          'state' => 'open'
+        }
+
+        date_one_day_before_due = DateTime.parse('2023-06-29T23:59:01Z')
+
+        allow(@plugin.github).to receive(:pr_json).and_return(pr_json)
+        allow(DateTime).to receive(:now).and_return(date_one_day_before_due)
+
+        @plugin.check_milestone_due_date
+
+        expected_warning = ["This PR is assigned to the milestone [Release Day](https://wp.com) which is expiring in less than 5 days.\nPlease make sure to get it merged by then or assign it to a later expiring milestone."]
+        expect(@dangerfile.status_report[:warnings]).to eq expected_warning
+      end
+
+      it 'does nothing when a PR has a milestone before the warning days threshold' do
+        pr_json = {
+          'milestone' => {
+            'title' => 'Release Day',
+            'html_url' => 'https://wp.com',
+            'due_on' => '2023-06-30T23:59:01Z'
+          },
+          'state' => 'open'
+        }
+
+        more_than_five_days_before_due = DateTime.parse('2023-06-25T23:00:01Z')
+
+        allow(@plugin.github).to receive(:pr_json).and_return(pr_json)
+        allow(DateTime).to receive(:now).and_return(more_than_five_days_before_due)
+
+        @plugin.check_milestone_due_date
+
+        expect(@dangerfile.status_report[:warnings]).to be_empty
+      end
+
+      it 'reports a warning when a PR has a milestone with due date after the warning days threshold' do
+        pr_json = {
+          'milestone' => {
+            'title' => 'Release Day',
+            'html_url' => 'https://wp.com',
+            'due_on' => '2023-06-30T23:59:01Z'
+          },
+          'state' => 'open'
+        }
+
+        date_one_day_after_due = DateTime.parse('2023-07-01T23:00:01Z')
+
+        allow(@plugin.github).to receive(:pr_json).and_return(pr_json)
+        allow(DateTime).to receive(:now).and_return(date_one_day_after_due)
+
+        @plugin.check_milestone_due_date
+
+        expected_warning = ["This PR is assigned to the milestone [Release Day](https://wp.com) which has already expired.\nPlease make sure to get it merged by then or assign it to a later expiring milestone."]
+        expect(@dangerfile.status_report[:warnings]).to eq expected_warning
+      end
+
+      it 'reports a warning when a PR has a milestone with due date within a custom warning days threshold' do
+        pr_json = {
+          'milestone' => {
+            'title' => 'Release Day',
+            'html_url' => 'https://wp.com',
+            'due_on' => '2023-06-30T23:59:01Z'
+          },
+          'state' => 'open'
+        }
+
+        date_nine_days_before_due = DateTime.parse('2023-06-21T23:59:01Z')
+
+        allow(@plugin.github).to receive(:pr_json).and_return(pr_json)
+        allow(DateTime).to receive(:now).and_return(date_nine_days_before_due)
+
+        @plugin.check_milestone_due_date(warning_days: 10)
+
+        expected_warning = ["This PR is assigned to the milestone [Release Day](https://wp.com) which is expiring in less than 10 days.\nPlease make sure to get it merged by then or assign it to a later expiring milestone."]
+        expect(@dangerfile.status_report[:warnings]).to eq expected_warning
+      end
+
+      it 'does nothing when a PR has a milestone without a due date' do
+        pr_json = {
+          'milestone' => {
+            'title' => 'Release Day',
+            'html_url' => 'https://wp.com'
+          },
+          'state' => 'open'
+        }
+
+        allow(@plugin.github).to receive(:pr_json).and_return(pr_json)
+
+        @plugin.check_milestone_due_date
+
+        expect(@dangerfile.status_report[:warnings]).to be_empty
+      end
+
+      it 'does nothing when a PR has a milestone but already closed' do
+        pr_json = {
+          'milestone' => {
+            'title' => 'Release Day',
+            'html_url' => 'https://wp.com',
+            'due_on' => '2023-06-30T23:59:01Z'
+          },
+          'state' => 'closed'
+        }
+
+        allow(@plugin.github).to receive(:pr_json).and_return(pr_json)
+
+        @plugin.check_milestone_due_date
+
+        expect(@dangerfile.status_report[:warnings]).to be_empty
+      end
+
+      it 'warns when a PR without a milestone' do
+        allow(@plugin.github).to receive(:pr_json).and_return({})
+
+        @plugin.check_milestone_due_date
+
+        expected_warning = ['PR is not assigned to a milestone.']
+        expect(@dangerfile.status_report[:warnings]).to eq expected_warning
+      end
+
+      it 'does nothing when a PR does not have a milestone but this isnt required' do
+        allow(@plugin.github).to receive(:pr_json).and_return({})
+
+        @plugin.check_milestone_due_date(needs_milestone: false)
+
+        expect(@dangerfile.status_report[:warnings]).to be_empty
+      end
+    end
+  end
+end


### PR DESCRIPTION
This PR adds a plugin to check the milestone assigned to a Pull Request: whether there is one assigned and whether the chosen milestone's due date is getting close.

It is based on the following Peril rules (which are essentially the same):
- https://github.com/Automattic/peril-settings/blob/master/org/pr/milestone.ts
- https://github.com/Automattic/peril-settings/blob/master/org/pr/milestone-woo.ts

This plugin provides the same functionality as the Peril rules above, but with parameters for:
- Requiring a milestone to be always set in the PR
- Customising the number of days before the milestone's due date when a warning is issued