### PR TITLE
Exclude specs from the `Metrics/ModuleLength` linter

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -39,6 +39,8 @@ Metrics/MethodLength:
 
 Metrics/ModuleLength:
   Max: 300
+  Exclude:
+    - spec/**/*_spec.rb
 
 Metrics/ParameterLists:
   Max: 10

--- a/spec/podfile_checks_spec.rb
+++ b/spec/podfile_checks_spec.rb
@@ -2,7 +2,6 @@
 
 require_relative 'spec_helper'
 
-# rubocop:disable Metrics/ModuleLength
 module Danger
   describe Danger::PodfileChecks do
     it 'is a plugin' do
@@ -594,4 +593,3 @@ module Danger
     end
   end
 end
-# rubocop:enable Metrics/ModuleLength


### PR DESCRIPTION
Specs can be verbose and end up being quite long, but that's not a problem in the context of unit tests. 

That's not to say we should not strive to keep our tests readable and tidy, but their maintainability depends less on line length (a rough metric, anyways) than the production code does.