### PR TITLE
Adding Danger Lint

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -36,3 +36,16 @@ steps:
       echo "--- :rubocop: Run Rubocop"
       bundle exec rubocop
     plugins: *common_plugins
+
+  #################
+  # Danger Lint
+  #################
+  - label: "☢️ Lint (Danger)"
+    key: dangerlint
+    command: |
+      echo "--- :rubygems: Setting up Gems"
+      bundle install
+
+      echo "--- ☢️ Run Danger Lint"
+      bundle exec danger plugins lint
+    plugins: *common_plugins

--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,8 @@ coverage/
 
 # YARD Documentation
 yard-doc/
+.yardoc/
+
 
 # L10n Linter
 vendor/swiftgen

--- a/lib/dangermattic/plugins/manifest_pr_checker.rb
+++ b/lib/dangermattic/plugins/manifest_pr_checker.rb
@@ -5,6 +5,8 @@ module Danger
   class ManifestPRChecker < Plugin
     # Performs all the checks, asserting that changes on `Gemfile`, `Podfile` and `Package.swift` must have corresponding
     # lock file changes.
+    #
+    # @return [void]
     def check_all_manifest_lock_updated
       check_gemfile_lock_updated
       check_podfile_lock_updated
@@ -12,6 +14,8 @@ module Danger
     end
 
     # Check if the `Gemfile` file was modified without a corresponding `Gemfile.lock` update
