### PR TITLE
Add custom RSpec Matchers for checking Danger errors and warnings

### DIFF
--- a/spec/milestone_checker_spec.rb
+++ b/spec/milestone_checker_spec.rb
@@ -22,7 +22,7 @@ module Danger
             @plugin.check_milestone_set
 
             expected_warning = ['PR is not assigned to a milestone.']
-            expect(@dangerfile).to contain_warnings(expected_warning)
+            expect(@dangerfile).to report_warnings(expected_warning)
           end
 
           it "reports an error when a PR doesn't have a milestone set" do
@@ -31,7 +31,7 @@ module Danger
             @plugin.check_milestone_set(fail_on_error: true)
 
             expected_error = ['PR is not assigned to a milestone.']
-            expect(@dangerfile).to contain_errors(expected_error)
+            expect(@dangerfile).to report_errors(expected_error)
           end
         end
 
@@ -47,7 +47,7 @@ module Danger
 
             @plugin.check_milestone_set
 
-            expect(@dangerfile).to contain_empty_report
+            expect(@dangerfile).to do_not_report
           end
 
           it 'does nothing when an error is expected but the PR has a milestone set' do
@@ -61,7 +61,7 @@ module Danger
 
             @plugin.check_milestone_set(fail_on_error: true)
 
-            expect(@dangerfile).to contain_empty_report
+            expect(@dangerfile).to do_not_report
           end
         end
       end
@@ -85,7 +85,7 @@ module Danger
           @plugin.check_milestone_due_date
 
           expected_warning = ["This PR is assigned to the milestone [Release Day](https://wp.com). This milestone is due in less than 5 days.\nPlease make sure to get it merged by then or assign it to a milestone with a later deadline."]
-          expect(@dangerfile).to contain_warnings(expected_warning)
+          expect(@dangerfile).to report_warnings(expected_warning)
         end
 
         it 'does nothing when a PR has a milestone before the warning days threshold' do
@@ -105,7 +105,7 @@ module Danger
 
           @plugin.check_milestone_due_date
 
-          expect(@dangerfile).to contain_empty_report
+          expect(@dangerfile).to do_not_report
         end
 
         it 'reports a warning when a PR has a milestone with due date after the warning days threshold' do
@@ -126,7 +126,7 @@ module Danger
           @plugin.check_milestone_due_date
 
           expected_warning = ["This PR is assigned to the milestone [Release Day](https://wp.com). The due date for this milestone has already passed.\nPlease make sure to get it merged by then or assign it to a milestone with a later deadline."]
-          expect(@dangerfile).to contain_warnings(expected_warning)
+          expect(@dangerfile).to report_warnings(expected_warning)
         end
 
         it 'reports a warning when a PR has a milestone with due date within a custom warning days threshold' do
@@ -147,7 +147,7 @@ module Danger
           @plugin.check_milestone_due_date(days_before_due: 10)
 
           expected_warning = ["This PR is assigned to the milestone [Release Day](https://wp.com). This milestone is due in less than 10 days.\nPlease make sure to get it merged by then or assign it to a milestone with a later deadline."]
-          expect(@dangerfile).to contain_warnings(expected_warning)
+          expect(@dangerfile).to report_warnings(expected_warning)
         end
 
         it 'does nothing when a PR has a milestone without a due date' do
@@ -163,7 +163,7 @@ module Danger
 
           @plugin.check_milestone_due_date
 
-          expect(@dangerfile).to contain_empty_report
+          expect(@dangerfile).to do_not_report
         end
 
         it 'does nothing when a PR has a milestone but it has already passed the due date' do
@@ -180,7 +180,7 @@ module Danger
 
           @plugin.check_milestone_due_date
 
-          expect(@dangerfile).to contain_empty_report
+          expect(@dangerfile).to do_not_report
         end
 
         it "reports a warning when asked to do so when a PR doesn't have a milestone set" do
