### PR TITLE
Error reporting consistency

### DIFF
--- a/lib/dangermattic/plugins/android_release_checker.rb
+++ b/lib/dangermattic/plugins/android_release_checker.rb
@@ -14,6 +14,7 @@ module Danger
   #
   class AndroidReleaseChecker < Plugin
     STRINGS_FILE = 'strings.xml'
+    MESSAGE_STRINGS_FILE_UPDATED = "`#{STRINGS_FILE}` files should only be updated on release branches, when the translations are downloaded by our automation.".freeze
 
     # Checks if changes made to the release notes are also followed by changes in the Play Store strings file.
     #
@@ -31,7 +32,7 @@ module Danger
     def check_modified_strings_on_release(fail_on_error: false)
       common_release_checker.check_file_changed(
         file_comparison: ->(path) { File.basename(path) == STRINGS_FILE },
-        message: "`#{STRINGS_FILE}` files should only be updated on release branches, when the translations are downloaded by our automation.",
+        message: MESSAGE_STRINGS_FILE_UPDATED,
         on_release_branch: false,
         fail_on_error: fail_on_error
       )

--- a/lib/dangermattic/plugins/android_strings_checker.rb
+++ b/lib/dangermattic/plugins/android_strings_checker.rb
@@ -11,17 +11,17 @@ module Danger
   # @tags android, localization
   #
   class AndroidStringsChecker < Plugin
+    MESSAGE = "This PR adds a translatable entry which references another string resource; this usually causes issues with translations.\n" \
+              'Please make sure to set the `translatable="false"` attribute:'
+
     # Check if translatable strings reference another string resource in 'strings.xml' files in a pull request.
     #
     # @return [void]
     def check_strings_do_not_refer_resource
-      warning_message = "This PR adds a translatable entry which references another string resource; this usually causes issues with translations.\n" \
-                        'Please make sure to set the `translatable="false"` attribute:'
-
       git_utils.check_added_diff_lines(
         file_selector: ->(path) { File.basename(path) == 'strings.xml' },
         line_matcher: ->(line) { line.include?('@string/') && !line.include?('translatable="false"') },
-        message: warning_message
+        message: MESSAGE
       )
     end
   end

--- a/lib/dangermattic/plugins/android_strings_checker.rb
+++ b/lib/dangermattic/plugins/android_strings_checker.rb
@@ -12,7 +12,7 @@ module Danger
   #
   class AndroidStringsChecker < Plugin
     MESSAGE = "This PR adds a translatable entry which references another string resource; this usually causes issues with translations.\n" \
-              'Please make sure to set the `translatable="false"` attribute:'
+              'Please make sure to set the `translatable="false"` attribute.'
 
     # Check if translatable strings reference another string resource in 'strings.xml' files in a pull request.
     #

--- a/lib/dangermattic/plugins/common/common_release_checker.rb
+++ b/lib/dangermattic/plugins/common/common_release_checker.rb
@@ -26,7 +26,7 @@ module Danger
   class CommonReleaseChecker < Plugin
     DEFAULT_INTERNAL_RELEASE_NOTES = 'RELEASE-NOTES.txt'
 
-    MESSAGE_STORE_FILE_NOT_CHANGED = 'The `%s` file should be updated if the editorialised release notes file `%s` is being changed.'
+    MESSAGE_STORE_FILE_NOT_CHANGED = 'The `%s` file should be updated if the editorialized release notes file `%s` is being changed.'
     MESSAGE_INTERNAL_RELEASE_NOTES_CHANGED = <<~WARNING
       This PR contains changes to `%s`.
       Note that these changes won't affect the final version of the release notes as this version is in code freeze.

--- a/lib/dangermattic/plugins/common/common_release_checker.rb
+++ b/lib/dangermattic/plugins/common/common_release_checker.rb
@@ -26,6 +26,13 @@ module Danger
   class CommonReleaseChecker < Plugin
     DEFAULT_INTERNAL_RELEASE_NOTES = 'RELEASE-NOTES.txt'
 
+    MESSAGE_STORE_FILE_NOT_CHANGED = 'The `%s` file should be updated if the editorialised release notes file `%s` is being changed.'
+    MESSAGE_INTERNAL_RELEASE_NOTES_CHANGED = <<~WARNING
+      This PR contains changes to `%s`.
+      Note that these changes won't affect the final version of the release notes as this version is in code freeze.
+      Please, get in touch with a release manager if you want to update the final release notes.
+    WARNING
+
     # Check if certain files have been modified, returning a warning or failure message based on the branch type.
     #
     # @param file_comparison [Proc] Function used to compare modified file paths.
@@ -82,8 +89,7 @@ module Danger
 
       return unless has_modified_release_notes && !has_modified_app_store_strings
 
-      report_message = "The `#{po_file}` file should be updated if the editorialised release notes file `#{release_notes_file}` is being changed."
-      message(report_message)
+      message(format(MESSAGE_STORE_FILE_NOT_CHANGED, po_file, release_notes_file))
     end
 
     # Check if there are changes to the internal release notes file in the release branch and emit a warning if that's the case.
@@ -99,15 +105,9 @@ module Danger
     #
     # @return [void]
     def check_internal_release_notes_changed(release_notes_file: DEFAULT_INTERNAL_RELEASE_NOTES)
-      warning = <<~WARNING
-        This PR contains changes to `#{release_notes_file}`.
-        Note that these changes won't affect the final version of the release notes as this version is in code freeze.
-        Please, get in touch with a release manager if you want to update the final release notes.
-      WARNING
-
       check_file_changed(
         file_comparison: ->(path) { path == release_notes_file },
-        message: warning,
+        message: format(MESSAGE_INTERNAL_RELEASE_NOTES_CHANGED, release_notes_file),
         on_release_branch: true,
         fail_on_error: false
       )

--- a/lib/dangermattic/plugins/ios_release_checker.rb
+++ b/lib/dangermattic/plugins/ios_release_checker.rb
@@ -19,16 +19,19 @@ module Danger
     LOCALIZABLE_STRINGS_FILE = 'Localizable.strings'
     BASE_STRINGS_FILE = "en.lproj/#{LOCALIZABLE_STRINGS_FILE}".freeze
 
+    MESSAGE_STRINGS_FILE_UPDATED = "The `#{LOCALIZABLE_STRINGS_FILE}` files should only be updated on release branches, when the translations are downloaded by our automation.".freeze
+    MESSAGE_BASE_STRINGS_FILE_UPDATED = "The `#{BASE_STRINGS_FILE}` file should only be updated before creating a release branch.".freeze
+    MESSAGE_TRANSLATION_FILE_UPDATED = "Translation files `*.lproj/#{LOCALIZABLE_STRINGS_FILE}` should only be updated on a release branch.".freeze
+    MESSAGE_CORE_DATA_UPDATED = 'Do not edit an existing Core Data model in a release branch unless it hasn\'t been released to testers yet. ' \
+                                'Instead create a new model version and merge back to develop soon.'
+
     # Checks if an existing Core Data model has been edited in a release branch.
     #
     # @return [void]
     def check_core_data_model_changed
