### PR TITLE
Fix Milestone Checker date parsing

### DIFF
--- a/lib/dangermattic/plugins/milestone_checker.rb
+++ b/lib/dangermattic/plugins/milestone_checker.rb
@@ -70,10 +70,9 @@ module Danger
       return unless pr_state != 'closed' && milestone_due_date
 
       today = DateTime.now
-      due_date = DateTime.parse(milestone_due_date)
 
       seconds_threshold = days_before_due * 24 * 60 * 60
-      time_before_due_date = due_date.to_time.to_i - today.to_time.to_i
+      time_before_due_date = milestone_due_date.to_time.to_i - today.to_time.to_i
       return unless time_before_due_date <= seconds_threshold
 
       message_text = "This PR is assigned to the milestone [#{milestone_title}](#{milestone_url}). "

--- a/spec/milestone_checker_spec.rb
+++ b/spec/milestone_checker_spec.rb
@@ -72,7 +72,7 @@ module Danger
             'milestone' => {
               'title' => 'Release Day',
               'html_url' => 'https://wp.com',
-              'due_on' => '2023-06-30T23:59:01Z'
+              'due_on' => DateTime.parse('2023-06-30T23:59:01Z')
             },
             'state' => 'open'
           }
@@ -93,7 +93,7 @@ module Danger
             'milestone' => {
               'title' => 'Release Day',
               'html_url' => 'https://wp.com',
-              'due_on' => '2023-06-30T23:59:01Z'
+              'due_on' => DateTime.parse('2023-06-30T23:59:01Z')
             },
             'state' => 'open'
           }
@@ -113,7 +113,7 @@ module Danger
             'milestone' => {
               'title' => 'Release Day',
               'html_url' => 'https://wp.com',
-              'due_on' => '2023-06-30T23:59:01Z'
+              'due_on' => DateTime.parse('2023-06-30T23:59:01Z')
             },
             'state' => 'open'
           }
@@ -134,7 +134,7 @@ module Danger
             'milestone' => {
               'title' => 'Release Day',
               'html_url' => 'https://wp.com',
-              'due_on' => '2023-06-30T23:59:01Z'
+              'due_on' => DateTime.parse('2023-06-30T23:59:01Z')
             },
             'state' => 'open'
           }
@@ -171,7 +171,7 @@ module Danger
             'milestone' => {
               'title' => 'Release Day',
               'html_url' => 'https://wp.com',
-              'due_on' => '2023-06-30T23:59:01Z'
+              'due_on' => DateTime.parse('2023-06-30T23:59:01Z')
             },
             'state' => 'closed'
           }


### PR DESCRIPTION
While developing, I assumed the date value on `github.pr_json['milestone']['due_on']` was going to be a string.

Now actually running on Github, it turns out it is already a `Time` object, so additional parsing shouldn't be necessary, and this PR fixes it.