### PR TITLE
Add options to check `Podfile` does not reference pods via branch

### DIFF
--- a/lib/dangermattic/plugins/podfile_checks.rb
+++ b/lib/dangermattic/plugins/podfile_checks.rb
@@ -47,9 +47,39 @@ module Danger
       check_podfile_diff_entries_do_not_match(regexp: COMMIT_REFERENCE_REGEXP, match_found_message: warning_message)
     end
 
+    # Check if the Podfile.lock contains any references to branches and raise a failure if it does.
+    #
+    # @param podfile_lock_path [String] (optional) The path to the Podfile.lock file.
+    #        Defaults to the `DEFAULT_PODFILE_LOCK_PATH` constant if not provided.
+    #
+    # @example Checking the default Podfile.lock:
+    #   check_podfile_does_not_have_branch_references
+    #
+    # @example Checking a custom Podfile.lock at a specific path:
+    #    check_podfile_does_not_have_branch_references(podfile_lock_path: '/path/to/Podfile.lock')
+    #
+    # @return [void]
+    def check_podfile_does_not_have_branch_references(podfile_lock_path: DEFAULT_PODFILE_LOCK_PATH)
+      check_podfile_does_not_match(
+        regexp: BRANCH_REFERENCE_REGEXP,
+        podfile_lock_path: podfile_lock_path,
+        match_found_message_generator: ->(matches) { "Podfile reference(s) to a branch:\n```#{matches.join("\n")}```" }
+      )
+    end
+
+    # Check for Podfile references to branches in the Podfile.lock in a pull request.
+    #
+    # @return [void]
+    def check_podfile_diff_does_not_have_branch_references
+      warning_message = 'This PR adds a Podfile reference to a branch:'
+      check_podfile_diff_entries_do_not_match(regexp: BRANCH_REFERENCE_REGEXP, match_found_message: warning_message)
+    end
+
     private
 
     COMMIT_REFERENCE_REGEXP = /\(from `\S+`, commit `\S+`\)/
+
+    BRANCH_REFERENCE_REGEXP = /\(from `\S+`, branch `\S+`\)/
 
     def check_podfile_does_not_match(
       regexp:,

--- a/lib/dangermattic/plugins/podfile_checks.rb
+++ b/lib/dangermattic/plugins/podfile_checks.rb
@@ -108,9 +108,5 @@ module Danger
         message: match_found_message
       )
     end
-
-    def podfile_lock_commit_reference?(podfile_line:)
-      podfile_line.match?(COMMIT_REFERENCE_REGEXP)
-    end
   end
 end

--- a/spec/podfile_checks_spec.rb
+++ b/spec/podfile_checks_spec.rb
@@ -62,7 +62,7 @@ module Danger
           @plugin.check_podfile_does_not_have_commit_references
 
           expected_message = "Podfile reference(s) to a commit hash:\n```Kingfisher (from `https://github.com/onevcat/Kingfisher.git`, commit `c1f60c63f356d364f4284ba82961acbe7de79bcc`)```"
-          expect(@dangerfile.status_report[:errors]).to eq [expected_message]
+          expect(@dangerfile).to report_errors([expected_message])
         end
 
         it 'returns the right errors when there are multiple podfile dependencies referencing a commit' do
@@ -119,7 +119,7 @@ module Danger
             SwiftGen (from `https://github.com/SwiftGen/SwiftGen.git`, commit `759cc111dfdc01dd8d66edf20ff88402b0978591`)
             SwiftLint (from `https://github.com/realm/SwiftLint.git`, commit `28a4aa2`)```
           MESSAGE
-          expect(@dangerfile.status_report[:errors]).to eq [expected_message]
+          expect(@dangerfile).to report_errors([expected_message])
         end
 
         it 'returns no error when there are no Podfile dependencies reference to a commit' do
@@ -150,7 +150,7 @@ module Danger
 
           @plugin.check_podfile_does_not_have_commit_references
 
-          expect(@dangerfile.status_report[:errors]).to be_empty
+          expect(@dangerfile).to not_report
         end
       end
 
@@ -236,7 +236,7 @@ module Danger
             ```
           WARNING
 
-          expect(@dangerfile.status_report[:warnings]).to contain_exactly(expected_warning, expected_warning2)
+          expect(@dangerfile).to report_warnings([expected_warning, expected_warning2])
         end
 
         it 'does nothing when a PR removes Podfile.lock commit references' do