-      warning = 'Do not edit an existing Core Data model in a release branch unless it hasn\'t been released to testers yet. ' \
-                'Instead create a new model version and merge back to develop soon.'
-
       common_release_checker.check_file_changed(
         file_comparison: ->(path) { File.extname(path) == '.xcdatamodeld' },
-        message: warning,
+        message: MESSAGE_CORE_DATA_UPDATED,
         on_release_branch: true
       )
     end
@@ -39,7 +42,7 @@ module Danger
     def check_modified_localizable_strings_on_release
       common_release_checker.check_file_changed(
         file_comparison: ->(path) { File.basename(path) == LOCALIZABLE_STRINGS_FILE },
-        message: "The `#{LOCALIZABLE_STRINGS_FILE}` files should only be updated on release branches, when the translations are downloaded by our automation.",
+        message: MESSAGE_STRINGS_FILE_UPDATED,
         on_release_branch: false
       )
     end
@@ -50,7 +53,7 @@ module Danger
     def check_modified_en_strings_on_regular_branch
       common_release_checker.check_file_changed(
         file_comparison: ->(path) { base_strings_file?(path: path) },
-        message: "The `#{BASE_STRINGS_FILE}` file should only be updated before creating a release branch.",
+        message: MESSAGE_BASE_STRINGS_FILE_UPDATED,
         on_release_branch: true
       )
     end
@@ -61,7 +64,7 @@ module Danger
     def check_modified_translations_on_release_branch
       common_release_checker.check_file_changed(
         file_comparison: ->(path) { !base_strings_file?(path: path) && File.basename(path) == LOCALIZABLE_STRINGS_FILE },
-        message: "Translation files `*.lproj/#{LOCALIZABLE_STRINGS_FILE}` should only be updated on a release branch.",
+        message: MESSAGE_TRANSLATION_FILE_UPDATED,
         on_release_branch: false
       )
     end

--- a/lib/dangermattic/plugins/manifest_pr_checker.rb
+++ b/lib/dangermattic/plugins/manifest_pr_checker.rb
@@ -28,6 +28,8 @@ module Danger
   # @tags ios, android
   #
   class ManifestPRChecker < Plugin
+    MESSAGE = '`%s` was changed without updating its corresponding `%s`. %s.'
+
     # Performs all the checks, asserting that changes on `Gemfile`, `Podfile` and `Package.swift` must have corresponding
     # lock file changes.
     #
@@ -82,7 +84,7 @@ module Danger
         lockfile_modified = git.modified_files.any? { |f| File.dirname(f) == File.dirname(manifest_file) && File.basename(f) == lock_file_name }
         next if lockfile_modified
 
-        warn("`#{manifest_file}` was changed without updating its corresponding `#{lock_file_name}`. #{instruction}.")
+        warn(format(MESSAGE, manifest_file, lock_file_name, instruction))
       end
     end
   end

--- a/lib/dangermattic/plugins/view_changes_checker.rb
+++ b/lib/dangermattic/plugins/view_changes_checker.rb
@@ -21,6 +21,9 @@ module Danger
       /<img\s+[^>]*src\s*=\s*[^>]*>/
     ].freeze
 
+    MESSAGE = 'View files have been modified, but no screenshot is included in the pull request. ' \
+              'Consider adding some for clarity.'
+
     # Checks if view files have been modified and if a screenshot is included in the pull request body,
     # displaying a warning if view files have been modified but no screenshot is included.
     #
@@ -34,9 +37,7 @@ module Danger
         github.pr_body =~ pattern
       end
 
-      warning = 'View files have been modified, but no screenshot is included in the pull request. ' \
-                'Consider adding some for clarity.'
-      warn(warning) if view_files_modified && !pr_has_screenshots
+      warn(MESSAGE) if view_files_modified && !pr_has_screenshots
     end
   end
 end

--- a/spec/android_release_checker_spec.rb
+++ b/spec/android_release_checker_spec.rb
@@ -22,7 +22,7 @@ module Danger
 
           @plugin.check_release_notes_and_play_store_strings
 
-          expect(@dangerfile).to report_messages(['The `metadata/PlayStoreStrings.po` file should be updated if the editorialised release notes file `metadata/release_notes.txt` is being changed.'])
+          expect(@dangerfile).to report_messages([format(CommonReleaseChecker::MESSAGE_STORE_FILE_NOT_CHANGED, 'metadata/PlayStoreStrings.po', 'metadata/release_notes.txt')])
         end
 
         it 'does nothing when a PR changes the release notes and the AppStore strings file' do
@@ -49,8 +49,7 @@ module Danger
 
           @plugin.check_modified_strings_on_release
 
-          expected_message = '`strings.xml` files should only be updated on release branches, when the translations are downloaded by our automation.'
-          expect(@dangerfile).to report_warnings([expected_message])
+          expect(@dangerfile).to report_warnings([AndroidReleaseChecker::MESSAGE_STRINGS_FILE_UPDATED])
         end
 
         it 'reports an error when a PR on a regular branch changes the source strings.xml' do
@@ -59,8 +58,7 @@ module Danger
 
           @plugin.check_modified_strings_on_release(fail_on_error: true)
 
-          expected_message = '`strings.xml` files should only be updated on release branches, when the translations are downloaded by our automation.'
-          expect(@dangerfile).to report_errors([expected_message])
+          expect(@dangerfile).to report_errors([AndroidReleaseChecker::MESSAGE_STRINGS_FILE_UPDATED])
         end
 
         it 'reports a warning when a PR on a regular branch changes a translated strings.xml' do
@@ -69,8 +67,7 @@ module Danger
 
           @plugin.check_modified_strings_on_release
 
-          expected_message = '`strings.xml` files should only be updated on release branches, when the translations are downloaded by our automation.'
-          expect(@dangerfile).to report_warnings([expected_message])
+          expect(@dangerfile).to report_warnings([AndroidReleaseChecker::MESSAGE_STRINGS_FILE_UPDATED])
         end
 
         it 'does nothing when a PR changes the strings.xml on a release branch' do

--- a/spec/android_strings_checker_spec.rb
+++ b/spec/android_strings_checker_spec.rb
@@ -19,7 +19,7 @@ module Danger
       end
 
       context 'when changing strings.xml files' do
-        it 'returns a warning when a PR adds a string resource reference inside a strings.xml file' do
+        it 'reports a warning when a PR adds a string resource reference inside a strings.xml file' do
           strings_xml_path = './src/main/res/values/strings.xml'
           allow(@plugin.git).to receive(:modified_files).and_return([strings_xml_path])
 
@@ -55,7 +55,7 @@ module Danger
           expect(@dangerfile).to report_warnings([expected_warning])
         end
 
-        it 'returns multiple warnings when a PR adds multiple string resource references inside multiple strings.xml files' do
+        it 'reports multiple warnings when a PR adds multiple string resource references inside multiple strings.xml files' do
           main_strings_xml = './src/main/res/values/strings.xml'
           ptbr_strings_xml = './src/main/res/values-pt-rBR/strings.xml'
           strings_xml_paths = [main_strings_xml, ptbr_strings_xml]

