### PR TITLE
Codefence both file and lockfile names in `manifest_pr_checker` warn

### DIFF
--- a/lib/dangermattic/plugins/manifest_pr_checker.rb
+++ b/lib/dangermattic/plugins/manifest_pr_checker.rb
@@ -82,7 +82,7 @@ module Danger
         lockfile_modified = git.modified_files.any? { |f| File.dirname(f) == File.dirname(manifest_file) && File.basename(f) == lock_file_name }
         next if lockfile_modified
 
-        warn("#{manifest_file} was changed without updating its corresponding #{lock_file_name}. #{instruction}.")
+        warn("`#{manifest_file}` was changed without updating its corresponding `#{lock_file_name}`. #{instruction}.")
       end
     end
   end

--- a/spec/manifest_pr_checker_spec.rb
+++ b/spec/manifest_pr_checker_spec.rb
@@ -21,7 +21,7 @@ module Danger
 
           @plugin.check_gemfile_lock_updated
 
-          expected_warning = ['Gemfile was changed without updating its corresponding Gemfile.lock. Please run `bundle install` or `bundle update <updated_gem>`.']
+          expected_warning = ['`Gemfile` was changed without updating its corresponding `Gemfile.lock`. Please run `bundle install` or `bundle update <updated_gem>`.']
           expect(@dangerfile.status_report[:warnings]).to eq expected_warning
         end
 
@@ -51,7 +51,7 @@ module Danger
 
           @plugin.check_podfile_lock_updated
 
-          expected_warning = ['Podfile was changed without updating its corresponding Podfile.lock. Please run `bundle exec pod install`.']
+          expected_warning = ['`Podfile` was changed without updating its corresponding `Podfile.lock`. Please run `bundle exec pod install`.']
           expect(@dangerfile.status_report[:warnings]).to eq expected_warning
         end
 
@@ -70,7 +70,7 @@ module Danger
 
           @plugin.check_podfile_lock_updated
 
-          expected_warning = ['./path/to/Podfile was changed without updating its corresponding Podfile.lock. Please run `bundle exec pod install`.']
+          expected_warning = ['`./path/to/Podfile` was changed without updating its corresponding `Podfile.lock`. Please run `bundle exec pod install`.']
           expect(@dangerfile.status_report[:warnings]).to eq expected_warning
         end
 
@@ -81,8 +81,8 @@ module Danger
           @plugin.check_podfile_lock_updated
 
           expected_warnings = [
-            './dir2/Podfile was changed without updating its corresponding Podfile.lock. Please run `bundle exec pod install`.',
-            './dir3/Podfile was changed without updating its corresponding Podfile.lock. Please run `bundle exec pod install`.'
+            '`./dir2/Podfile` was changed without updating its corresponding `Podfile.lock`. Please run `bundle exec pod install`.',
+            '`./dir3/Podfile` was changed without updating its corresponding `Podfile.lock`. Please run `bundle exec pod install`.'
           ]
           expect(@dangerfile.status_report[:warnings]).to eq expected_warnings
         end
@@ -113,7 +113,7 @@ module Danger
 
           @plugin.check_swift_package_resolved_updated
 
-          expected_warning = ['Package.swift was changed without updating its corresponding Package.resolved. Please resolve the Swift packages in Xcode.']
+          expected_warning = ['`Package.swift` was changed without updating its corresponding `Package.resolved`. Please resolve the Swift packages in Xcode.']
           expect(@dangerfile.status_report[:warnings]).to eq expected_warning
         end
 


### PR DESCRIPTION
I got a `Podfile.lock` warning in https://github.com/wordpress-mobile/WordPress-iOS/pull/21961:

![image](https://github.com/Automattic/dangermattic/assets/1218433/2a8c02ae-065a-48b9-a188-a240f8d593c0)

Just a personal opinion that those file names look better rendered as `<code>`. Also, it would look consistent with the codefenced command suggestion.

<img width="964" alt="image" src="https://github.com/Automattic/dangermattic/assets/1218433/d17060cd-5e36-4440-bec9-35fe64c2ca23">

If this doesn't resonate, feel free to discard.
