### PR TITLE
Add video support for View Changes Checker

### DIFF
--- a/lib/dangermattic/plugins/view_changes_checker.rb
+++ b/lib/dangermattic/plugins/view_changes_checker.rb
@@ -15,17 +15,20 @@ module Danger
     VIEW_EXTENSIONS_IOS = /(View|Button)\.(swift|m)$|\.xib$|\.storyboard$/
     VIEW_EXTENSIONS_ANDROID = /(?i)(View|Button)\.(java|kt|xml)$/
 
-    IMAGE_IN_PR_BODY_PATTERNS = [
+    MEDIA_IN_PR_BODY_PATTERNS = [
       %r{https?://\S*\.(gif|jpg|jpeg|png|svg)},
+      %r{https?://\S*\.(mp4|avi|mov|mkv)},
+      %r{https?://\S*github\S+/\S+/assets/\d+/},
       /!\[(.*?)\]\((.*?)\)/,
-      /<img\s+[^>]*src\s*=\s*[^>]*>/
+      /<img\s+[^>]*src\s*=\s*[^>]*>/,
+      /<video\s+[^>]*src\s*=\s*[^>]*>/
     ].freeze
 
-    MESSAGE = 'View files have been modified, but no screenshot is included in the pull request. ' \
+    MESSAGE = 'View files have been modified, but no screenshot or video is included in the pull request. ' \
               'Consider adding some for clarity.'
 
-    # Checks if view files have been modified and if a screenshot is included in the pull request body,
-    # displaying a warning if view files have been modified but no screenshot is included.
+    # Checks if view files have been modified and if a screenshot or video is included in the pull request body,
+    # displaying a warning if view files have been modified but no screenshot or video is included.
     #
     # @return [void]
     def check
@@ -33,11 +36,11 @@ module Danger
         VIEW_EXTENSIONS_IOS =~ file || VIEW_EXTENSIONS_ANDROID =~ file
       end
 
-      pr_has_screenshots = IMAGE_IN_PR_BODY_PATTERNS.any? do |pattern|
+      pr_has_media = MEDIA_IN_PR_BODY_PATTERNS.any? do |pattern|
         github.pr_body =~ pattern
       end
 
-      warn(MESSAGE) if view_files_modified && !pr_has_screenshots
+      warn(MESSAGE) if view_files_modified && !pr_has_media
     end
   end
 end

--- a/spec/view_changes_checker_spec.rb
+++ b/spec/view_changes_checker_spec.rb
@@ -48,9 +48,36 @@ module Danger
         expect(@dangerfile).to not_report
       end
 
-      it 'does nothing when a PR with view code changes has a screenshot defined with a html' do
+      it 'does nothing when a PR with view code changes has a screenshot defined with a html tag' do
         allow(@plugin.github).to receive(:pr_body)
           .and_return("see screenshot:\n<img src=\"https://github.com/woocommerce/woocommerce-ios/assets/1864060/17d9227d-67e8-4efb-8c26-02b81e1b19d2\" width=\"375\"> body body")
+
+        @plugin.check
+
+        expect(@dangerfile).to not_report
+      end
+
+      it 'does nothing when a PR with view code changes has a video defined with a html tag with different attributes before src' do
+        allow(@plugin.github).to receive(:pr_body)
+          .and_return("see video:\n<video width=300 hint=\"First video\" src=\"https://www.w3schools.com/tags/movie.mp4\"> body body")
+
+        @plugin.check
+
+        expect(@dangerfile).to not_report
+      end
+
+      it 'does nothing when a PR with view code changes has a video defined with a html tag' do
+        allow(@plugin.github).to receive(:pr_body)
+          .and_return("see video:\n<video src=\"https://www.w3schools.com/tags/movie.mp4\" width=\"375\"> body body")
+
+        @plugin.check
+
+        expect(@dangerfile).to not_report
+      end
+
+      it 'does nothing when a PR with view code changes has a video defined with a simple URL' do
+        allow(@plugin.github).to receive(:pr_body)
+          .and_return("see video:\nhttps://github.com/woocommerce/woocommerce-ios/assets/1864060/0e983305-5047-40a3-8829-734e0b582b96 body body")
 
         @plugin.check
 


### PR DESCRIPTION
Adding to the ViewChangesChecker plugin support to also detect videos in PR body descriptions.

Example PR: https://github.com/woocommerce/woocommerce-ios/pull/11156