--- a/spec/android_strings_checker_spec.rb
+++ b/spec/android_strings_checker_spec.rb
@@ -52,7 +52,7 @@ module Danger
             ```
           WARNING
 
-          expect(@dangerfile.status_report[:warnings]).to eq [expected_warning]
+          expect(@dangerfile).to report_warnings([expected_warning])
         end
 
         it 'returns multiple warnings when a PR adds multiple string resource references inside multiple strings.xml files' do
@@ -155,7 +155,7 @@ module Danger
 
           @plugin.check_strings_do_not_refer_resource
 
-          expect(@dangerfile.status_report[:warnings]).to be_empty
+          expect(@dangerfile).to not_report
         end
 
         it 'does nothing when a PR adds strings without resource references' do
@@ -181,7 +181,7 @@ module Danger
 
           @plugin.check_strings_do_not_refer_resource
 
-          expect(@dangerfile.status_report[:warnings]).to be_empty
+          expect(@dangerfile).to not_report
         end
       end
     end

--- a/spec/android_strings_checker_spec.rb
+++ b/spec/android_strings_checker_spec.rb
@@ -44,8 +44,7 @@ module Danger
           @plugin.check_strings_do_not_refer_resource
 
           expected_warning = <<~WARNING
-            This PR adds a translatable entry which references another string resource; this usually causes issues with translations.
-            Please make sure to set the `translatable="false"` attribute:
+            #{AndroidStringsChecker::MESSAGE}
             File `#{strings_xml_path}`:
             ```diff
             +  <string name="screen_title">@string/app_name</string>
@@ -102,8 +101,7 @@ module Danger
           @plugin.check_strings_do_not_refer_resource
 
           expected_warning = <<~WARNING
-            This PR adds a translatable entry which references another string resource; this usually causes issues with translations.
-            Please make sure to set the `translatable="false"` attribute:
+            #{AndroidStringsChecker::MESSAGE}
             File `#{main_strings_xml}`:
             ```diff
             +  <string name="screen_title">@string/app_name</string>
@@ -111,8 +109,7 @@ module Danger
           WARNING
 
           expected_warning2 = <<~WARNING
-            This PR adds a translatable entry which references another string resource; this usually causes issues with translations.
-            Please make sure to set the `translatable="false"` attribute:
+            #{AndroidStringsChecker::MESSAGE}
             File `#{main_strings_xml}`:
             ```diff
             +  <string name="screen_button">@string/button</string>
@@ -120,8 +117,7 @@ module Danger
           WARNING
 
           expected_warning3 = <<~WARNING
-            This PR adds a translatable entry which references another string resource; this usually causes issues with translations.
-            Please make sure to set the `translatable="false"` attribute:
+            #{AndroidStringsChecker::MESSAGE}
             File `#{ptbr_strings_xml}`:
             ```diff
             +  <string name="popup_title">@string/app_name_title</string>

--- a/spec/android_unit_test_checker_spec.rb
+++ b/spec/android_unit_test_checker_spec.rb
@@ -65,7 +65,7 @@ module Danger
 
         @plugin.check_missing_tests
 
-        expect(@dangerfile.status_report[:errors]).to be_empty
+        expect(@dangerfile).to not_report
       end
 
       it 'does not report errors when we are deleting classes' do
@@ -80,7 +80,7 @@ module Danger
 
         @plugin.check_missing_tests
 
-        expect(@dangerfile.status_report[:errors]).to be_empty
+        expect(@dangerfile).to not_report
       end
 
       it 'reports errors when we remove test classes for classes we refactored' do
@@ -122,7 +122,7 @@ module Danger
 
         @plugin.check_missing_tests
 
-        expect(@dangerfile.status_report[:errors]).to be_empty
+        expect(@dangerfile).to not_report
       end
 
       it 'does nothing when a PR adds classes that dont need tests' do
@@ -141,7 +141,7 @@ module Danger
 
         @plugin.check_missing_tests
 
-        expect(@dangerfile.status_report[:errors]).to be_empty
+        expect(@dangerfile).to not_report
       end
 
       it 'does not report that a PR with the tests bypass label is missing tests' do
@@ -281,7 +281,7 @@ module Danger
 
         @plugin.check_missing_tests
 
-        expect(@dangerfile.status_report[:errors]).to be_empty
+        expect(@dangerfile).to not_report
       end
     end
 

--- a/spec/common_release_checker_spec.rb
+++ b/spec/common_release_checker_spec.rb
@@ -30,7 +30,7 @@ module Danger
             Please, get in touch with a release manager if you want to update the final release notes.
           WARNING
 
-          expect(@dangerfile.status_report[:warnings]).to eq [expected_message]
+          expect(@dangerfile).to report_warnings([expected_message])
         end
 
         it 'reports a warning when a PR on a release branch changes the internal release notes using a custom filename' do
@@ -46,7 +46,7 @@ module Danger
             Please, get in touch with a release manager if you want to update the final release notes.
           WARNING
 
-          expect(@dangerfile.status_report[:warnings]).to eq [expected_message]
+          expect(@dangerfile).to report_warnings([expected_message])
         end
 
         it 'does nothing when a PR changes the release notes file on a regular branch' do
@@ -55,7 +55,7 @@ module Danger
 
           @plugin.check_internal_release_notes_changed
 
-          expect(@dangerfile.status_report[:warnings]).to be_empty
+          expect(@dangerfile).to not_report
         end
 
         it 'does nothing when a PR changes a custom release notes file on a regular branch' do
@@ -65,7 +65,7 @@ module Danger
 
           @plugin.check_internal_release_notes_changed(release_notes_file: notes_file)
 
-          expect(@dangerfile.status_report[:warnings]).to be_empty
+          expect(@dangerfile).to not_report
         end
 
         it 'does nothing when a PR ca warning when a PR does not change the release notes file on the release branch' do
@@ -74,7 +74,7 @@ module Danger
 
           @plugin.check_internal_release_notes_changed
 
-          expect(@dangerfile.status_report[:warnings]).to be_empty
+          expect(@dangerfile).to not_report
         end
       end
     end

--- a/spec/common_release_checker_spec.rb
+++ b/spec/common_release_checker_spec.rb
@@ -24,13 +24,7 @@ module Danger
 
           @plugin.check_internal_release_notes_changed
 
-          expected_message = <<~WARNING
-            This PR contains changes to `#{notes_file}`.
-            Note that these changes won't affect the final version of the release notes as this version is in code freeze.
-            Please, get in touch with a release manager if you want to update the final release notes.
-          WARNING
-
-          expect(@dangerfile).to report_warnings([expected_message])
+          expect(@dangerfile).to report_warnings([format(CommonReleaseChecker::MESSAGE_INTERNAL_RELEASE_NOTES_CHANGED, notes_file)])
         end
 
         it 'reports a warning when a PR on a release branch changes the internal release notes using a custom filename' do
@@ -40,13 +34,7 @@ module Danger
 
           @plugin.check_internal_release_notes_changed(release_notes_file: notes_file)
 
-          expected_message = <<~WARNING
-            This PR contains changes to `#{notes_file}`.
-            Note that these changes won't affect the final version of the release notes as this version is in code freeze.
-            Please, get in touch with a release manager if you want to update the final release notes.
-          WARNING
-
-          expect(@dangerfile).to report_warnings([expected_message])
+          expect(@dangerfile).to report_warnings([format(CommonReleaseChecker::MESSAGE_INTERNAL_RELEASE_NOTES_CHANGED, notes_file)])
         end
 
         it 'does nothing when a PR changes the release notes file on a regular branch' do

