### PR TITLE
Reusable workflow for running Danger via GitHub Actions

### DIFF
--- a/.github/workflows/reusable-run-danger.yml
+++ b/.github/workflows/reusable-run-danger.yml
@@ -1,0 +1,34 @@
+on:
+  workflow_call:
+    inputs:
+      remove-previous-comments:
+        description: 'Configures Danger to always remove previous comments and add a new one instead of editing the same comment.'
+        default: true
+        type: boolean
+        required: false
+    secrets:
+      github-token:
+        required: true
+
+concurrency:
+  group: danger-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  dangermattic:
+    runs-on: ubuntu-latest
+    steps:
+      - name: "📥 Checkout Repo"
+        uses: actions/checkout@v4
+      - name: "💎 Ruby Setup"
+        uses: ruby/setup-ruby@v1
+        with:
+          bundler-cache: true
+      - name: "☢️ Danger PR Check"
+        env:
+          REMOVE_PREVIOUS_COMMENTS: ${{ inputs.remove-previous-comments }}
+          DANGER_GITHUB_API_TOKEN: ${{ secrets.github-token }}
+        run: |
+          echo "--- 🏃 Running Danger: PR Check"
+          bundle exec danger --fail-on-errors=true ${REMOVE_PREVIOUS_COMMENTS:+--remove-previous-comments} --danger_id=pr-check
+

--- a/.github/workflows/reusable-run-danger.yml
+++ b/.github/workflows/reusable-run-danger.yml
@@ -20,6 +20,8 @@ jobs:
     steps:
       - name: "📥 Checkout Repo"
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 100
       - name: "💎 Ruby Setup"
         uses: ruby/setup-ruby@v1
         with:


### PR DESCRIPTION
This PR implements a reusable workflow for running Danger on PRs, so that repos using Danger can do so with minimal configuration.
The job on the repo should be configured to run at every commit (`synchronize` event) as well as on the desired PR events, such as `labeled`, `milestoned`, etc.
This is a PR in a repo adopting the present reusable workflow solution: https://github.com/woocommerce/woocommerce-android/pull/10483

## How to test
The best way to test this is to use the workflow in another repo, such as the mentioned above.