### PR TITLE
Prevent Danger crash due to nil Diff Stats

### DIFF
--- a/lib/dangermattic/plugins/pr_size_checker.rb
+++ b/lib/dangermattic/plugins/pr_size_checker.rb
@@ -85,7 +85,13 @@ module Danger
       return danger.git.insertions unless file_selector
 
       filtered_files = git_utils.all_changed_files.select(&file_selector)
-      filtered_files.sum { |file| danger.git.info_for_file(file)[:insertions].to_i }
+
+      filtered_files.sum do |file|
+        # stats for a file in the GitHub API might be nil, making `info_for_file()` crash
+        next 0 if danger.git.diff.stats[:files][file].nil?
+
+        danger.git.info_for_file(file)&.[](:insertions).to_i
+      end
     end
 
     # Calculate the total size of deletions in modified files that match the file selector.
@@ -97,7 +103,13 @@ module Danger
       return danger.git.deletions unless file_selector
 
       filtered_files = git_utils.all_changed_files.select(&file_selector)
-      filtered_files.sum { |file| danger.git.info_for_file(file)[:deletions].to_i }
+
+      filtered_files.sum do |file|
+        # stats for a file in the GitHub API might be nil, making `info_for_file()` crash
+        next 0 if danger.git.diff.stats[:files][file].nil?
+
+        danger.git.info_for_file(file)&.[](:deletions).to_i
+      end
     end
 
     # Calculate the total size of changes (insertions and deletions) in modified files that match the file selector.
@@ -109,7 +121,13 @@ module Danger
       return danger.git.lines_of_code unless file_selector
 
       filtered_files = git_utils.all_changed_files.select(&file_selector)
-      filtered_files.sum { |file| danger.git.info_for_file(file)[:deletions].to_i + danger.git.info_for_file(file)[:insertions].to_i }
+
+      filtered_files.sum do |file|
+        # stats for a file in the GitHub API might be nil, making `info_for_file()` crash
+        next 0 if danger.git.diff.stats[:files][file].nil?
+
+        danger.git.info_for_file(file)&.[](:deletions).to_i + danger.git.info_for_file(file)&.[](:insertions).to_i
+      end
     end
   end
 end

--- a/spec/pr_size_checker_spec.rb
+++ b/spec/pr_size_checker_spec.rb
@@ -151,6 +151,10 @@ module Danger
 
             allow(@plugin.git).to receive_messages(added_files: [added_config, added_file], modified_files: [modified_file1, modified_file2, added_test_file, modified_strings], deleted_files: [deleted_file1, deleted_test_file, deleted_strings, deleted_file2])
 
+            allow(@plugin.git).to receive(:diff).and_return(instance_double(Git::Diff))
+            expected_files = { added_test_file => {}, added_config => {}, added_file => {}, modified_file1 => {}, modified_file2 => {}, modified_strings => {}, deleted_file1 => {}, deleted_file2 => {}, deleted_test_file => {}, deleted_strings => {} }
+            allow(@plugin.git.diff).to receive(:stats).and_return({ files: expected_files })
+
             allow(@plugin.git).to receive(:info_for_file).with(added_test_file).and_return({ insertions: 201 })
             allow(@plugin.git).to receive(:info_for_file).with(added_config).and_return({ insertions: 311 })
             allow(@plugin.git).to receive(:info_for_file).with(added_file).and_return({ insertions: 13 })


### PR DESCRIPTION
[This WordPress Android PR](https://github.com/wordpress-mobile/WordPress-Android/pull/19488) had an interesting crash: it happened internally in Danger when calling the `git` function `info_for_file` ([see code](https://github.com/danger/danger/blob/d9fff7cbed6b0a4bfb6465709d0352e700bdd00e/lib/danger/danger_core/plugins/dangerfile_git_plugin.rb#L138)). The GitHub API might return nil for the stats object.

The present PR fixes the issue by avoiding the `info_for_file` call when the `stats` object is `nil`.

## How to test

1. Checkout the aforementioned WP Android branch
2. Change the Gemfile to use this branch:
`gem 'danger-dangermattic', git: 'https://github.com/Automattic/dangermattic', branch: 'fix/prevent-info-for-file-crash`
3. Run `bundle update danger-dangermattic`
4. Run danger locally but pointing to the PR above:
```
DANGER_GITHUB_API_TOKEN=<token> bundle exec danger pr https://github.com/wordpress-mobile/WordPress-Android/pull/19488
```