--- a/spec/podfile_checks_spec.rb
+++ b/spec/podfile_checks_spec.rb
@@ -2,6 +2,7 @@
 
 require_relative 'spec_helper'
 
+# rubocop:disable Metrics/ModuleLength
 module Danger
   describe Danger::PodfileChecks do
     it 'is a plugin' do
@@ -18,7 +19,7 @@ module Danger
         stub_const('GitDiffStruct', Struct.new(:type, :path, :patch))
       end
 
-      context 'when checking the entire Podfile.lock file' do
+      context 'when checking the entire Podfile.lock file for commit references' do
         it 'returns an error when there is a podfile dependency reference to a commit' do
           podfile_lock_content = <<~CONTENT
             PODS:
@@ -153,7 +154,7 @@ module Danger
         end
       end
 
-      context 'when changing the Podfile.lock in a Pull Request' do
+      context 'when changing the Podfile.lock in a Pull Request and checking for commit references' do
         it 'returns warnings when a PR adds pods pointing to a specific commit' do
           podfile_path = './path/to/podfile/Podfile.lock'
           allow(@plugin.git).to receive(:modified_files).and_return([podfile_path])
@@ -298,6 +299,299 @@ module Danger
           expect(@dangerfile.status_report[:warnings]).to be_empty
         end
       end