@@ -189,7 +189,7 @@ module Danger
           @plugin.check_milestone_due_date(if_no_milestone: :warn)
 
           expected_warning = ['PR is not assigned to a milestone.']
-          expect(@dangerfile).to contain_warnings(expected_warning)
+          expect(@dangerfile).to report_warnings(expected_warning)
         end
 
         it "reports an error when asked to do so when a PR doesn't have a milestone set" do
@@ -198,7 +198,7 @@ module Danger
           @plugin.check_milestone_due_date(if_no_milestone: :error)
 
           expected_error = ['PR is not assigned to a milestone.']
-          expect(@dangerfile).to contain_errors(expected_error)
+          expect(@dangerfile).to report_errors(expected_error)
         end
 
         it "does nothing when asked to do so when a PR doesn't have a milestone set" do
@@ -206,7 +206,7 @@ module Danger
 
           @plugin.check_milestone_due_date(if_no_milestone: :none)
 
-          expect(@dangerfile).to contain_empty_report
+          expect(@dangerfile).to do_not_report
         end
 
         it "does nothing when nil is used and a PR doesn't have a milestone set" do
@@ -214,7 +214,7 @@ module Danger
 
           @plugin.check_milestone_due_date(if_no_milestone: nil)
 
-          expect(@dangerfile).to contain_empty_report
+          expect(@dangerfile).to do_not_report
         end
       end
     end

--- a/spec/milestone_checker_spec.rb
+++ b/spec/milestone_checker_spec.rb
@@ -22,8 +22,7 @@ module Danger
             @plugin.check_milestone_set
 
             expected_warning = ['PR is not assigned to a milestone.']
-            expect(@dangerfile.status_report[:errors]).to be_empty
-            expect(@dangerfile.status_report[:warnings]).to eq expected_warning
+            expect(@dangerfile).to contain_warnings(expected_warning)
           end
 
           it "reports an error when a PR doesn't have a milestone set" do
@@ -32,8 +31,7 @@ module Danger
             @plugin.check_milestone_set(fail_on_error: true)
 
             expected_error = ['PR is not assigned to a milestone.']
-            expect(@dangerfile.status_report[:warnings]).to be_empty
-            expect(@dangerfile.status_report[:errors]).to eq expected_error
+            expect(@dangerfile).to contain_errors(expected_error)
           end
         end
 
@@ -49,8 +47,7 @@ module Danger
 
             @plugin.check_milestone_set
 
-            expect(@dangerfile.status_report[:warnings]).to be_empty
-            expect(@dangerfile.status_report[:errors]).to be_empty
+            expect(@dangerfile).to contain_empty_report
           end
 
           it 'does nothing when an error is expected but the PR has a milestone set' do
@@ -64,8 +61,7 @@ module Danger
 
             @plugin.check_milestone_set(fail_on_error: true)
 
-            expect(@dangerfile.status_report[:warnings]).to be_empty
-            expect(@dangerfile.status_report[:errors]).to be_empty
+            expect(@dangerfile).to contain_empty_report
           end
         end
       end
@@ -89,8 +85,7 @@ module Danger
           @plugin.check_milestone_due_date
 
           expected_warning = ["This PR is assigned to the milestone [Release Day](https://wp.com). This milestone is due in less than 5 days.\nPlease make sure to get it merged by then or assign it to a milestone with a later deadline."]
-          expect(@dangerfile.status_report[:errors]).to be_empty
-          expect(@dangerfile.status_report[:warnings]).to eq expected_warning
+          expect(@dangerfile).to contain_warnings(expected_warning)
         end
 
         it 'does nothing when a PR has a milestone before the warning days threshold' do
@@ -110,8 +105,7 @@ module Danger
 
           @plugin.check_milestone_due_date
 
