### PR TITLE
Improve screenshot matching in the PR description

### DIFF
--- a/lib/dangermattic/plugins/view_changes_need_screenshots.rb
+++ b/lib/dangermattic/plugins/view_changes_need_screenshots.rb
@@ -20,7 +20,7 @@ module Danger
     IMAGE_IN_PR_BODY_PATTERNS = [
       %r{https?://\S*\.(gif|jpg|jpeg|png|svg)},
       /!\[(.*?)\]\((.*?)\)/,
-      /<img\s+[^\>]*src\s*=\s*[^\>]*>/
+      /<img\s+[^>]*src\s*=\s*[^>]*>/
     ].freeze
 
     # Checks if view files have been modified and if a screenshot is included in the pull request body,

--- a/lib/dangermattic/plugins/view_changes_need_screenshots.rb
+++ b/lib/dangermattic/plugins/view_changes_need_screenshots.rb
@@ -17,6 +17,12 @@ module Danger
     VIEW_EXTENSIONS_IOS = /(View|Button)\.(swift|m)$|\.xib$|\.storyboard$/
     VIEW_EXTENSIONS_ANDROID = /(?i)(View|Button)\.(java|kt|xml)$/
 
+    IMAGE_IN_PR_BODY_PATTERNS = [
+      %r{https?://\S*\.(gif|jpg|jpeg|png|svg)},
+      /!\[(.*?)\]\((.*?)\)/,
+      /<img\s+[^\>]*src\s*=\s*[^\>]*>/
+    ].freeze
+
     # Checks if view files have been modified and if a screenshot is included in the pull request body,
     # displaying a warning if view files have been modified but no screenshot is included.
     #
@@ -26,9 +32,9 @@ module Danger
         VIEW_EXTENSIONS_IOS =~ file || VIEW_EXTENSIONS_ANDROID =~ file
       end
 
-      pr_has_screenshots = github.pr_body =~ %r{https?://\S*\.(gif|jpg|jpeg|png|svg)}
-      pr_has_screenshots ||= github.pr_body =~ /!\[(.*?)\]\((.*?)\)/
-      pr_has_screenshots ||= github.pr_body =~ /<img\s[^>]*\ssrc=[^>]*>/
+      pr_has_screenshots = IMAGE_IN_PR_BODY_PATTERNS.any? do |pattern|
+        github.pr_body =~ pattern
+      end
 
       warning = 'View files have been modified, but no screenshot is included in the pull request. ' \
                 'Consider adding some for clarity.'

--- a/spec/view_changes_need_screenshots_spec.rb
+++ b/spec/view_changes_need_screenshots_spec.rb
@@ -39,9 +39,18 @@ module Danger
         expect(@dangerfile.status_report[:warnings]).to be_empty
       end
 
-      it 'does nothing when a PR with view code changes has a screenshot defined with a html tag' do
+      it 'does nothing when a PR with view code changes has a screenshot defined with a html tag with different attributes before src' do
         allow(@plugin.github).to receive(:pr_body)
-          .and_return("see screenshot:\n<img width=300 src=\"https://github.com/bloom/DayOne-Apple/assets/4780/1f9e01a8-c63d-41d4-9ac8-fa9a5182ab55\"> body body")
+          .and_return("see screenshot:\n<img width=300 hint=\"First screenshots\" src=\"https://github.com/bloom/DayOne-Apple/assets/4780/1f9e01a8-c63d-41d4-9ac8-fa9a5182ab55\"> body body")
+
+        @plugin.view_changes_need_screenshots
+
+        expect(@dangerfile.status_report[:warnings]).to be_empty
+      end
+
+      it 'does nothing when a PR with view code changes has a screenshot defined with a html' do
+        allow(@plugin.github).to receive(:pr_body)
+          .and_return("see screenshot:\n<img src=\"https://github.com/woocommerce/woocommerce-ios/assets/1864060/17d9227d-67e8-4efb-8c26-02b81e1b19d2\" width=\"375\"> body body")
 
         @plugin.view_changes_need_screenshots
 


### PR DESCRIPTION
## What
The plugin wasn't detecting the screenshots on [this PR](https://github.com/woocommerce/woocommerce-ios/pull/11097), so I tweaked the Regex a bit more, which should now better cover the `<img>` HTML tag in the PR description.

## How to test

1. Checkout the branch from the aforementioned PR
2. Change the `Gemfile` to use the present branch:
`gem 'danger-dangermattic', git: 'https://github.com/Automattic/dangermattic', branch: 'fix/screenshots-pr-check`
3. Run `bundle install`
4. Run danger locally but pointing to the PR above:
```
DANGER_GITHUB_API_TOKEN=<token> bundle exec danger pr https://github.com/woocommerce/woocommerce-ios/pull/11097
```