+
+      context 'when checking the entire Podfile.lock file for branch references' do
+        it 'returns an error when there is a podfile dependency reference to a branch' do
+          podfile_lock_content = <<~CONTENT
+            PODS:
+              - Kingfisher (7.8.1)
+              - SwiftGen (6.5.1)
+              - SwiftLint (0.49.1)
+
+            DEPENDENCIES:
+              - Kingfisher (from `https://github.com/onevcat/Kingfisher.git`, branch `main`)
+              - SwiftGen (~> 6.0)
+              - SwiftLint (~> 0.49)
+
+            SPEC REPOS:
+              trunk:
+              - SwiftGen
+              - SwiftLint
+
+            EXTERNAL SOURCES:
+              Kingfisher:
+              :branch: main
+              :git: https://github.com/onevcat/Kingfisher.git
+
+            CHECKOUT OPTIONS:
+              Kingfisher:
+              :commit: c1f60c63f356d364f4284ba82961acbe7de79bcc
+              :git: https://github.com/onevcat/Kingfisher.git
+
+            SPEC CHECKSUMS:
+              Kingfisher: 63f677311d36a3473f6b978584f8a3845d023dc5
+              SwiftGen: a6d22010845f08fe18fbdf3a07a8e380fd22e0ea
+              SwiftLint: 32ee33ded0636d0905ef6911b2b67bbaeeedafa5
+
+            PODFILE CHECKSUM: 58bea7d9e64aa93550617dd989b9e5ceed3df3f4
+
+            COCOAPODS: 1.12.1
+          CONTENT
+
+          allow(File).to receive(:read).with('./Podfile.lock').and_return(podfile_lock_content)
+
+          @plugin.check_podfile_does_not_have_branch_references
+
+          expected_message = "Podfile reference(s) to a branch:\n```Kingfisher (from `https://github.com/onevcat/Kingfisher.git`, branch `main`)```"
+          expect(@dangerfile.status_report[:errors]).to eq [expected_message]
+        end
+
+        it 'returns the right errors when there are multiple podfile dependencies referencing a branch' do
+          podfile_lock_content = <<~CONTENT
+            PODS:
+            - Kingfisher (7.8.1)
+            - SwiftGen (6.6.1)
+            - SwiftLint (0.50.1)
+
+            DEPENDENCIES:
+              - Kingfisher (from `https://github.com/onevcat/Kingfisher.git`, branch `main`)
+              - SwiftGen (from `https://github.com/SwiftGen/SwiftGen.git`, branch `test/a-test-branch`)
+              - SwiftLint (from `https://github.com/realm/SwiftLint.git`, branch `feature-branch`)
+
+            EXTERNAL SOURCES:
+              Kingfisher:
+                :branch: main
+                :git: https://github.com/onevcat/Kingfisher.git
+              SwiftGen:
+                :branch: test/a-test-branch
+                :git: https://github.com/SwiftGen/SwiftGen.git
+              SwiftLint:
+                :branch: feature-branch
+                :git: https://github.com/realm/SwiftLint.git
+
+            CHECKOUT OPTIONS:
+              Kingfisher:
+                :commit: c1f60c63f356d364f4284ba82961acbe7de79bcc
+                :git: https://github.com/onevcat/Kingfisher.git
+              SwiftGen:
+                :commit: 759cc111dfdc01dd8d66edf20ff88402b0978591
+                :git: https://github.com/SwiftGen/SwiftGen.git
+              SwiftLint:
+                :commit: 28a4aa2
+                :git: https://github.com/realm/SwiftLint.git
+
+            SPEC CHECKSUMS:
+              Kingfisher: 63f677311d36a3473f6b978584f8a3845d023dc5
+              SwiftGen: 787181d7895fa2f5e7313d05de92c387010149c2
+              SwiftLint: 6b0cf1f4d619808dbc16e4fab064ce6fc79f090b
+
+            PODFILE CHECKSUM: 33ada736a0466cd5db78f4a568b5cdafdeeddb22
+
+            COCOAPODS: 1.12.1
+          CONTENT
+
+          allow(File).to receive(:read).with('./Podfile.lock').and_return(podfile_lock_content)
+
+          @plugin.check_podfile_does_not_have_branch_references
+
+          expected_message = <<~MESSAGE.chomp
+            Podfile reference(s) to a branch:
+            ```Kingfisher (from `https://github.com/onevcat/Kingfisher.git`, branch `main`)
+            SwiftGen (from `https://github.com/SwiftGen/SwiftGen.git`, branch `test/a-test-branch`)
+            SwiftLint (from `https://github.com/realm/SwiftLint.git`, branch `feature-branch`)```
+          MESSAGE
+          expect(@dangerfile.status_report[:errors]).to eq [expected_message]
+        end
+
+        it 'returns no error when there are no Podfile dependency references to a branch' do
+          podfile_lock_content = <<~CONTENT
+            PODS:
+              - SwiftGen (6.5.1)
+              - SwiftLint (0.49.1)
+
+            DEPENDENCIES:
+              - SwiftGen (~> 6.0)
+              - SwiftLint (from `https://github.com/realm/SwiftLint.git`, commit `759cc111dfdc01dd8d66edf20ff88402b0978591`)
+
+            SPEC REPOS:
+              trunk:
+              - SwiftGen
+              - SwiftLint
+
+            EXTERNAL SOURCES:
+              SwiftLint:
+                :commit: 759cc111dfdc01dd8d66edf20ff88402b0978591
+                :git: https://github.com/realm/SwiftLint.git
+
+            CHECKOUT OPTIONS:
+              SwiftLint:
+                :commit: 759cc111dfdc01dd8d66edf20ff88402b0978591
+                :git: https://github.com/realm/SwiftLint.git
+
+
+            SPEC CHECKSUMS:
+              SwiftGen: a6d22010845f08fe18fbdf3a07a8e380fd22e0ea
+              SwiftLint: 32ee33ded0636d0905ef6911b2b67bbaeeedafa5
+
+            PODFILE CHECKSUM: 58bea7d9e64aa93550617dd989b9e5ceed3df3f4
+
+            COCOAPODS: 1.12.1
+          CONTENT
+
+          allow(File).to receive(:read).with('./Podfile.lock').and_return(podfile_lock_content)
+
+          @plugin.check_podfile_does_not_have_branch_references
+
+          expect(@dangerfile.status_report[:errors]).to be_empty
+        end
+      end
+
+      context 'when changing the Podfile.lock in a Pull Request and checking for branch references' do
+        it 'returns warnings when a PR adds pods pointing to a branch' do
+          podfile_path = './path/to/podfile/Podfile.lock'
+          allow(@plugin.git).to receive(:modified_files).and_return([podfile_path])
+
+          podfile_lock_diff = <<~PODFILE
+            diff --git a/Podfile.lock b/Podfile.lock
+            index 4a47d5fc..d57533f5 100644
+            --- a/Podfile.lock
+            +++ b/Podfile.lock
+            @@ -1,24 +1,38 @@
+            PODS:
+              - Kingfisher (7.8.1)
+            -  - SwiftGen (6.6.2)
+            -  - SwiftLint (0.51.0)
+            +  - SwiftGen (6.6.1)
+            +  - SwiftLint (0.50.1)
+
+            DEPENDENCIES:
+              - Kingfisher
+            -  - SwiftGen
+            -  - SwiftLint
+            +  - SwiftGen (from `https://github.com/SwiftGen/SwiftGen.git`, branch `trunk`)
+            +  - SwiftLint (from `https://github.com/realm/SwiftLint.git`, branch `develop`)
+
+            SPEC REPOS:
+              trunk:
+                - Kingfisher
+            -    - SwiftGen
+            -    - SwiftLint
+            +
+            +EXTERNAL SOURCES:
+            +  SwiftGen:
+            +    :branch: trunk
+            +    :git: https://github.com/SwiftGen/SwiftGen.git
+            +  SwiftLint:
+            +    :branch: develop
+            +    :git: https://github.com/realm/SwiftLint.git
+            +
+            +CHECKOUT OPTIONS:
+            +  SwiftGen:
+            +    :commit: 759cc111dfdc01dd8d66edf20ff88402b0978591
+            +    :git: https://github.com/SwiftGen/SwiftGen.git
+            +  SwiftLint:
+            +    :commit: 28a4aa2
+            +    :git: https://github.com/realm/SwiftLint.git
+
+            SPEC CHECKSUMS:
+              Kingfisher: 63f677311d36a3473f6b978584f8a3845d023dc5
+            -  SwiftGen: 1366a7f71aeef49954ca5a63ba4bef6b0f24138c
+            -  SwiftLint: 1b7561918a19e23bfed960e40759086e70f4dba5
+            +  SwiftGen: 787181d7895fa2f5e7313d05de92c387010149c2
+            +  SwiftLint: 6b0cf1f4d619808dbc16e4fab064ce6fc79f090b
+
+            -PODFILE CHECKSUM: 2c09a6c90634ae2e0afd8d992b96b06ae68cabc2
+            +PODFILE CHECKSUM: 8dc39244eeee7e5d107d943a6269ca525115094b
+
+            COCOAPODS: 1.12.1
+          PODFILE
+
+          diff = GitDiffStruct.new('modified', podfile_path, podfile_lock_diff)
+
+          allow(@plugin.git).to receive(:diff_for_file).with(podfile_path).and_return(diff)
+
+          @plugin.check_podfile_diff_does_not_have_branch_references
+
+          expected_warning = <<~WARNING
+            This PR adds a Podfile reference to a branch:
+            File `#{podfile_path}`:
+            ```diff
+            +  - SwiftGen (from `https://github.com/SwiftGen/SwiftGen.git`, branch `trunk`)
+            ```
+          WARNING
+
+          expected_warning2 = <<~WARNING
+            This PR adds a Podfile reference to a branch:
+            File `#{podfile_path}`:
+            ```diff
+            +  - SwiftLint (from `https://github.com/realm/SwiftLint.git`, branch `develop`)
+            ```
+          WARNING
+
+          expect(@dangerfile.status_report[:warnings]).to contain_exactly(expected_warning, expected_warning2)
+        end
+
+        it 'does nothing when a PR removes Podfile.lock branch references' do
+          podfile_path = './path/to/podfile/Podfile.lock'
+          allow(@plugin.git).to receive(:modified_files).and_return([podfile_path])
+
+          podfile_lock_diff = <<~PODFILE
+            diff --git a/Podfile.lock b/Podfile.lock
+            index 369b66d6..4a47d5fc 100644
+            --- a/Podfile.lock
+            +++ b/Podfile.lock
+            @@ -1,33 +1,24 @@
+            PODS:
+              - Kingfisher (7.8.1)
+              - SwiftGen (6.6.2)
+            -  - SwiftLint (0.50.1)
+            +  - SwiftLint (0.51.0)
+
+            DEPENDENCIES:
+            -  - Kingfisher (>= 7.6.2, ~> 7.6)
+            +  - Kingfisher
+              - SwiftGen
+            -  - SwiftLint (from `https://github.com/realm/SwiftLint.git`, branch `a-feature-branch`)
+            +  - SwiftLint
+
+            SPEC REPOS:
+              trunk:
+                - Kingfisher
+                - SwiftGen
+            -
+            -EXTERNAL SOURCES:
+            -  SwiftLint:
+            -    :branch: a-feature-branch
+            -    :git: https://github.com/realm/SwiftLint.git
+            -
+            -CHECKOUT OPTIONS:
+            -  SwiftLint:
+            -    :commit: 28a4aa2
+            -    :git: https://github.com/realm/SwiftLint.git
+            +  SwiftLint
+
+            SPEC CHECKSUMS:
+              Kingfisher: 63f677311d36a3473f6b978584f8a3845d023dc5
+              SwiftGen: 1366a7f71aeef49954ca5a63ba4bef6b0f24138c
+            -  SwiftLint: 6b0cf1f4d619808dbc16e4fab064ce6fc79f090b
+            +  SwiftLint: 1b7561918a19e23bfed960e40759086e70f4dba5
+
+            -PODFILE CHECKSUM: 7eea968a423d51c238de59edf2a857d882a9d762
+            +PODFILE CHECKSUM: 2c09a6c90634ae2e0afd8d992b96b06ae68cabc2
+
+            COCOAPODS: 1.12.1
+          PODFILE
+
+          diff = GitDiffStruct.new('modified', podfile_path, podfile_lock_diff)
+
+          allow(@plugin.git).to receive(:diff_for_file).with(podfile_path).and_return(diff)
+
+          @plugin.check_podfile_diff_does_not_have_branch_references
+
+          expect(@dangerfile.status_report[:warnings]).to be_empty
+        end
+      end
     end
   end
 end
