### PR TITLE
Add RuboCop Danger plugin

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -5,6 +5,7 @@ PATH
       danger (~> 9.3)
       danger-junit (~> 1.0)
       danger-plugin-api (~> 1.0)
+      danger-rubocop (~> 0.11)
       danger-swiftlint (~> 0.29)
       danger-xcode_summary (~> 1.0)
       rubocop (~> 1.56)
@@ -43,6 +44,9 @@ GEM
       ox (~> 2.0)
     danger-plugin-api (1.0.0)
       danger (> 2.0)
+    danger-rubocop (0.11.0)
+      danger
+      rubocop (~> 1.0)
     danger-swiftlint (0.33.0)
       danger
       rake (> 10)

--- a/danger-dangermattic.gemspec
+++ b/danger-dangermattic.gemspec
@@ -26,6 +26,7 @@ Gem::Specification.new do |spec|
 
   # Danger plugins
   spec.add_dependency 'danger-junit', '~> 1.0'
+  spec.add_dependency 'danger-rubocop', '~> 0.11'
   spec.add_dependency 'danger-swiftlint', '~> 0.29'
   spec.add_dependency 'danger-xcode_summary', '~> 1.0'
 


### PR DESCRIPTION
Adding `danger-rubocop` so it becomes part of the "Dangermattic package", so that we can use it as needed in client repos without the need for adding it as a separate dependency.