--- a/spec/ios_release_checker_spec.rb
+++ b/spec/ios_release_checker_spec.rb
@@ -23,9 +23,7 @@ module Danger
 
           @plugin.check_core_data_model_changed
 
-          expected_message = 'Do not edit an existing Core Data model in a release branch unless it hasn\'t been released to testers yet. ' \
-                             'Instead create a new model version and merge back to develop soon.'
-          expect(@dangerfile).to report_warnings([expected_message])
+          expect(@dangerfile).to report_warnings([IosReleaseChecker::MESSAGE_CORE_DATA_UPDATED])
         end
 
         it 'does nothing when a PR changes a Core Data model on a regular branch' do
@@ -55,8 +53,7 @@ module Danger
 
             @plugin.check_modified_localizable_strings_on_release
 
-            expected_message = 'The `Localizable.strings` files should only be updated on release branches, when the translations are downloaded by our automation.'
-            expect(@dangerfile).to report_warnings([expected_message])
+            expect(@dangerfile).to report_warnings([IosReleaseChecker::MESSAGE_STRINGS_FILE_UPDATED])
           end
 
           it 'reports a warning when a PR on a regular branch changes a translated Localizable.strings' do
@@ -65,8 +62,7 @@ module Danger
 
             @plugin.check_modified_localizable_strings_on_release
 
-            expected_message = 'The `Localizable.strings` files should only be updated on release branches, when the translations are downloaded by our automation.'
-            expect(@dangerfile).to report_warnings([expected_message])
+            expect(@dangerfile).to report_warnings([IosReleaseChecker::MESSAGE_STRINGS_FILE_UPDATED])
           end
 
           it 'does nothing when a PR changes the Localizable.strings on a release branch' do
@@ -95,8 +91,7 @@ module Danger
 
             @plugin.check_modified_en_strings_on_regular_branch
 
-            expected_message = 'The `en.lproj/Localizable.strings` file should only be updated before creating a release branch.'
-            expect(@dangerfile).to report_warnings([expected_message])
+            expect(@dangerfile).to report_warnings([IosReleaseChecker::MESSAGE_BASE_STRINGS_FILE_UPDATED])
           end
 
           it 'does nothing when a PR changes the Localizable.strings on a regular branch' do
@@ -134,8 +129,7 @@ module Danger
 
             @plugin.check_modified_translations_on_release_branch
 
-            expected_message = 'Translation files `*.lproj/Localizable.strings` should only be updated on a release branch.'
-            expect(@dangerfile).to report_warnings([expected_message])
+            expect(@dangerfile).to report_warnings([IosReleaseChecker::MESSAGE_TRANSLATION_FILE_UPDATED])
           end
 
           it 'does nothing when a PR changes a translation string on a release branch' do
@@ -173,7 +167,7 @@ module Danger
 
           @plugin.check_release_notes_and_app_store_strings
 
-          expect(@dangerfile).to report_messages(['The `Resources/AppStoreStrings.po` file should be updated if the editorialised release notes file `Resources/release_notes.txt` is being changed.'])
+          expect(@dangerfile).to report_messages([format(CommonReleaseChecker::MESSAGE_STORE_FILE_NOT_CHANGED, 'Resources/AppStoreStrings.po', 'Resources/release_notes.txt')])
         end
 
         it 'does nothing when a PR changes the release notes and the AppStore strings file' do

--- a/spec/labels_checker_spec.rb
+++ b/spec/labels_checker_spec.rb
@@ -21,8 +21,7 @@ module Danger
           error = 'PR is missing at least one label.'
           @plugin.check(required_labels: [//], required_labels_error: error)
 
-          expect(@dangerfile.status_report[:warnings]).to be_empty
-          expect(@dangerfile.status_report[:errors]).to eq([error])
+          expect(@dangerfile).to report_errors([error])
         end
 
         it 'does nothing when a PR has at least one label' do
@@ -31,8 +30,7 @@ module Danger
 
           @plugin.check(required_labels: [//])
 
-          expect(@dangerfile.status_report[:errors]).to be_empty
-          expect(@dangerfile.status_report[:warnings]).to be_empty
+          expect(@dangerfile).to not_report
         end
 
         it 'returns an error containing the required labels when a PR does not meet the label requirements' do
@@ -43,8 +41,7 @@ module Danger
             required_labels: [/^\[feature\]/, /^\[type\]:/]
           )
 
-          expect(@dangerfile.status_report[:warnings]).to be_empty
-          expect(@dangerfile.status_report[:errors]).to eq(['PR is missing label(s) matching: `^\[type\]:`'])
+          expect(@dangerfile).to report_errors(['PR is missing label(s) matching: `^\[type\]:`'])
         end
 
         it 'returns a custom error when a PR has custom label requirements' do
@@ -58,8 +55,7 @@ module Danger
             required_labels_error: custom_labels_error
           )
 
-          expect(@dangerfile.status_report[:warnings]).to be_empty
-          expect(@dangerfile.status_report[:errors]).to eq([custom_labels_error])
+          expect(@dangerfile).to report_errors([custom_labels_error])
         end
 
         it 'does nothing when custom required labels are correctly set in the PR' do
@@ -76,8 +72,7 @@ module Danger
             required_labels: [/^feature:/, /^type:/]
           )
 
-          expect(@dangerfile.status_report[:errors]).to be_empty
-          expect(@dangerfile.status_report[:warnings]).to be_empty
+          expect(@dangerfile).to not_report
         end
       end
 
@@ -90,8 +85,7 @@ module Danger
             recommended_labels: [/^feature:/, /^milestone:/, /^\[type\]/]
           )
 
-          expect(@dangerfile.status_report[:errors]).to be_empty
-          expect(@dangerfile.status_report[:warnings]).to eq(['PR is missing label(s) matching: `^feature:`, `^\[type\]`'])
+          expect(@dangerfile).to report_warnings(['PR is missing label(s) matching: `^feature:`, `^\[type\]`'])
         end
 
         it 'returns a custom warning when a PR has custom label requirements' do
@@ -105,8 +99,7 @@ module Danger
             recommended_labels_warning: custom_labels_warning
           )
 
-          expect(@dangerfile.status_report[:errors]).to be_empty
-          expect(@dangerfile.status_report[:warnings]).to eq([custom_labels_warning])
+          expect(@dangerfile).to report_warnings([custom_labels_warning])
         end
 
         it 'does nothing when custom recommended labels are correctly set in the PR' do
@@ -122,8 +115,7 @@ module Danger
             recommended_labels: [/^\[feature\]:/, /^\[type\]:/]
           )
 
-          expect(@dangerfile.status_report[:warnings]).to be_empty
-          expect(@dangerfile.status_report[:errors]).to be_empty
+          expect(@dangerfile).to not_report
         end
       end
 
@@ -134,8 +126,7 @@ module Danger
 
           @plugin.check
 