-          expect(@dangerfile.status_report[:errors]).to be_empty
-          expect(@dangerfile.status_report[:warnings]).to be_empty
+          expect(@dangerfile).to contain_empty_report
         end
 
         it 'reports a warning when a PR has a milestone with due date after the warning days threshold' do
@@ -132,8 +126,7 @@ module Danger
           @plugin.check_milestone_due_date
 
           expected_warning = ["This PR is assigned to the milestone [Release Day](https://wp.com). The due date for this milestone has already passed.\nPlease make sure to get it merged by then or assign it to a milestone with a later deadline."]
-          expect(@dangerfile.status_report[:errors]).to be_empty
-          expect(@dangerfile.status_report[:warnings]).to eq expected_warning
+          expect(@dangerfile).to contain_warnings(expected_warning)
         end
 
         it 'reports a warning when a PR has a milestone with due date within a custom warning days threshold' do
@@ -154,8 +147,7 @@ module Danger
           @plugin.check_milestone_due_date(days_before_due: 10)
 
           expected_warning = ["This PR is assigned to the milestone [Release Day](https://wp.com). This milestone is due in less than 10 days.\nPlease make sure to get it merged by then or assign it to a milestone with a later deadline."]
-          expect(@dangerfile.status_report[:errors]).to be_empty
-          expect(@dangerfile.status_report[:warnings]).to eq expected_warning
+          expect(@dangerfile).to contain_warnings(expected_warning)
         end
 
         it 'does nothing when a PR has a milestone without a due date' do
@@ -171,8 +163,7 @@ module Danger
 
           @plugin.check_milestone_due_date
 
-          expect(@dangerfile.status_report[:errors]).to be_empty
-          expect(@dangerfile.status_report[:warnings]).to be_empty
+          expect(@dangerfile).to contain_empty_report
         end
 
         it 'does nothing when a PR has a milestone but it has already passed the due date' do
@@ -189,8 +180,7 @@ module Danger
 
           @plugin.check_milestone_due_date
 
-          expect(@dangerfile.status_report[:errors]).to be_empty
-          expect(@dangerfile.status_report[:warnings]).to be_empty
+          expect(@dangerfile).to contain_empty_report
         end
 
         it "reports a warning when asked to do so when a PR doesn't have a milestone set" do
@@ -199,8 +189,7 @@ module Danger
           @plugin.check_milestone_due_date(if_no_milestone: :warn)
 
           expected_warning = ['PR is not assigned to a milestone.']
-          expect(@dangerfile.status_report[:errors]).to be_empty
-          expect(@dangerfile.status_report[:warnings]).to eq expected_warning
+          expect(@dangerfile).to contain_warnings(expected_warning)
         end
 
         it "reports an error when asked to do so when a PR doesn't have a milestone set" do
@@ -209,8 +198,7 @@ module Danger
           @plugin.check_milestone_due_date(if_no_milestone: :error)
 
           expected_error = ['PR is not assigned to a milestone.']
-          expect(@dangerfile.status_report[:warnings]).to be_empty
-          expect(@dangerfile.status_report[:errors]).to eq expected_error
+          expect(@dangerfile).to contain_errors(expected_error)
         end
 
         it "does nothing when asked to do so when a PR doesn't have a milestone set" do
@@ -218,8 +206,7 @@ module Danger
 
           @plugin.check_milestone_due_date(if_no_milestone: :none)
 
-          expect(@dangerfile.status_report[:warnings]).to be_empty
-          expect(@dangerfile.status_report[:errors]).to be_empty
+          expect(@dangerfile).to contain_empty_report
         end
 
         it "does nothing when nil is used and a PR doesn't have a milestone set" do
@@ -227,8 +214,7 @@ module Danger
 
           @plugin.check_milestone_due_date(if_no_milestone: nil)
 
-          expect(@dangerfile.status_report[:warnings]).to be_empty
-          expect(@dangerfile.status_report[:errors]).to be_empty
+          expect(@dangerfile).to contain_empty_report
         end
       end
     end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -62,7 +62,7 @@ end
 
 # custom matchers
 