+# rubocop:enable Metrics/ModuleLength

--- a/spec/podfile_checks_spec.rb
+++ b/spec/podfile_checks_spec.rb
@@ -343,7 +343,7 @@ module Danger
           @plugin.check_podfile_does_not_have_branch_references
 
           expected_message = "Podfile reference(s) to a branch:\n```Kingfisher (from `https://github.com/onevcat/Kingfisher.git`, branch `main`)```"
-          expect(@dangerfile.status_report[:errors]).to eq [expected_message]
+          expect(@dangerfile).to report_errors([expected_message])
         end
 
         it 'returns the right errors when there are multiple podfile dependencies referencing a branch' do
@@ -400,7 +400,7 @@ module Danger
             SwiftGen (from `https://github.com/SwiftGen/SwiftGen.git`, branch `test/a-test-branch`)
             SwiftLint (from `https://github.com/realm/SwiftLint.git`, branch `feature-branch`)```
           MESSAGE
-          expect(@dangerfile.status_report[:errors]).to eq [expected_message]
+          expect(@dangerfile).to report_errors([expected_message])
         end
 
         it 'returns no error when there are no Podfile dependency references to a branch' do
@@ -442,7 +442,7 @@ module Danger
 
           @plugin.check_podfile_does_not_have_branch_references
 
-          expect(@dangerfile.status_report[:errors]).to be_empty
+          expect(@dangerfile).to not_report
         end
       end
 
@@ -528,7 +528,7 @@ module Danger
             ```
           WARNING
 