-          expect(@dangerfile.status_report[:warnings]).to be_empty
-          expect(@dangerfile.status_report[:errors]).to eq(["This PR is tagged with `#{pr_label}` label(s)."])
+          expect(@dangerfile).to report_errors(["This PR is tagged with `#{pr_label}` label(s)."])
         end
 
         it 'returns an error when a PR has a custom label for not merging' do
@@ -147,8 +138,7 @@ module Danger
             do_not_merge_labels: labels
           )
 
-          expect(@dangerfile.status_report[:warnings]).to be_empty
-          expect(@dangerfile.status_report[:errors]).to eq(["This PR is tagged with `#{pr_label}` label(s)."])
+          expect(@dangerfile).to report_errors(["This PR is tagged with `#{pr_label}` label(s)."])
         end
       end
 

--- a/spec/labels_checker_spec.rb
+++ b/spec/labels_checker_spec.rb
@@ -15,7 +15,7 @@ module Danger
       end
 
       context 'with required labels' do
-        it 'returns a custom error when a PR does not have at least one label' do
+        it 'reports a custom error when a PR does not have at least one label' do
           allow(@plugin.github).to receive(:pr_labels).and_return([])
 
           error = 'PR is missing at least one label.'
@@ -33,7 +33,7 @@ module Danger
           expect(@dangerfile).to not_report
         end
 
-        it 'returns an error containing the required labels when a PR does not meet the label requirements' do
+        it 'reports an error containing the required labels when a PR does not meet the label requirements' do
           pr_labels = ['random other label', '[feature] magic', 'wizard needed', 'type: fantasy']
           allow(@plugin.github).to receive(:pr_labels).and_return(pr_labels)
 
@@ -44,7 +44,7 @@ module Danger
           expect(@dangerfile).to report_errors(['PR is missing label(s) matching: `^\[type\]:`'])
         end
 
-        it 'returns a custom error when a PR has custom label requirements' do
+        it 'reports a custom error when a PR has custom label requirements' do
           pr_labels = ['random label', 'feature: magic', 'wizard needed', 'another type: test']
           allow(@plugin.github).to receive(:pr_labels).and_return(pr_labels)
 
@@ -77,7 +77,7 @@ module Danger
       end
 
       context 'with recommended labels' do
-        it 'returns a warning containing the recommended labels when a PR does not meet the label requirements' do
+        it 'reports a warning containing the recommended labels when a PR does not meet the label requirements' do
           pr_labels = ['random other label', 'milestone: rc']
           allow(@plugin.github).to receive(:pr_labels).and_return(pr_labels)
 
@@ -88,7 +88,7 @@ module Danger
           expect(@dangerfile).to report_warnings(['PR is missing label(s) matching: `^feature:`, `^\[type\]`'])
         end
 
-        it 'returns a custom warning when a PR has custom label requirements' do
+        it 'reports a custom warning when a PR has custom label requirements' do
           pr_labels = ['random other label', 'feature: myFeature', 'Milestone: beta']
           allow(@plugin.github).to receive(:pr_labels).and_return(pr_labels)
 
@@ -120,7 +120,7 @@ module Danger
       end
 
       context 'with \'do not merge\' labels' do
-        it 'returns an error when a PR has a \'do not merge\' label' do
+        it 'reports an error when a PR has a \'do not merge\' label' do
           pr_label = 'DO NOT MERGE'
           allow(@plugin.github).to receive(:pr_labels).and_return([pr_label])
 
@@ -129,7 +129,7 @@ module Danger
           expect(@dangerfile).to report_errors(["This PR is tagged with `#{pr_label}` label(s)."])
         end
 
-        it 'returns an error when a PR has a custom label for not merging' do
+        it 'reports an error when a PR has a custom label for not merging' do
           pr_label = 'please dont merge'
           allow(@plugin.github).to receive(:pr_labels).and_return([pr_label])
 
@@ -142,7 +142,7 @@ module Danger
         end
       end
 
-      it 'returns the right errors and warning when combining the check parameters' do
+      it 'reports the right errors and warning when combining the check parameters' do
         do_not_merge_label = 'blocked'
         pr_labels = [do_not_merge_label, 'type: test', 'milestone: alpha']
         allow(@plugin.github).to receive(:pr_labels).and_return(pr_labels)

--- a/spec/manifest_pr_checker_spec.rb
+++ b/spec/manifest_pr_checker_spec.rb
@@ -15,7 +15,7 @@ module Danger
       end
 
       describe 'Bundler' do
-        it 'returns a warning when a PR changed the Gemfile but not the Gemfile.lock' do
+        it 'reports a warning when a PR changed the Gemfile but not the Gemfile.lock' do
           modified_files = ['Gemfile']
           allow(@plugin.git).to receive(:modified_files).and_return(modified_files)
 
@@ -25,7 +25,7 @@ module Danger
           expect(@dangerfile).to report_warnings([expected_warning])
         end
 
-        it 'returns no warnings when both the Gemfile and the Gemfile.lock were updated' do
+        it 'reports no warnings when both the Gemfile and the Gemfile.lock were updated' do
           modified_files = ['Gemfile', 'Gemfile.lock']
           allow(@plugin.git).to receive(:modified_files).and_return(modified_files)
 
@@ -34,7 +34,7 @@ module Danger
           expect(@dangerfile).to not_report
         end
 
-        it 'returns no warnings when only the Gemfile.lock was updated' do
+        it 'reports no warnings when only the Gemfile.lock was updated' do
           modified_files = ['Gemfile.lock']
           allow(@plugin.git).to receive(:modified_files).and_return(modified_files)
 
@@ -45,7 +45,7 @@ module Danger
       end
 
       describe 'CocoaPods' do
-        it 'returns a warning when a PR changed the Podfile but not the Podfile.lock' do
+        it 'reports a warning when a PR changed the Podfile but not the Podfile.lock' do
           modified_files = ['Podfile']
           allow(@plugin.git).to receive(:modified_files).and_return(modified_files)
 
@@ -55,7 +55,7 @@ module Danger
           expect(@dangerfile).to report_warnings([expected_warning])
         end
 
-        it 'returns no warnings when both the Podfile and the Podfile.lock were updated' do
+        it 'reports no warnings when both the Podfile and the Podfile.lock were updated' do
           modified_files = ['Podfile', 'Podfile.lock']
           allow(@plugin.git).to receive(:modified_files).and_return(modified_files)
 
@@ -64,7 +64,7 @@ module Danger
           expect(@dangerfile).to not_report
         end
 
-        it 'returns a warning when a PR changed a custom located Podfile but not the corresponding Podfile.lock' do
+        it 'reports a warning when a PR changed a custom located Podfile but not the corresponding Podfile.lock' do
           modified_files = ['./path/to/Podfile', './my/Podfile.lock']
           allow(@plugin.git).to receive(:modified_files).and_return(modified_files)
 
@@ -74,7 +74,7 @@ module Danger
           expect(@dangerfile).to report_warnings([expected_warning])
         end
 
-        it 'returns multiple warnings when a PR changed multiple custom located Podfiles but not the corresponding Podfile.lock' do
+        it 'reports multiple warnings when a PR changed multiple custom located Podfiles but not the corresponding Podfile.lock' do
           modified_files = ['./dir1/Podfile', './dir2/Podfile', './dir3/Podfile', './dir1/Podfile.lock']
           allow(@plugin.git).to receive(:modified_files).and_return(modified_files)
 