-RSpec::Matchers.define :contain_warnings do |expected_warnings|
+RSpec::Matchers.define :report_warnings do |expected_warnings|
   match do |dangerfile|
     dangerfile.status_report[:warnings].eql?(expected_warnings) &&
       dangerfile.status_report[:errors]&.empty?
@@ -73,7 +73,7 @@ RSpec::Matchers.define :contain_warnings do |expected_warnings|
   end
 end
 
-RSpec::Matchers.define :contain_errors do |expected_errors|
+RSpec::Matchers.define :report_errors do |expected_errors|
   match do |dangerfile|
     dangerfile.status_report[:errors].eql?(expected_errors) &&
       dangerfile.status_report[:warnings]&.empty?
@@ -84,7 +84,7 @@ RSpec::Matchers.define :contain_errors do |expected_errors|
   end
 end
 
-RSpec::Matchers.define :contain_empty_report do
+RSpec::Matchers.define :do_not_report do
   match do |dangerfile|
     dangerfile.status_report[:errors]&.empty? &&
       dangerfile.status_report[:warnings]&.empty?

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -59,3 +59,38 @@ def testing_dangerfile
   env = Danger::EnvironmentManager.new(testing_env)
   Danger::Dangerfile.new(env, testing_ui)
 end
+
+# custom matchers
+
+RSpec::Matchers.define :contain_warnings do |expected_warnings|
+  match do |dangerfile|
+    dangerfile.status_report[:warnings].eql?(expected_warnings) &&
+      dangerfile.status_report[:errors]&.empty?
+  end
+
+  failure_message do |dangerfile|
+    "expected warnings '#{expected_warnings}' to be reported, got instead:\n- Warnings: #{dangerfile.status_report[:warnings]}\n- Errors: #{dangerfile.status_report[:errors]}"
+  end
+end
+
+RSpec::Matchers.define :contain_errors do |expected_errors|
+  match do |dangerfile|
+    dangerfile.status_report[:errors].eql?(expected_errors) &&
+      dangerfile.status_report[:warnings]&.empty?
+  end
+
+  failure_message do |dangerfile|
+    "expected errors '#{expected_errors}' to be reported, got instead:\n- Errors: #{dangerfile.status_report[:errors]}\n- Warnings: #{dangerfile.status_report[:warnings]}"
+  end
+end
+
+RSpec::Matchers.define :contain_empty_report do
+  match do |dangerfile|
+    dangerfile.status_report[:errors]&.empty? &&
+      dangerfile.status_report[:warnings]&.empty?
+  end
+
+  failure_message do |dangerfile|
+    "expected no warnings or errors to be reported, got instead:\n#{dangerfile.status_report}"
+  end
+end


### PR DESCRIPTION
Based on my recent discussions with @mokagio on #13, this PR builds on top of #13 and adds custom matchers to be used with expectations, so that instead of:

```ruby
# expect empty warning/error reports
expect(@dangerfile.status_report[:warnings]).to be_empty
expect(@dangerfile.status_report[:errors]).to be_empty

# expect no warnings reported and the specified errors
expected_errors = ...
expect(@dangerfile.status_report[:warnings]).to be_empty
expect(@dangerfile.status_report[:errors]).to eq expected_errors

# expect no errors reported and the specified warnings
expected_warnings = ...
expect(@dangerfile.status_report[:errors]).to be_empty
expect(@dangerfile.status_report[:warnings]).to eq expected_warnings
```

We can do:
```ruby
# expect empty warning/error reports
expect(@dangerfile).to contain_empty_report

# expect no warnings reported and the specified errors
expected_errors = ...
expect(@dangerfile).to contain_errors(expected_errors)

# expect no errors reported and the specified warnings
expected_warnings = ...
expect(@dangerfile).to contain_warnings(expected_warnings)
```