+    #
+    # @return [void]
     def check_gemfile_lock_updated
       check_manifest_lock_updated(
         file_name: 'Gemfile',
@@ -21,6 +25,8 @@ module Danger
     end
 
     # Check if the `Podfile` file was modified without a corresponding `Podfile.lock` update
+    #
+    # @return [void]
     def check_podfile_lock_updated
       check_manifest_lock_updated(
         file_name: 'Podfile',
@@ -30,6 +36,8 @@ module Danger
     end
 
     # Check if the `Package.swift` file was modified without a corresponding `Package.resolved` update
+    #
+    # @return [void]
     def check_swift_package_resolved_updated
       check_manifest_lock_updated(
         file_name: 'Package.swift',

--- a/lib/dangermattic/plugins/manifest_pr_checker.rb
+++ b/lib/dangermattic/plugins/manifest_pr_checker.rb
@@ -1,7 +1,32 @@
 # frozen_string_literal: true
 
 module Danger
-  # Plugin to check if the Gemfile.lock was updated when changing the Gemfile in a PR.
+  # Plugin to check if the a lock file (Gemfile.lock, Podfile.lock, Package.resolved) was updated when changing a manifest
+  # file (Gemfile, Podfile, Package.swift) in a PR.
+  #
+  # @example Running manifest / lock checks
+  #
+  #          # Check all manifest files (Gemfile, Podfile, Package.swift) have a corresponding lock change
+  #          checker.check_all_manifest_lock_updated
+  #
+  # @example Gemfile check
+  #
+  #          # Check if the Gemfile and the Gemfile.lock are both updated
+  #          checker.check_gemfile_lock_updated
+  #
+  # @example Podfile check
+  #
+  #          # Check if the Podfile and the Podfile.lock are both updated
+  #          checker.check_podfile_lock_updated
+  #
+  # @example Package.swift check
+  #
+  #          # Check if the Package.swift and the Package.resolved are both updated
+  #          checker.check_swift_package_resolved_updated
+  #
+  # @see Automattic/dangermattic
+  # @tags ios, android
+  #
   class ManifestPRChecker < Plugin
     # Performs all the checks, asserting that changes on `Gemfile`, `Podfile` and `Package.swift` must have corresponding
     # lock file changes.

--- a/lib/dangermattic/plugins/milestone_checker.rb
+++ b/lib/dangermattic/plugins/milestone_checker.rb
@@ -36,8 +36,7 @@ module Danger
         return
       end
 
-      milestone_due_date = milestone['due_on']
-      return unless github.pr_json['state'] != 'closed' && milestone_due_date
+      return unless pr_state != 'closed' && milestone_due_date
 
       today = DateTime.now
       due_date = DateTime.parse(milestone_due_date)
@@ -46,7 +45,7 @@ module Danger
       time_before_due_date = due_date.to_time.to_i - today.to_time.to_i
       return unless time_before_due_date <= seconds_threshold
 
-      message_text = "This PR is assigned to the milestone [#{milestone['title']}](#{milestone['html_url']}). "
+      message_text = "This PR is assigned to the milestone [#{milestone_title}](#{milestone_url}). "
       message_text += if time_before_due_date.positive?
                         "This milestone is due in less than #{days_before_due} days.\n"
                       else
@@ -57,8 +56,26 @@ module Danger
       warn(message_text)
     end
 
+    private
+
     def milestone
       github.pr_json['milestone']
+    end
+
+    def milestone_due_date
+      milestone['due_on']
+    end
+
+    def milestone_title
+      milestone['title']
+    end
+
+    def milestone_url
+      milestone['html_url']
+    end
+
+    def pr_state
+      github.pr_json['state']
     end
   end
 end

--- a/lib/dangermattic/plugins/milestone_checker.rb
+++ b/lib/dangermattic/plugins/milestone_checker.rb
@@ -1,7 +1,34 @@
 # frozen_string_literal: true
 
 module Danger
-  # Plugin for performing checks on a milestone associated with a pull request.
+  # This plugin checks whether a pull request is assigned to a milestone and whether the milestone's due date is approaching.
+  #
+  # @example Check if a milestone is set
+  #
+  #          # Check if PR is assigned to a milestone
+  #          checker.check_milestone_set
+  #
+  #          # Check if PR is assigned to a milestone, reporting an error if that's not the case
+  #          checker.check_milestone_set(fail_on_error: true)
+  #
+  # @example Run a milestone check
+  #
+  #          # Check if milestone due date is approaching, reporting a warning if the milestone is in less than 5 days
+  #          checker.check_milestone_due_date
+  #
+  # @example Run a milestone check with custom parameters
+  #
+  #          # Check if milestone due date is within 3 days, reporting an error in case there's no milestone set
+  #          checker.check_milestone_due_date(days_before_due: 3, if_no_milestone: :error)
+  #
+  # @example Run a milestone check with a custom milestone behaviour parameter
+  #
+  #          # Check if milestone due date is approaching and don't report anything if no milestone is assigned
+  #          checker.check_milestone_due_date(if_no_milestone: :none)
+  #
+  # @see Automattic/dangermattic
+  # @tags milestone, github, process
+  #
   class MilestoneChecker < Plugin
     DEFAULT_DAYS_THRESHOLD = 5
 
@@ -24,9 +51,9 @@ module Danger
     #
     # @param days_before_due [Integer] Number of days before the milestone due date for the check to apply (default: DEFAULT_DAYS_THRESHOLD).
     # @param if_no_milestone [Symbol] Action to take if the pull request is not assigned to a milestone. Possible values:
-    #                 - :warn (default): Reports a warning.
-    #                 - :error: Reports an error.
-    #                 - :none or nil: Takes no action.
+    #                        - :warn (default): Reports a warning.
+    #                        - :error: Reports an error.
+    #                        - :none or nil: Takes no action.
     #
     # @return [void]
     def check_milestone_due_date(days_before_due: DEFAULT_DAYS_THRESHOLD, if_no_milestone: :warn)

--- a/lib/dangermattic/plugins/milestone_checker.rb
+++ b/lib/dangermattic/plugins/milestone_checker.rb
@@ -6,6 +6,8 @@ module Danger
     DEFAULT_DAYS_THRESHOLD = 5
 
     # Checks if the pull request is assigned to a milestone.
+    #
+    # @return [void]
     def check_milestone_set(fail_on_error: false)
       return unless milestone.nil?
 
@@ -25,6 +27,8 @@ module Danger
     #                 - :warn (default): Reports a warning.
     #                 - :error: Reports an error.
     #                 - :none or nil: Takes no action.
+    #
+    # @return [void]
     def check_milestone_due_date(days_before_due: DEFAULT_DAYS_THRESHOLD, if_no_milestone: :warn)
       if milestone.nil?
         case if_no_milestone

--- a/lib/dangermattic/plugins/pr_size_checker.rb
+++ b/lib/dangermattic/plugins/pr_size_checker.rb
@@ -2,6 +2,35 @@
 
 module Danger
   # Plugin to check the size of a Pull Request content and text body.
+  #
+  # @example Running a PR diff size check with default parameters
+  #
+  #          # Check the total size of changes in the PR using the default parameters, reporting a warning if the PR is larger than 500
+  #          pr_size_checker.check_diff_size
+  #
+  # @example Running a PR diff size check customizing the size, message and type of report
+  #
+  #          # Check the total size of changes in the PR, reporting an error if the diff is larger than 1000 using the specified message
+  #          pr_size_checker.check_diff_size(max_size: 1000, message: 'PR too large, 1000 is the max!!', fail_on_error: true)
+  #
+  # @example Running a PR diff size check on the specified files in part of the diff
+  #
+  #          # Check the size of insertions in the files selected by the file_selector
+  #          pr_size_checker.check_diff_size(file_selector: ->(file) { file.include?('/java/test/') }, type: :insertions)
+  #
+  # @example Running a PR description length check
+  #
+  #          # Check the PR Body using the default parameters, reporting a warning if the PR is smaller than 10 characters
+  #          pr_size_checker.check_pr_body
+  #
+  # @example Running a PR description length check with custom parameters
+  #
+  #          # Check if the minimum length of the PR body is smaller than 20 characters, reporting an error using a custom error message
+  #          pr_size_checker.check_pr_body(min_length: 20, message: 'Add a better description, 20 chars at least!!', fail_on_error: true)
+  #
+  # @see Automattic/dangermattic
+  # @tags github, pull request, process
+  #
   class PRSizeChecker < Plugin
     DEFAULT_MAX_DIFF_SIZE = 500
     DEFAULT_DIFF_SIZE_MESSAGE_FORMAT = 'This PR is larger than %d lines of changes. Please consider splitting it into smaller PRs for easier and faster reviews.'

--- a/lib/dangermattic/plugins/pr_size_checker.rb
+++ b/lib/dangermattic/plugins/pr_size_checker.rb
@@ -15,6 +15,8 @@ module Danger
     # @param max_size [Integer] The maximum allowed size for the diff. (default: DEFAULT_MAX_DIFF_SIZE)
     # @param message [String] The message to display if the diff size exceeds the maximum. (default: DEFAULT_DIFF_SIZE_MESSAGE)
     # @param fail_on_error [Boolean] If true, fail the PR check when the diff size exceeds the maximum (default: false).
+    #
+    # @return [void]
     def check_diff_size(file_selector: nil, type: :all, max_size: DEFAULT_MAX_DIFF_SIZE, message: format(DEFAULT_DIFF_SIZE_MESSAGE_FORMAT, max_size), fail_on_error: false)
       case type
       when :insertions
@@ -35,7 +37,10 @@ module Danger
     # Check the size of the Pull Request description (PR body) against a specified minimum size.
     #
     # @param min_length [Integer] The minimum allowed length for the PR body. (default: DEFAULT_MIN_PR_BODY)
+    # @param message [String] The message to display if the length of the PR body is smaller than the minimum. (default: DEFAULT_MIN_PR_BODY_MESSAGE_FORMAT)
     # @param fail_on_error [Boolean] If true, fail the PR check when the PR body length is too small. (default: false)
+    #
+    # @return [void]
     def check_pr_body(min_length: DEFAULT_MIN_PR_BODY, message: format(DEFAULT_MIN_PR_BODY_MESSAGE_FORMAT, min_length), fail_on_error: false)
       return if danger.github.pr_body.length > min_length
 
@@ -45,8 +50,9 @@ module Danger
     # Calculate the total size of insertions in modified files that match the file selector.
     #
     # @param file_selector [Proc] Select the files to be used for the insertions calculation.
+    #
     # @return [Integer] The total size of insertions in the selected modified files.
-    def insertions_size(file_selector:)
+    def insertions_size(file_selector: nil)
       return danger.git.insertions unless file_selector
 
       filtered_files = all_modified_files.select(&file_selector)
@@ -56,8 +62,9 @@ module Danger
     # Calculate the total size of deletions in modified files that match the file selector.
     #
     # @param file_selector [Proc] Select the files to be used for the deletions calculation.
+    #
     # @return [Integer] The total size of deletions in the selected modified files.
-    def deletions_size(file_selector:)
+    def deletions_size(file_selector: nil)
       return danger.git.deletions unless file_selector
 
       filtered_files = all_modified_files.select(&file_selector)
@@ -67,8 +74,9 @@ module Danger
     # Calculate the total size of changes (insertions and deletions) in modified files that match the file selector.
     #
     # @param file_selector [Proc] Select the files to be used for the total insertions and deletions calculation.
+    #
     # @return [Integer] The total size of changes in the selected modified files.
-    def diff_size(file_selector:)
+    def diff_size(file_selector: nil)
       return danger.git.lines_of_code unless file_selector
 
       filtered_files = all_modified_files.select(&file_selector)

--- a/lib/dangermattic/plugins/view_changes_need_screenshots.rb
+++ b/lib/dangermattic/plugins/view_changes_need_screenshots.rb
@@ -2,6 +2,17 @@
 
 module Danger
   # Plugin to detect View files in a PR but without having accompanying screenshots.
+  #
+  # This plugin provides a method to check if view files have been modified without accompanying screenshots in the pull request body.
+  #
+  # @example Check if a PR needs screenshots changes check
+  #
+  #          # If a PR has view changes, report a warning if there are no screenshots attached
+  #          checker.view_changes_need_screenshots
+  #
+  # @see Automattic/dangermattic
+  # @tags ios, android, swift, java, kotlin, screenshots
+  #
   class ViewChangesNeedScreenshots < Plugin
     VIEW_EXTENSIONS_IOS = /(View|Button)\.(swift|m)$|\.xib$|\.storyboard$/
     VIEW_EXTENSIONS_ANDROID = /(?i)(View|Button)\.(java|kt|xml)$/

--- a/lib/dangermattic/plugins/view_changes_need_screenshots.rb
+++ b/lib/dangermattic/plugins/view_changes_need_screenshots.rb
@@ -8,6 +8,8 @@ module Danger
 
     # Checks if view files have been modified and if a screenshot is included in the pull request body,
     # displaying a warning if view files have been modified but no screenshot is included.
+    #
+    # @return [void]
     def view_changes_need_screenshots
       view_files_modified = git.modified_files.any? do |file|
         VIEW_EXTENSIONS_IOS =~ file || VIEW_EXTENSIONS_ANDROID =~ file


### PR DESCRIPTION
This PR adds a step in the project's Buildkite pipeline for performing Danger Lint checks, and also fixing all issues found.

These Danger Lint fixes are important also for standardising the documentation of the plugins, mainly by adding `@example`s detailing how to use each one.