@@ -87,7 +87,7 @@ module Danger
           expect(@dangerfile).to report_warnings(expected_warnings)
         end
 
-        it 'returns no warnings when both custom located Podfile`s and their corresponding Podfile.lock were updated' do
+        it 'reports no warnings when both custom located Podfile`s and their corresponding Podfile.lock were updated' do
           modified_files = ['./my/path/to/Podfile', './another/path/to/Podfile', './my/path/to/Podfile.lock', './another/path/to/Podfile.lock']
           allow(@plugin.git).to receive(:modified_files).and_return(modified_files)
 
@@ -96,7 +96,7 @@ module Danger
           expect(@dangerfile).to not_report
         end
 
-        it 'returns no warnings when only the Podfile.lock was updated' do
+        it 'reports no warnings when only the Podfile.lock was updated' do
           modified_files = ['Podfile.lock']
           allow(@plugin.git).to receive(:modified_files).and_return(modified_files)
 
@@ -107,7 +107,7 @@ module Danger
       end
 
       describe 'Swift Package Manager' do
-        it 'returns a warning when a PR changed the Package.swift but not the Package.resolved' do
+        it 'reports a warning when a PR changed the Package.swift but not the Package.resolved' do
           modified_files = ['Package.swift']
           allow(@plugin.git).to receive(:modified_files).and_return(modified_files)
 
@@ -117,7 +117,7 @@ module Danger
           expect(@dangerfile).to report_warnings([expected_warning])
         end
 
-        it 'returns no warnings when both the Package.swift and the Package.resolved were updated' do
+        it 'reports no warnings when both the Package.swift and the Package.resolved were updated' do
           modified_files = ['Package.swift', 'Package.resolved']
           allow(@plugin.git).to receive(:modified_files).and_return(modified_files)
 
@@ -126,7 +126,7 @@ module Danger
           expect(@dangerfile).to not_report
         end
 
-        it 'returns no warnings when only the Package.resolved was updated' do
+        it 'reports no warnings when only the Package.resolved was updated' do
           modified_files = ['Package.resolved']
           allow(@plugin.git).to receive(:modified_files).and_return(modified_files)
 

--- a/spec/manifest_pr_checker_spec.rb
+++ b/spec/manifest_pr_checker_spec.rb
@@ -21,7 +21,7 @@ module Danger
 
           @plugin.check_gemfile_lock_updated
 
-          expected_warning = '`Gemfile` was changed without updating its corresponding `Gemfile.lock`. Please run `bundle install` or `bundle update <updated_gem>`.'
+          expected_warning = format(ManifestPRChecker::MESSAGE, 'Gemfile', 'Gemfile.lock', 'Please run `bundle install` or `bundle update <updated_gem>`')
           expect(@dangerfile).to report_warnings([expected_warning])
         end
 
@@ -51,7 +51,7 @@ module Danger
 
           @plugin.check_podfile_lock_updated
 
-          expected_warning = '`Podfile` was changed without updating its corresponding `Podfile.lock`. Please run `bundle exec pod install`.'
+          expected_warning = format(ManifestPRChecker::MESSAGE, 'Podfile', 'Podfile.lock', 'Please run `bundle exec pod install`')
           expect(@dangerfile).to report_warnings([expected_warning])
         end
 
@@ -70,7 +70,7 @@ module Danger
 
           @plugin.check_podfile_lock_updated
 
-          expected_warning = '`./path/to/Podfile` was changed without updating its corresponding `Podfile.lock`. Please run `bundle exec pod install`.'
+          expected_warning = format(ManifestPRChecker::MESSAGE, './path/to/Podfile', 'Podfile.lock', 'Please run `bundle exec pod install`')
           expect(@dangerfile).to report_warnings([expected_warning])
         end
 
@@ -81,8 +81,8 @@ module Danger
           @plugin.check_podfile_lock_updated
 
           expected_warnings = [
-            '`./dir2/Podfile` was changed without updating its corresponding `Podfile.lock`. Please run `bundle exec pod install`.',
-            '`./dir3/Podfile` was changed without updating its corresponding `Podfile.lock`. Please run `bundle exec pod install`.'
+            format(ManifestPRChecker::MESSAGE, './dir2/Podfile', 'Podfile.lock', 'Please run `bundle exec pod install`'),
+            format(ManifestPRChecker::MESSAGE, './dir3/Podfile', 'Podfile.lock', 'Please run `bundle exec pod install`')
           ]
           expect(@dangerfile).to report_warnings(expected_warnings)
         end
@@ -113,7 +113,7 @@ module Danger
 
           @plugin.check_swift_package_resolved_updated
 
-          expected_warning = '`Package.swift` was changed without updating its corresponding `Package.resolved`. Please resolve the Swift packages in Xcode.'
+          expected_warning = format(ManifestPRChecker::MESSAGE, 'Package.swift', 'Package.resolved', 'Please resolve the Swift packages in Xcode')
           expect(@dangerfile).to report_warnings([expected_warning])
         end
 

--- a/spec/manifest_pr_checker_spec.rb
+++ b/spec/manifest_pr_checker_spec.rb
@@ -21,8 +21,8 @@ module Danger
 
           @plugin.check_gemfile_lock_updated
 
-          expected_warning = ['`Gemfile` was changed without updating its corresponding `Gemfile.lock`. Please run `bundle install` or `bundle update <updated_gem>`.']
-          expect(@dangerfile.status_report[:warnings]).to eq expected_warning
+          expected_warning = '`Gemfile` was changed without updating its corresponding `Gemfile.lock`. Please run `bundle install` or `bundle update <updated_gem>`.'
+          expect(@dangerfile).to report_warnings([expected_warning])
         end
 
         it 'returns no warnings when both the Gemfile and the Gemfile.lock were updated' do
@@ -31,7 +31,7 @@ module Danger
 
           @plugin.check_gemfile_lock_updated
 
-          expect(@dangerfile.status_report[:warnings]).to be_empty
+          expect(@dangerfile).to not_report
         end
 
         it 'returns no warnings when only the Gemfile.lock was updated' do
@@ -40,7 +40,7 @@ module Danger
 
           @plugin.check_gemfile_lock_updated
 
-          expect(@dangerfile.status_report[:warnings]).to be_empty
+          expect(@dangerfile).to not_report
         end
       end
 
@@ -51,8 +51,8 @@ module Danger
 
           @plugin.check_podfile_lock_updated
 
-          expected_warning = ['`Podfile` was changed without updating its corresponding `Podfile.lock`. Please run `bundle exec pod install`.']
-          expect(@dangerfile.status_report[:warnings]).to eq expected_warning
+          expected_warning = '`Podfile` was changed without updating its corresponding `Podfile.lock`. Please run `bundle exec pod install`.'
+          expect(@dangerfile).to report_warnings([expected_warning])
         end
 
         it 'returns no warnings when both the Podfile and the Podfile.lock were updated' do
@@ -61,7 +61,7 @@ module Danger
 
           @plugin.check_podfile_lock_updated
 