-          expect(@dangerfile.status_report[:warnings]).to contain_exactly(expected_warning, expected_warning2)
+          expect(@dangerfile).to report_warnings([expected_warning, expected_warning2])
         end
 
         it 'does nothing when a PR removes Podfile.lock branch references' do
@@ -588,7 +588,7 @@ module Danger
 
           @plugin.check_podfile_diff_does_not_have_branch_references
 
-          expect(@dangerfile.status_report[:warnings]).to be_empty
+          expect(@dangerfile).to not_report
         end
       end
     end


### PR DESCRIPTION
Our new libraries workflow expects developers to reference pods by commit and recommends not merging pods referencing a branch into `trunk`. More details at paNNhX-K4-p2.

At this time, our Danger checks prevent merging PR with pods referenced by commit while allowing merges with pods referencing branches.

This PR replicates the existing `check_podfile_does_not_have_commit_references` `check_podfile_diff_does_not_have_commit_references` but for branch references. I decided to add new methods instead of modifying the existing ones because it felt appropriate for the tool at this level to keep both options available, even though effectively we'll be using only one for the time being. As I write this, I also realize removing the existing methods would have counted as a breaking change, but the thought didn't occur at the time of developing 😅 

On top of the unit tests, I tested this live via https://github.com/wordpress-mobile/WordPress-iOS/pull/22081

See also https://github.com/Automattic/peril-settings/pull/118