### PR TITLE
Screenshots Check: match HTML image tag

### DIFF
--- a/lib/dangermattic/plugins/view_changes_need_screenshots.rb
+++ b/lib/dangermattic/plugins/view_changes_need_screenshots.rb
@@ -25,8 +25,10 @@ module Danger
       view_files_modified = git.modified_files.any? do |file|
         VIEW_EXTENSIONS_IOS =~ file || VIEW_EXTENSIONS_ANDROID =~ file
       end
+
       pr_has_screenshots = github.pr_body =~ %r{https?://\S*\.(gif|jpg|jpeg|png|svg)}
       pr_has_screenshots ||= github.pr_body =~ /!\[(.*?)\]\((.*?)\)/
+      pr_has_screenshots ||= github.pr_body =~ /<img\s[^>]*\ssrc=[^>]*>/
 
       warning = 'View files have been modified, but no screenshot is included in the pull request. ' \
                 'Consider adding some for clarity.'

--- a/spec/view_changes_need_screenshots_spec.rb
+++ b/spec/view_changes_need_screenshots_spec.rb
@@ -21,9 +21,27 @@ module Danger
         expect(@dangerfile.status_report[:warnings].count).to eq 1
       end
 
-      it 'does nothing when a PR with view code changes has screenshots' do
+      it 'does nothing when a PR with view code changes has screenshots defined in markdown' do
         allow(@plugin.github).to receive(:pr_body)
           .and_return('PR [![Alt text](https://myimages.com/boo)](https://digitalocean.com) Body')
+
+        @plugin.view_changes_need_screenshots
+
+        expect(@dangerfile.status_report[:warnings]).to be_empty
+      end
+
+      it 'does nothing when a PR with view code changes has url to screenshots' do
+        allow(@plugin.github).to receive(:pr_body)
+          .and_return('<a href=\'https://myimages.com/boo.jpg\'>see secreenshot</a> Body')
+
+        @plugin.view_changes_need_screenshots
+
+        expect(@dangerfile.status_report[:warnings]).to be_empty
+      end
+
+      it 'does nothing when a PR with view code changes has a screenshot defined with a html tag' do
+        allow(@plugin.github).to receive(:pr_body)
+          .and_return("see screenshot:\n<img width=300 src=\"https://github.com/bloom/DayOne-Apple/assets/4780/1f9e01a8-c63d-41d4-9ac8-fa9a5182ab55\"> body body")
 
         @plugin.view_changes_need_screenshots
 


### PR DESCRIPTION
We noticed images defined in the PR body with a plain HTML `<img>` tag but without an image extension would not be recognised as images. The `view_changes_need_screenshots` plugin would then wrongly assert that a PR would not contain an image, even if it did.

This PR fixes the issue by also matching with a `<img>` tag in the PR body, independent of the link.