-          expect(@dangerfile.status_report[:warnings]).to be_empty
+          expect(@dangerfile).to not_report
         end
 
         it 'returns a warning when a PR changed a custom located Podfile but not the corresponding Podfile.lock' do
@@ -70,8 +70,8 @@ module Danger
 
           @plugin.check_podfile_lock_updated
 
-          expected_warning = ['`./path/to/Podfile` was changed without updating its corresponding `Podfile.lock`. Please run `bundle exec pod install`.']
-          expect(@dangerfile.status_report[:warnings]).to eq expected_warning
+          expected_warning = '`./path/to/Podfile` was changed without updating its corresponding `Podfile.lock`. Please run `bundle exec pod install`.'
+          expect(@dangerfile).to report_warnings([expected_warning])
         end
 
         it 'returns multiple warnings when a PR changed multiple custom located Podfiles but not the corresponding Podfile.lock' do
@@ -84,7 +84,7 @@ module Danger
             '`./dir2/Podfile` was changed without updating its corresponding `Podfile.lock`. Please run `bundle exec pod install`.',
             '`./dir3/Podfile` was changed without updating its corresponding `Podfile.lock`. Please run `bundle exec pod install`.'
           ]
-          expect(@dangerfile.status_report[:warnings]).to eq expected_warnings
+          expect(@dangerfile).to report_warnings(expected_warnings)
         end
 
         it 'returns no warnings when both custom located Podfile`s and their corresponding Podfile.lock were updated' do
@@ -93,7 +93,7 @@ module Danger
 
           @plugin.check_podfile_lock_updated
 
-          expect(@dangerfile.status_report[:warnings]).to be_empty
+          expect(@dangerfile).to not_report
         end
 
         it 'returns no warnings when only the Podfile.lock was updated' do
@@ -102,7 +102,7 @@ module Danger
 
           @plugin.check_podfile_lock_updated
 
-          expect(@dangerfile.status_report[:warnings]).to be_empty
+          expect(@dangerfile).to not_report
         end
       end
 
@@ -113,8 +113,8 @@ module Danger
 
           @plugin.check_swift_package_resolved_updated
 
-          expected_warning = ['`Package.swift` was changed without updating its corresponding `Package.resolved`. Please resolve the Swift packages in Xcode.']
-          expect(@dangerfile.status_report[:warnings]).to eq expected_warning
+          expected_warning = '`Package.swift` was changed without updating its corresponding `Package.resolved`. Please resolve the Swift packages in Xcode.'
+          expect(@dangerfile).to report_warnings([expected_warning])
         end
 
         it 'returns no warnings when both the Package.swift and the Package.resolved were updated' do
@@ -123,7 +123,7 @@ module Danger
 
           @plugin.check_swift_package_resolved_updated
 
-          expect(@dangerfile.status_report[:warnings]).to be_empty
+          expect(@dangerfile).to not_report
         end
 
         it 'returns no warnings when only the Package.resolved was updated' do
@@ -132,7 +132,7 @@ module Danger
 
           @plugin.check_swift_package_resolved_updated
 
-          expect(@dangerfile.status_report[:warnings]).to be_empty
+          expect(@dangerfile).to not_report
         end
       end
     end

--- a/spec/podfile_checker_spec.rb
+++ b/spec/podfile_checker_spec.rb
@@ -19,7 +19,7 @@ module Danger
       end
 
       context 'when checking the entire Podfile.lock file for commit references' do
-        it 'returns an error when there is a podfile dependency reference to a commit' do
+        it 'reports an error when there is a podfile dependency reference to a commit' do
           podfile_lock_content = <<~CONTENT
             PODS:
               - Kingfisher (7.8.1)
@@ -64,7 +64,7 @@ module Danger
           expect(@dangerfile).to report_errors([expected_message])
         end
 
-        it 'returns the right errors when there are multiple podfile dependencies referencing a commit' do
+        it 'reports the right errors when there are multiple podfile dependencies referencing a commit' do
           podfile_lock_content = <<~CONTENT
             PODS:
             - Kingfisher (7.8.1)
@@ -121,7 +121,7 @@ module Danger
           expect(@dangerfile).to report_errors([expected_message])
         end
 
-        it 'returns no error when there are no Podfile dependencies reference to a commit' do
+        it 'reports no error when there are no Podfile dependencies reference to a commit' do
           podfile_lock_content = <<~CONTENT
             PODS:
               - SwiftGen (6.5.1)
@@ -154,7 +154,7 @@ module Danger
       end
 
       context 'when changing the Podfile.lock in a Pull Request and checking for commit references' do
-        it 'returns warnings when a PR adds pods pointing to a specific commit' do
+        it 'reports warnings when a PR adds pods pointing to a specific commit' do
           podfile_path = './path/to/podfile/Podfile.lock'
           allow(@plugin.git).to receive(:modified_files).and_return([podfile_path])
 
@@ -300,7 +300,7 @@ module Danger
       end
 
       context 'when checking the entire Podfile.lock file for branch references' do
-        it 'returns an error when there is a podfile dependency reference to a branch' do
+        it 'reports an error when there is a podfile dependency reference to a branch' do
           podfile_lock_content = <<~CONTENT
             PODS:
               - Kingfisher (7.8.1)
@@ -345,7 +345,7 @@ module Danger
           expect(@dangerfile).to report_errors([expected_message])
         end
 
-        it 'returns the right errors when there are multiple podfile dependencies referencing a branch' do
+        it 'reports the right errors when there are multiple podfile dependencies referencing a branch' do
           podfile_lock_content = <<~CONTENT
             PODS:
             - Kingfisher (7.8.1)
@@ -402,7 +402,7 @@ module Danger
           expect(@dangerfile).to report_errors([expected_message])
         end
 
-        it 'returns no error when there are no Podfile dependency references to a branch' do
+        it 'reports no error when there are no Podfile dependency references to a branch' do
           podfile_lock_content = <<~CONTENT
             PODS:
               - SwiftGen (6.5.1)
@@ -446,7 +446,7 @@ module Danger
       end
 
       context 'when changing the Podfile.lock in a Pull Request and checking for branch references' do
-        it 'returns warnings when a PR adds pods pointing to a branch' do
+        it 'reports warnings when a PR adds pods pointing to a branch' do
           podfile_path = './path/to/podfile/Podfile.lock'
           allow(@plugin.git).to receive(:modified_files).and_return([podfile_path])
 

--- a/spec/podfile_checker_spec.rb
+++ b/spec/podfile_checker_spec.rb
@@ -295,7 +295,7 @@ module Danger
 
           @plugin.check_podfile_diff_does_not_have_commit_references
 
-          expect(@dangerfile.status_report[:warnings]).to be_empty
+          expect(@dangerfile).to not_report
         end
       end
 

--- a/spec/pr_size_checker_spec.rb
+++ b/spec/pr_size_checker_spec.rb
@@ -35,8 +35,7 @@ module Danger
 
             @plugin.check_diff_size(type: type)
 
-            expect(@dangerfile.status_report[:errors]).to be_empty
-            expect(@dangerfile.status_report[:warnings]).to eq [format(described_class::DEFAULT_DIFF_SIZE_MESSAGE_FORMAT, described_class::DEFAULT_MAX_DIFF_SIZE)]
+            expect(@dangerfile).to report_warnings([format(described_class::DEFAULT_DIFF_SIZE_MESSAGE_FORMAT, described_class::DEFAULT_MAX_DIFF_SIZE)])
           end
 
           it 'does nothing when using default parameters in a PR that has equal diff than the default maximum' do
