### PR TITLE
Running Danger on Forks: avoid commenting back on PR

### DIFF
--- a/.github/workflows/reusable-run-danger.yml
+++ b/.github/workflows/reusable-run-danger.yml
@@ -33,9 +33,22 @@ jobs:
           bundler-cache: true
       - name: "☢️ Danger PR Check"
         env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          RUNNING_ON_FORK: ${{ github.event.pull_request.head.repo.fork }}
           REMOVE_PREVIOUS_COMMENTS: ${{ inputs.remove-previous-comments }}
           DANGER_GITHUB_API_TOKEN: ${{ secrets.github-token }}
         run: |
           echo "--- 🏃 Running Danger: PR Check"
-          bundle exec danger --fail-on-errors=true --danger_id=pr-check $([ "$REMOVE_PREVIOUS_COMMENTS" = true ] && echo "--remove-previous-comments")
 
+          if [ "$RUNNING_ON_FORK" = true ]; then
+            danger_output=$(bundle exec danger pr "$PR_URL" --verbose)
+
+            echo "$danger_output"
+
+            if echo "$danger_output" | grep -q "Errors:"; then
+              echo "Danger encountered errors."
+              exit 1
+            fi
+          else
+            bundle exec danger --fail-on-errors=true --danger_id=pr-check $([ "$REMOVE_PREVIOUS_COMMENTS" = true ] && echo "--remove-previous-comments")
+          fi


### PR DESCRIPTION
Danger has an issue when running on forks: secrets from the main repo [aren't forwarded](https://docs.github.com/en/free-pro-team@latest/actions/reference/encrypted-secrets) to an execution from a fork (understandably).
The default `GITHUB_TOKEN` also will only have [read permission](https://docs.github.com/en/free-pro-team@latest/actions/reference/authentication-in-a-workflow#permissions-for-the-github_token) on forks as well.

This PR changes the code so that Danger will still run on forks, but not posting back comments. It will then log the results in the console and fail the build when there's an error.

An alternative solution could be running Danger on forks only on Buildkite. Since we just moved away from Buildkite for Danger, I refrained from adding it for now, but perhaps this is something we could revisit in the future.