### PR TITLE
README.md update and prepare for documentation generation

### DIFF
--- a/.yardopts
+++ b/.yardopts
@@ -1,0 +1,7 @@
+--no-save
+--protected
+--no-private
+--markup markdown
+--output-dir yard-doc
+-
+CHANGELOG.md

--- a/README.md
+++ b/README.md
@@ -1,22 +1,42 @@
-# dangermattic
-Shared collection of Danger plugins
+# Dangermattic
+`Dangermattic` builds on [Danger on Ruby](https://danger.systems/ruby/) and is essentially a collection of Danger plugins. Its goal is to provide customisable checks and common utilities to help perform checks on Pull Requests, from simple routine validations to more sophisticated ones.
 
 ## Installation
 
-Add to your `Gemfile`
+Add to your project's `Gemfile`
 ```
-gem 'dangermattic'
+gem 'danger-dangermattic', git: 'https://github.com/Automattic/dangermattic'
 ```
 
-## Usage
+## Available plugins and their usage
 
-    Methods and attributes from this plugin are available in
-    your `Dangerfile` under the `dangermattic` namespace.
+Once the main Gem is installed, all Dangermattic plugins are available in your `Dangerfile` under their corresponding namespace:
+
+- `manifest_pr_checker` - Plugin to check if changes on a manifest file (i.e. `Gemfile`, `Podfile`) has a corresponding change in a lock file (i.e. `Gemfile.lock`, `Podfile.lock`)
+```ruby
+# Reports a warning if the Gemfile was changed but the Gemfile.lock wasn't
+manifest_pr_checker.check_gemfile_lock_updated
+```
+- `milestone_checker` - Plugin for performing checks on a milestone associated with a pull request
+```ruby
+# Reports a warning if the Gemfile was changed but the Gemfile.lock wasn't
+milestone_checker.check_milestone_due_date(days_before_due: 3)
+```
+- `pr_size_checker` - Plugin to check the size of a Pull Request content and text body
+```ruby
+# Reports a warning if a pull request diff size is greater than 300
+pr_size_checker.check_diff_size(max_size: 300)
+```
+- `view_changes_need_screenshots` - Detects view changes in a PR and reports a warning if there are no attached screenshots
+```ruby
+# Reports a warning if a pull request changing views doesn't have a screenshot
+view_changes_need_screenshots.view_changes_need_screenshots
+```
 
 ## Development
 
-1. Clone this repo
-2. Run `bundle install` to setup dependencies.
-3. Run `bundle exec rake spec` to run the tests.
-4. Use `bundle exec guard` to automatically have tests run as you make changes.
-5. Make your changes.
+- Clone the repo and run `bundle install` to setup dependencies
+- Run `bundle exec rake spec` to run the all the tests, RuboCop and Danger Lint
+- Run `bundle exec rspec` to run the all unit tests
+- Use `bundle exec guard` to automatically have tests run as you make changes.
+- You can generate the documentation using `bundle exec yard doc`. The documentation is generated locally in the `yard-doc/` folder.

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ manifest_pr_checker.check_gemfile_lock_updated
 ```
 - `milestone_checker` - Plugin for performing checks on a milestone associated with a pull request
 ```ruby
-# Reports a warning if the Gemfile was changed but the Gemfile.lock wasn't
+# Checks if the pull request's milestone is due in 3 days or less, reporting a warning if that's the case
 milestone_checker.check_milestone_due_date(days_before_due: 3)
 ```
 - `pr_size_checker` - Plugin to check the size of a Pull Request content and text body

--- a/README.md
+++ b/README.md
@@ -38,7 +38,8 @@ All available plugins are defined here: https://github.com/Automattic/dangermatt
 ## Development
 
 - Clone the repo and run `bundle install` to setup dependencies
-- Run `bundle exec rake spec` to run the all the tests, RuboCop and Danger Lint
-- Run `bundle exec rspec` to run the all unit tests
+- Run `bundle exec rake` to run the all the tests, RuboCop and Danger Lint
+- Run `bundle exec rake specs` / `bundle exec rspec` to run only the unit tests
+- Run `bundle exec rake lint` to run only the linting tasks: RuboCop and Danger Lint
 - Use `bundle exec guard` to automatically have tests run as you make changes.
 - You can generate the documentation using `bundle exec yard doc`. The documentation is generated locally in the `yard-doc/` folder.

--- a/README.md
+++ b/README.md
@@ -13,25 +13,25 @@ gem 'danger-dangermattic', git: 'https://github.com/Automattic/dangermattic'
 Once the main Gem is installed, all Dangermattic plugins are available in your `Dangerfile` under their corresponding namespace. A few examples:
 
 - `manifest_pr_checker` - Plugin to check if changes on a manifest file (i.e. `Gemfile`, `Podfile`) has a corresponding change in a lock file (i.e. `Gemfile.lock`, `Podfile.lock`)
-```ruby
-# Reports a warning if the Gemfile was changed but the Gemfile.lock wasn't
-manifest_pr_checker.check_gemfile_lock_updated
-```
+    ```ruby
+    # Reports a warning if the Gemfile was changed but the Gemfile.lock wasn't
+    manifest_pr_checker.check_gemfile_lock_updated
+    ```
 - `milestone_checker` - Plugin for performing checks on a milestone associated with a pull request
-```ruby
-# Checks if the pull request's milestone is due in 3 days or less, reporting a warning if that's the case
-milestone_checker.check_milestone_due_date(days_before_due: 3)
-```
+    ```ruby
+    # Checks if the pull request's milestone is due in 3 days or less, reporting a warning if that's the case
+    milestone_checker.check_milestone_due_date(days_before_due: 3)
+    ```
 - `pr_size_checker` - Plugin to check the size of a Pull Request content and text body
-```ruby
-# Reports a warning if a pull request diff size is greater than 300
-pr_size_checker.check_diff_size(max_size: 300)
-```
+    ```ruby
+    # Reports a warning if a pull request diff size is greater than 300
+    pr_size_checker.check_diff_size(max_size: 300)
+    ```
 - `view_changes_need_screenshots` - Detects view changes in a PR and reports a warning if there are no attached screenshots
-```ruby
-# Reports a warning if a pull request changing views doesn't have a screenshot
-view_changes_need_screenshots.view_changes_need_screenshots
-```
+    ```ruby
+    # Reports a warning if a pull request changing views doesn't have a screenshot
+    view_changes_need_screenshots.view_changes_need_screenshots
+    ```
 
 All available plugins are defined here: https://github.com/Automattic/dangermattic/tree/trunk/lib/dangermattic/plugins
 

--- a/README.md
+++ b/README.md
@@ -8,9 +8,9 @@ Add to your project's `Gemfile`
 gem 'danger-dangermattic', git: 'https://github.com/Automattic/dangermattic'
 ```
 
-## Available plugins and their usage
+## Example of available plugins and their usage
 
-Once the main Gem is installed, all Dangermattic plugins are available in your `Dangerfile` under their corresponding namespace:
+Once the main Gem is installed, all Dangermattic plugins are available in your `Dangerfile` under their corresponding namespace. A few examples:
 
 - `manifest_pr_checker` - Plugin to check if changes on a manifest file (i.e. `Gemfile`, `Podfile`) has a corresponding change in a lock file (i.e. `Gemfile.lock`, `Podfile.lock`)
 ```ruby
@@ -32,6 +32,8 @@ pr_size_checker.check_diff_size(max_size: 300)
 # Reports a warning if a pull request changing views doesn't have a screenshot
 view_changes_need_screenshots.view_changes_need_screenshots
 ```
+
+All available plugins are defined here: https://github.com/Automattic/dangermattic/tree/trunk/lib/dangermattic/plugins
 
 ## Development
 

--- a/Rakefile
+++ b/Rakefile
@@ -7,10 +7,7 @@ require 'rubocop/rake_task'
 task default: :all
 
 desc 'Runs all tasks: :specs, :rubocop and :danger_lint'
-task :all do
-  Rake::Task['specs'].invoke
-  Rake::Task['lint'].invoke
-end
+task all: %i[specs lint]
 
 desc 'Ensure that the plugin passes `danger plugins lint`'
 task :danger_lint do
@@ -18,10 +15,7 @@ task :danger_lint do
 end
 
 desc 'Runs linting tasks: :rubocop and :danger_lint'
-task :lint do
-  Rake::Task['rubocop'].invoke
-  Rake::Task['danger_lint'].invoke
-end
+task lint: %i[rubocop danger_lint]
 
 desc 'Run Unit Tests'
 RSpec::Core::RakeTask.new(:specs)

--- a/Rakefile
+++ b/Rakefile
@@ -4,21 +4,27 @@ require 'bundler/gem_tasks'
 require 'rspec/core/rake_task'
 require 'rubocop/rake_task'
 
-RSpec::Core::RakeTask.new(:specs)
+task default: :all
 
-task default: :specs
-
-desc 'Runs all tasks: :specs, :rubocop and :spec_docs'
-task :spec do
+desc 'Runs all tasks: :specs, :rubocop and :danger_lint'
+task :all do
   Rake::Task['specs'].invoke
-  Rake::Task['rubocop'].invoke
-  Rake::Task['spec_docs'].invoke
+  Rake::Task['lint'].invoke
 end
+
+desc 'Ensure that the plugin passes `danger plugins lint`'
+task :danger_lint do
+  sh 'bundle exec danger plugins lint'
+end
+
+desc 'Runs linting tasks: :rubocop and :danger_lint'
+task :lint do
+  Rake::Task['rubocop'].invoke
+  Rake::Task['danger_lint'].invoke
+end
+
+desc 'Run Unit Tests'
+RSpec::Core::RakeTask.new(:specs)
 
 desc 'Run RuboCop on the lib/specs directory'
 RuboCop::RakeTask.new(:rubocop)
-
-desc 'Ensure that the plugin passes `danger plugins lint`'
-task :spec_docs do
-  sh 'bundle exec danger plugins lint'
-end


### PR DESCRIPTION
Linked to the [publishing of the `dangermattic` Gem](https://github.com/Automattic/dangermattic/pull/18) and [Danger Lint](https://github.com/Automattic/dangermattic/pull/16), this pull request introduces a foundational YARD documentation configuration to facilitate the generation of documentation for the Gem.

I've also added more information and an initial structure to the project's `README.md`.