@@ -44,8 +43,7 @@ module Danger
 
             @plugin.check_diff_size(type: type)
 
-            expect(@dangerfile.status_report[:errors]).to be_empty
-            expect(@dangerfile.status_report[:warnings]).to be_empty
+            expect(@dangerfile).to not_report
           end
 
           it 'does nothing when using default parameters in a PR that has smaller diff than the default maximum' do
@@ -53,8 +51,7 @@ module Danger
 
             @plugin.check_diff_size(type: type)
 
-            expect(@dangerfile.status_report[:errors]).to be_empty
-            expect(@dangerfile.status_report[:warnings]).to be_empty
+            expect(@dangerfile).to not_report
           end
 
           context 'when reporting a custom error or warning with a custom max_size' do
@@ -103,8 +100,7 @@ module Danger
                 max_size: max_sizes[0]
               )
 
-              expect(@dangerfile.status_report[:errors]).to be_empty
-              expect(@dangerfile.status_report[:warnings]).to eq [format(described_class::DEFAULT_DIFF_SIZE_MESSAGE_FORMAT, max_sizes[0])]
+              expect(@dangerfile).to report_warnings([format(described_class::DEFAULT_DIFF_SIZE_MESSAGE_FORMAT, max_sizes[0])])
             end
 
             it 'reports a custom error' do
@@ -119,8 +115,7 @@ module Danger
                 fail_on_error: true
               )
 
-              expect(@dangerfile.status_report[:warnings]).to be_empty
-              expect(@dangerfile.status_report[:errors]).to eq [custom_message]
+              expect(@dangerfile).to report_errors([custom_message])
             end
           end
 
@@ -133,8 +128,7 @@ module Danger
               max_size: max_sizes[2]
             )
 
-            expect(@dangerfile.status_report[:errors]).to be_empty
-            expect(@dangerfile.status_report[:warnings]).to be_empty
+            expect(@dangerfile).to not_report
           end
 
           def prepare_diff_with_test_files
@@ -190,8 +184,7 @@ module Danger
 
           @plugin.check_pr_body
 
-          expect(@dangerfile.status_report[:errors]).to be_empty
-          expect(@dangerfile.status_report[:warnings]).to eq [format(described_class::DEFAULT_MIN_PR_BODY_MESSAGE_FORMAT, described_class::DEFAULT_MIN_PR_BODY)]
+          expect(@dangerfile).to report_warnings([format(described_class::DEFAULT_MIN_PR_BODY_MESSAGE_FORMAT, described_class::DEFAULT_MIN_PR_BODY)])
         end
 
         it 'does nothing when using default parameters in a PR that has a bigger PR body text length than the default minimum' do
@@ -199,8 +192,7 @@ module Danger
 
           @plugin.check_pr_body
 
-          expect(@dangerfile.status_report[:errors]).to be_empty
-          expect(@dangerfile.status_report[:warnings]).to be_empty
+          expect(@dangerfile).to not_report
         end
 
         it 'reports a warning when using default parameters in a PR that has an equal PR body text length than the default minimum' do
@@ -208,8 +200,7 @@ module Danger
 
           @plugin.check_pr_body
 
-          expect(@dangerfile.status_report[:errors]).to be_empty
-          expect(@dangerfile.status_report[:warnings]).to eq [format(described_class::DEFAULT_MIN_PR_BODY_MESSAGE_FORMAT, described_class::DEFAULT_MIN_PR_BODY)]
+          expect(@dangerfile).to report_warnings([format(described_class::DEFAULT_MIN_PR_BODY_MESSAGE_FORMAT, described_class::DEFAULT_MIN_PR_BODY)])
         end
 
         context 'when reporting a custom error or warning with a custom min_length' do
@@ -249,11 +240,9 @@ module Danger
 
       def expect_warning_or_error(fail_on_error:, message:)
         if fail_on_error
-          expect(@dangerfile.status_report[:warnings]).to be_empty
-          expect(@dangerfile.status_report[:errors]).to eq [message]
+          expect(@dangerfile).to report_errors([message])
         else
-          expect(@dangerfile.status_report[:warnings]).to eq [message]
-          expect(@dangerfile.status_report[:errors]).to be_empty
+          expect(@dangerfile).to report_warnings([message])
         end
       end
     end

--- a/spec/view_changes_checker_spec.rb
+++ b/spec/view_changes_checker_spec.rb
@@ -18,7 +18,7 @@ module Danger
 
         @plugin.check
 
-        expect(@dangerfile.status_report[:warnings].count).to eq 1
+        expect(@dangerfile).to report_warnings([Danger::ViewChangesChecker::MESSAGE])
       end
 
       it 'does nothing when a PR with view code changes has screenshots defined in markdown' do
@@ -27,7 +27,7 @@ module Danger
 
         @plugin.check
 
-        expect(@dangerfile.status_report[:warnings]).to be_empty
+        expect(@dangerfile).to not_report
       end
 
       it 'does nothing when a PR with view code changes has url to screenshots' do
@@ -36,7 +36,7 @@ module Danger
 
         @plugin.check
 
-        expect(@dangerfile.status_report[:warnings]).to be_empty
+        expect(@dangerfile).to not_report
       end
 
       it 'does nothing when a PR with view code changes has a screenshot defined with a html tag with different attributes before src' do
@@ -45,7 +45,7 @@ module Danger
 
         @plugin.check
 
-        expect(@dangerfile.status_report[:warnings]).to be_empty
+        expect(@dangerfile).to not_report
       end
 
       it 'does nothing when a PR with view code changes has a screenshot defined with a html' do
@@ -54,7 +54,7 @@ module Danger
 
         @plugin.check
 
-        expect(@dangerfile.status_report[:warnings]).to be_empty
+        expect(@dangerfile).to not_report
       end
     end
 
@@ -66,7 +66,7 @@ module Danger
       end
 
       it 'does nothing' do
-        expect(@dangerfile.status_report[:warnings]).to be_empty
+        expect(@dangerfile).to not_report
       end
     end
 

--- a/spec/view_changes_checker_spec.rb
+++ b/spec/view_changes_checker_spec.rb
@@ -18,7 +18,7 @@ module Danger
 
         @plugin.check
 
-        expect(@dangerfile).to report_warnings([Danger::ViewChangesChecker::MESSAGE])
+        expect(@dangerfile).to report_warnings([ViewChangesChecker::MESSAGE])
       end
 
       it 'does nothing when a PR with view code changes has screenshots defined in markdown' do


### PR DESCRIPTION
The PR implements a few improvements on the internal consistency for error reporting:

- Use constants for error/warning messages, for improved use on Unit Tests
- Changes wording on tests from "returns an error/warning" to "reports an error/warning"
- Updates status report check calls to use our custom matchers, such as:
```diff
-expect(@dangerfile.status_report[:warnings]).to eq [message]
-expect(@dangerfile.status_report[:errors]).to be_empty
+expect(@dangerfile).to report_warnings([message])
```