### PR TITLE
Plugins Error Policy Review

### DIFF
--- a/lib/dangermattic/plugins/android_release_checker.rb
+++ b/lib/dangermattic/plugins/android_release_checker.rb
@@ -38,11 +38,13 @@ module Danger
       )
     end
 
-    # Check if there are changes to the internal release notes file RELEASE-NOTES.txt and emit a warning message if that's the case.
+    # Check if there are changes to the internal release notes file RELEASE-NOTES.txt and report a message if that's the case.
+    #
+    # @param report_type [Symbol] (optional) The type of report for the message. Types: :error, :warning (default), :message.
     #
     # @return [void]
-    def check_internal_release_notes_changed
-      common_release_checker.check_internal_release_notes_changed
+    def check_internal_release_notes_changed(report_type: :warning)
+      common_release_checker.check_internal_release_notes_changed(report_type: report_type)
     end
   end
 end

--- a/lib/dangermattic/plugins/android_release_checker.rb
+++ b/lib/dangermattic/plugins/android_release_checker.rb
@@ -29,12 +29,12 @@ module Danger
     # Checks if any strings file (values*/strings.xml) has been modified on a release branch, otherwise reporting a warning / error.
     #
     # @return [void]
-    def check_modified_strings_on_release(fail_on_error: false)
+    def check_modified_strings_on_release(report_type: :warning)
       common_release_checker.check_file_changed(
         file_comparison: ->(path) { File.basename(path) == STRINGS_FILE },
         message: MESSAGE_STRINGS_FILE_UPDATED,
         on_release_branch: false,
-        fail_on_error: fail_on_error
+        report_type: report_type
       )
     end
 

--- a/lib/dangermattic/plugins/android_strings_checker.rb
+++ b/lib/dangermattic/plugins/android_strings_checker.rb
@@ -16,12 +16,15 @@ module Danger
 
     # Check if translatable strings reference another string resource in 'strings.xml' files in a pull request.
     #
+    # @param report_type [Boolean] (optional) Type of report (:error, :warning, :message) whenever a line matches the criteria. Default is :warning.
+    #
     # @return [void]
-    def check_strings_do_not_refer_resource
+    def check_strings_do_not_refer_resource(report_type: :warning)
       git_utils.check_added_diff_lines(
         file_selector: ->(path) { File.basename(path) == 'strings.xml' },
         line_matcher: ->(line) { line.include?('@string/') && !line.include?('translatable="false"') },
-        message: MESSAGE
+        message: MESSAGE,
+        report_type: report_type
       )
     end
   end

--- a/lib/dangermattic/plugins/common/common_release_checker.rb
+++ b/lib/dangermattic/plugins/common/common_release_checker.rb
@@ -44,7 +44,7 @@ module Danger
     #
     # @param on_release_branch [Boolean] If true, the check will only run on release branches, otherwise on non-release branches.
     #
-    # @param report_type [Boolean] If true, a failure message will be displayed instead of a warning.
+    # @param report_type [Symbol] (optional) The type of report for the message. Types: :error, :warning (default), :message.
     #
     # @example Check if any modified file is under the 'app/' directory and emit a warning on release branches:
     #   check_file_changed(file_comparison: ->(file_path) { file_path.include?('app/') },
@@ -92,6 +92,7 @@ module Danger
     #
     # @param release_notes_file [String] (optional) The path to the internal release notes file.
     #        Defaults to the `DEFAULT_INTERNAL_RELEASE_NOTES` constant if not provided.
+    # @param report_type [Symbol] (optional) The type of report for the message. Types: :error, :warning (default), :message.
     #
     # @example Checking for changes in the default internal release notes file:
     #   check_internal_release_notes_changed
@@ -100,12 +101,12 @@ module Danger
     #   check_internal_release_notes_changed(release_notes_file: '/path/to/internal_release_notes.txt')
     #
     # @return [void]
-    def check_internal_release_notes_changed(release_notes_file: DEFAULT_INTERNAL_RELEASE_NOTES)
+    def check_internal_release_notes_changed(release_notes_file: DEFAULT_INTERNAL_RELEASE_NOTES, report_type: :warning)
       check_file_changed(
         file_comparison: ->(path) { path == release_notes_file },
         message: format(MESSAGE_INTERNAL_RELEASE_NOTES_CHANGED, release_notes_file),
         on_release_branch: true,
-        report_type: :warning
+        report_type: report_type
       )
     end
 

--- a/lib/dangermattic/plugins/common/common_release_checker.rb
+++ b/lib/dangermattic/plugins/common/common_release_checker.rb
@@ -44,7 +44,7 @@ module Danger
     #
     # @param on_release_branch [Boolean] If true, the check will only run on release branches, otherwise on non-release branches.
     #
-    # @param fail_on_error [Boolean] If true, a failure message will be displayed instead of a warning.
+    # @param report_type [Boolean] If true, a failure message will be displayed instead of a warning.
     #
     # @example Check if any modified file is under the 'app/' directory and emit a warning on release branches:
     #   check_file_changed(file_comparison: ->(file_path) { file_path.include?('app/') },
@@ -55,20 +55,16 @@ module Danger
     #   check_file_changed(file_comparison: ->(file_path) { file_path == 'path/to/file/DoNotChange.java' },
     #                      message: 'The "DoNotChange.java" file has been modified. This change is not allowed on non-release branches.',
     #                      on_release_branch: false,
-    #                      fail_on_error: true)
+    #                      report_type: :error)
     #
     # @return [void]
-    def check_file_changed(file_comparison:, message:, on_release_branch:, fail_on_error: false)
+    def check_file_changed(file_comparison:, message:, on_release_branch:, report_type: :warning)
       has_modified_file = git_utils.all_changed_files.any?(&file_comparison)
 
       should_be_changed = (on_release_branch == release_branch?)
       return unless should_be_changed && has_modified_file
 
-      if fail_on_error
-        failure(message)
-      else
-        warn(message)
-      end
+      reporter.report(message: message, type: report_type)
     end
 
     # Check if the release notes and store strings files are correctly updated after a modification to the release notes.
@@ -109,7 +105,7 @@ module Danger
         file_comparison: ->(path) { path == release_notes_file },
         message: format(MESSAGE_INTERNAL_RELEASE_NOTES_CHANGED, release_notes_file),
         on_release_branch: true,
-        fail_on_error: false
+        report_type: :warning
       )
     end
 

--- a/lib/dangermattic/plugins/common/git_utils.rb
+++ b/lib/dangermattic/plugins/common/git_utils.rb
@@ -45,7 +45,7 @@ module Danger
     #
     # @param message [String] The warning or failure message to display when the pattern is found in a line.
     #
-    # @param report_type [Boolean] (optional) Type of report (:error, :warning, :message) whenever a line matches the criteria. Default is :warning.
+    # @param report_type [Symbol] (optional) Type of report (:error, :warning, :message) whenever a line matches the criteria. Default is :warning.
     #
     # @example Checking for added lines containing 'FIXME' and failing the build:
     #   check_added_diff_lines(file_selector: ->(path) { File.extname(path) == ('.swift') }, line_matcher: ->(line) { line.include?("FIXME") }, message: "A FIXME was added, failing build.", report_type: :error)

--- a/lib/dangermattic/plugins/common/git_utils.rb
+++ b/lib/dangermattic/plugins/common/git_utils.rb
@@ -45,13 +45,13 @@ module Danger
     #
     # @param message [String] The warning or failure message to display when the pattern is found in a line.
     #
-    # @param fail_on_error [Boolean] (optional) When set to true, whenever a line matches the criteria, the method will emit an error, when false, emit a warning. Default is false.
+    # @param report_type [Boolean] (optional) When set to true, whenever a line matches the criteria, the method will emit an error, when false, emit a warning. Default is false.
     #
     # @example Checking for added lines containing 'FIXME' and failing the build:
-    #   check_added_diff_lines(file_selector: ->(path) { File.extname(path) == ('.swift') }, line_matcher: ->(line) { line.include?("FIXME") }, message: "A FIXME was added, failing build.", fail_on_error: true)
+    #   check_added_diff_lines(file_selector: ->(path) { File.extname(path) == ('.swift') }, line_matcher: ->(line) { line.include?("FIXME") }, message: "A FIXME was added, failing build.", report_type: :error)
     #
     # @return [void]
-    def check_added_diff_lines(file_selector:, line_matcher:, message:, fail_on_error: false)
+    def check_added_diff_lines(file_selector:, line_matcher:, message:, report_type: :warning)
       modified_files = added_and_modified_files.select(&file_selector)
 
       matches = matching_lines_in_diff_files(
@@ -70,11 +70,7 @@ module Danger
             ```
           MESSAGE
 
-          if fail_on_error
-            failure(final_message)
-          else
-            warn(final_message)
-          end
+          reporter.report(message: final_message, type: report_type)
         end
       end
     end

--- a/lib/dangermattic/plugins/common/git_utils.rb
+++ b/lib/dangermattic/plugins/common/git_utils.rb
@@ -45,7 +45,7 @@ module Danger
     #
     # @param message [String] The warning or failure message to display when the pattern is found in a line.
     #
-    # @param report_type [Boolean] (optional) When set to true, whenever a line matches the criteria, the method will emit an error, when false, emit a warning. Default is false.
+    # @param report_type [Boolean] (optional) Type of report (:error, :warning, :message) whenever a line matches the criteria. Default is :warning.
     #
     # @example Checking for added lines containing 'FIXME' and failing the build:
     #   check_added_diff_lines(file_selector: ->(path) { File.extname(path) == ('.swift') }, line_matcher: ->(line) { line.include?("FIXME") }, message: "A FIXME was added, failing build.", report_type: :error)

--- a/lib/dangermattic/plugins/common/reporter.rb
+++ b/lib/dangermattic/plugins/common/reporter.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+module Danger
+  # Handles reporting messages in the context of Danger, allowing the generation of
+  # warnings, errors, and simple messages in a Danger run.
+  #
+  # @example Reporting a Warning
+  #   reporter.report(message: "This is a warning message", type: :warning)
+  #
+  # @example Reporting an Error
+  #   reporter.report(message: "This is an error message", type: :error)
+  #
+  # @see Automattic/dangermattic
+  # @tags tool, util, danger
+  #
+  class Reporter < Plugin
+    # Report a message to be posted by Danger as an error (failing the build), a warning or a simple message.
+    #
+    # @param message [String] The message to be reported to Danger.
+    # @param type [Symbol] The type of report. Possible values:
+    #                        - :warning (default): Reports a warning.
+    #                        - :error: Reports an error.
+    #                        - :message: Reports a simple message.
+    #                        - :none or nil: Takes no action.
+    #
+    # @return [void]
+    def report(message:, type: :warning)
+      return if message.nil? || message.empty? || type.nil?
+
+      case type
+      when :error
+        failure(message)
+      when :warning
+        warn(message)
+      when :message
+        danger.message(message)
+      end
+    end
+  end
+end

--- a/lib/dangermattic/plugins/common/reporter.rb
+++ b/lib/dangermattic/plugins/common/reporter.rb
@@ -25,8 +25,6 @@ module Danger
     #
     # @return [void]
     def report(message:, type: :warning)
-      return if message.nil? || message.empty? || type.nil?
-
       case type
       when :error
         failure(message)

--- a/lib/dangermattic/plugins/common/reporter.rb
+++ b/lib/dangermattic/plugins/common/reporter.rb
@@ -21,7 +21,7 @@ module Danger
     #                        - :warning (default): Reports a warning.
     #                        - :error: Reports an error.
     #                        - :message: Reports a simple message.
-    #                        - :none or nil: Takes no action.
+    #                        - Any other value or nil: Takes no action.
     #
     # @return [void]
     def report(message:, type: :warning)

--- a/lib/dangermattic/plugins/ios_release_checker.rb
+++ b/lib/dangermattic/plugins/ios_release_checker.rb
@@ -27,45 +27,57 @@ module Danger
 
     # Checks if an existing Core Data model has been edited in a release branch.
     #
+    # @param report_type [Symbol] (optional) The type of report for the message. Types: :error, :warning (default), :message.
+    #
     # @return [void]
-    def check_core_data_model_changed
+    def check_core_data_model_changed(report_type: :warning)
       common_release_checker.check_file_changed(
         file_comparison: ->(path) { File.extname(path) == '.xcdatamodeld' },
         message: MESSAGE_CORE_DATA_UPDATED,
-        on_release_branch: true
+        on_release_branch: true,
+        report_type: report_type
       )
     end
 
     # Checks if any Localizable.strings file has been modified on a release branch, otherwise reporting a warning.
     #
+    # @param report_type [Symbol] (optional) The type of report for the message. Types: :error, :warning (default), :message.
+    #
     # @return [void]
-    def check_modified_localizable_strings_on_release
+    def check_modified_localizable_strings_on_release(report_type: :warning)
       common_release_checker.check_file_changed(
         file_comparison: ->(path) { File.basename(path) == LOCALIZABLE_STRINGS_FILE },
         message: MESSAGE_STRINGS_FILE_UPDATED,
-        on_release_branch: false
+        on_release_branch: false,
+        report_type: report_type
       )
     end
 
     # Checks if the en.lproj/Localizable.strings file has been modified on a regular branch, otherwise reporting a warning.
     #
+    # @param report_type [Symbol] (optional) The type of report for the message. Types: :error, :warning (default), :message.
+    #
     # @return [void]
-    def check_modified_en_strings_on_regular_branch
+    def check_modified_en_strings_on_regular_branch(report_type: :warning)
       common_release_checker.check_file_changed(
         file_comparison: ->(path) { base_strings_file?(path: path) },
         message: MESSAGE_BASE_STRINGS_FILE_UPDATED,
-        on_release_branch: true
+        on_release_branch: true,
+        report_type: report_type
       )
     end
 
     # Checks if a translation file (*.lproj/Localizable.strings) has been modified on a release branch, otherwise reporting a warning.
     #
+    # @param report_type [Symbol] (optional) The type of report for the message. Types: :error, :warning (default), :message.
+    #
     # @return [void]
-    def check_modified_translations_on_release_branch
+    def check_modified_translations_on_release_branch(report_type: :warning)
       common_release_checker.check_file_changed(
         file_comparison: ->(path) { !base_strings_file?(path: path) && File.basename(path) == LOCALIZABLE_STRINGS_FILE },
         message: MESSAGE_TRANSLATION_FILE_UPDATED,
-        on_release_branch: false
+        on_release_branch: false,
+        report_type: report_type
       )
     end
 

--- a/lib/dangermattic/plugins/labels_checker.rb
+++ b/lib/dangermattic/plugins/labels_checker.rb
@@ -51,15 +51,15 @@ module Danger
       failure("This PR is tagged with #{markdown_list_string(found_do_not_merge_labels)} label(s).") unless found_do_not_merge_labels.empty?
 
       # fail if a PR is missing any of the required labels
-      check_missing_labels(labels: github_labels, expected_labels: required_labels, fail_on_missing: true, custom_message: required_labels_error)
+      check_missing_labels(labels: github_labels, expected_labels: required_labels, report_on_missing: :error, custom_message: required_labels_error)
 
       # warn if a PR is missing any of the recommended labels
-      check_missing_labels(labels: github_labels, expected_labels: recommended_labels, fail_on_missing: false, custom_message: recommended_labels_warning)
+      check_missing_labels(labels: github_labels, expected_labels: recommended_labels, report_on_missing: :warning, custom_message: recommended_labels_warning)
     end
 
     private
 
-    def check_missing_labels(labels:, expected_labels:, fail_on_missing:, custom_message: nil)
+    def check_missing_labels(labels:, expected_labels:, report_on_missing:, custom_message: nil)
       missing_expected_labels = expected_labels.reject do |required_label|
         labels.any? { |label| label =~ required_label }
       end
@@ -69,11 +69,7 @@ module Danger
       missing_labels_list = missing_expected_labels.map(&:source)
       message = custom_message || "PR is missing label(s) matching: #{markdown_list_string(missing_labels_list)}"
 
-      if fail_on_missing
-        failure(message)
-      else
-        warn(message)
-      end
+      reporter.report(message: message, type: report_on_missing)
     end
 
     def markdown_list_string(items)

--- a/lib/dangermattic/plugins/milestone_checker.rb
+++ b/lib/dangermattic/plugins/milestone_checker.rb
@@ -19,12 +19,12 @@ module Danger
   # @example Run a milestone check with custom parameters
   #
   #          # Check if milestone due date is within 3 days, reporting an error if the due date has passed and in case there's no milestone set
-  #          checker.check_milestone_due_date(days_before_due: 3, report_type: :error, report_if_no_milestone: :error)
+  #          checker.check_milestone_due_date(days_before_due: 3, report_type: :error, report_type_if_no_milestone: :error)
   #
   # @example Run a milestone check with a custom milestone behaviour parameter
   #
   #          # Check if milestone due date is approaching and don't report anything if no milestone is assigned
-  #          checker.check_milestone_due_date(report_if_no_milestone: :none)
+  #          checker.check_milestone_due_date(report_type_if_no_milestone: :none)
   #
   # @see Automattic/dangermattic
   # @tags milestone, github, process
@@ -46,16 +46,16 @@ module Danger
     #
     # @param days_before_due [Integer] Number of days before the milestone due date for the check to apply (default: DEFAULT_DAYS_THRESHOLD).
     # @param report_type [Symbol] (optional) The type of report for the message. Types: :error, :warning (default), :message.
-    # @param report_if_no_milestone [Symbol] Action to take if the pull request is not assigned to a milestone. Possible values:
+    # @param report_type_if_no_milestone [Symbol] Action to take if the pull request is not assigned to a milestone. Possible values:
     #                                 - :warning (default): Reports a warning.
     #                                 - :error: Reports an error.
     #                                 - :message: Reports a message.
     #                                 - :none or nil: Takes no action.
     #
     # @return [void]
-    def check_milestone_due_date(days_before_due: DEFAULT_DAYS_THRESHOLD, report_type: :warning, report_if_no_milestone: :warning)
+    def check_milestone_due_date(days_before_due: DEFAULT_DAYS_THRESHOLD, report_type: :warning, report_type_if_no_milestone: :warning)
       if milestone.nil?
-        check_milestone_set(report_type: report_if_no_milestone)
+        check_milestone_set(report_type: report_type_if_no_milestone)
         return
       end
 

--- a/lib/dangermattic/plugins/milestone_checker.rb
+++ b/lib/dangermattic/plugins/milestone_checker.rb
@@ -45,6 +45,7 @@ module Danger
     # Checks if the pull request's milestone is due to finish within a certain number of days.
     #
     # @param days_before_due [Integer] Number of days before the milestone due date for the check to apply (default: DEFAULT_DAYS_THRESHOLD).
+    # @param report_type [Symbol] (optional) The type of report for the message. Types: :error, :warning (default), :message.
     # @param report_if_no_milestone [Symbol] Action to take if the pull request is not assigned to a milestone. Possible values:
     #                                 - :warning (default): Reports a warning.
     #                                 - :error: Reports an error.

--- a/lib/dangermattic/plugins/milestone_checker.rb
+++ b/lib/dangermattic/plugins/milestone_checker.rb
@@ -45,12 +45,8 @@ module Danger
     # Checks if the pull request's milestone is due to finish within a certain number of days.
     #
     # @param days_before_due [Integer] Number of days before the milestone due date for the check to apply (default: DEFAULT_DAYS_THRESHOLD).
-    # @param report_type [Symbol] (optional) The type of report for the message. Types: :error, :warning (default), :message.
-    # @param report_type_if_no_milestone [Symbol] Action to take if the pull request is not assigned to a milestone. Possible values:
-    #                                 - :warning (default): Reports a warning.
-    #                                 - :error: Reports an error.
-    #                                 - :message: Reports a message.
-    #                                 - :none or nil: Takes no action.
+    # @param report_type [Symbol] (optional) The type of message for when the PR is has passed over the `days_before_due` threshold. Types: :error, :warning (default), :message.
+    # @param report_type_if_no_milestone [Symbol] The type of message for when the PR is not assigned to a milestone. Types: :error, :warning (default), :message. You can also pass :none to not leave a message when there is no milestone.
     #
     # @return [void]
     def check_milestone_due_date(days_before_due: DEFAULT_DAYS_THRESHOLD, report_type: :warning, report_type_if_no_milestone: :warning)

--- a/lib/dangermattic/plugins/milestone_checker.rb
+++ b/lib/dangermattic/plugins/milestone_checker.rb
@@ -9,7 +9,7 @@ module Danger
   #          checker.check_milestone_set
   #
   #          # Check if PR is assigned to a milestone, reporting an error if that's not the case
-  #          checker.check_milestone_set(fail_on_error: true)
+  #          checker.check_milestone_set(report_type: :error)
   #
   # @example Run a milestone check
   #
@@ -35,16 +35,11 @@ module Danger
     # Checks if the pull request is assigned to a milestone.
     #
     # @return [void]
-    def check_milestone_set(fail_on_error: false)
+    def check_milestone_set(report_type: :warning)
       return unless milestone.nil?
 
       message = 'PR is not assigned to a milestone.'
-      sticky = false
-      if fail_on_error
-        failure(message, sticky: sticky)
-      else
-        warn(message, sticky: sticky)
-      end
+      reporter.report(message: message, type: report_type)
     end
 
     # Checks if the pull request's milestone is due to finish within a certain number of days.
@@ -60,9 +55,9 @@ module Danger
       if milestone.nil?
         case if_no_milestone
         when :warn
-          check_milestone_set(fail_on_error: false)
+          check_milestone_set(report_type: :warning)
         when :error
-          check_milestone_set(fail_on_error: true)
+          check_milestone_set(report_type: :error)
         end
         return
       end

--- a/lib/dangermattic/plugins/pr_size_checker.rb
+++ b/lib/dangermattic/plugins/pr_size_checker.rb
@@ -43,7 +43,7 @@ module Danger
     # @param type [:insertions, :deletions, :all] The type of diff size to check. (default: :all)
     # @param max_size [Integer] The maximum allowed size for the diff. (default: DEFAULT_MAX_DIFF_SIZE)
     # @param message [String] The message to display if the diff size exceeds the maximum. (default: DEFAULT_DIFF_SIZE_MESSAGE)
-    # @param report_type [Boolean] If true, fail the PR check when the diff size exceeds the maximum (default: false).
+    # @param report_type [Symbol] (optional) The type of report for the message. Types: :error, :warning (default), :message.
     #
     # @return [void]
     def check_diff_size(file_selector: nil, type: :all, max_size: DEFAULT_MAX_DIFF_SIZE, message: format(DEFAULT_DIFF_SIZE_MESSAGE_FORMAT, max_size), report_type: :warning)

--- a/lib/dangermattic/plugins/pr_size_checker.rb
+++ b/lib/dangermattic/plugins/pr_size_checker.rb
@@ -11,7 +11,7 @@ module Danger
   # @example Running a PR diff size check customizing the size, message and type of report
   #
   #          # Check the total size of changes in the PR, reporting an error if the diff is larger than 1000 using the specified message
-  #          pr_size_checker.check_diff_size(max_size: 1000, message: 'PR too large, 1000 is the max!!', fail_on_error: true)
+  #          pr_size_checker.check_diff_size(max_size: 1000, message: 'PR too large, 1000 is the max!!', report_type: :error)
   #
   # @example Running a PR diff size check on the specified files in part of the diff
   #
@@ -26,7 +26,7 @@ module Danger
   # @example Running a PR description length check with custom parameters
   #
   #          # Check if the minimum length of the PR body is smaller than 20 characters, reporting an error using a custom error message
-  #          pr_size_checker.check_pr_body(min_length: 20, message: 'Add a better description, 20 chars at least!!', fail_on_error: true)
+  #          pr_size_checker.check_pr_body(min_length: 20, message: 'Add a better description, 20 chars at least!!', report_type: :error)
   #
   # @see Automattic/dangermattic
   # @tags github, pull request, process
@@ -43,23 +43,17 @@ module Danger
     # @param type [:insertions, :deletions, :all] The type of diff size to check. (default: :all)
     # @param max_size [Integer] The maximum allowed size for the diff. (default: DEFAULT_MAX_DIFF_SIZE)
     # @param message [String] The message to display if the diff size exceeds the maximum. (default: DEFAULT_DIFF_SIZE_MESSAGE)
-    # @param fail_on_error [Boolean] If true, fail the PR check when the diff size exceeds the maximum (default: false).
+    # @param report_type [Boolean] If true, fail the PR check when the diff size exceeds the maximum (default: false).
     #
     # @return [void]
-    def check_diff_size(file_selector: nil, type: :all, max_size: DEFAULT_MAX_DIFF_SIZE, message: format(DEFAULT_DIFF_SIZE_MESSAGE_FORMAT, max_size), fail_on_error: false)
+    def check_diff_size(file_selector: nil, type: :all, max_size: DEFAULT_MAX_DIFF_SIZE, message: format(DEFAULT_DIFF_SIZE_MESSAGE_FORMAT, max_size), report_type: :warning)
       case type
       when :insertions
-        if insertions_size(file_selector: file_selector) > max_size
-          fail_on_error ? failure(message) : warn(message)
-        end
+        reporter.report(message: message, type: report_type) if insertions_size(file_selector: file_selector) > max_size
       when :deletions
-        if deletions_size(file_selector: file_selector) > max_size
-          fail_on_error ? failure(message) : warn(message)
-        end
+        reporter.report(message: message, type: report_type) if deletions_size(file_selector: file_selector) > max_size
       when :all
-        if diff_size(file_selector: file_selector) > max_size
-          fail_on_error ? failure(message) : warn(message)
-        end
+        reporter.report(message: message, type: report_type) if diff_size(file_selector: file_selector) > max_size
       end
     end
 
@@ -67,13 +61,13 @@ module Danger
     #
     # @param min_length [Integer] The minimum allowed length for the PR body. (default: DEFAULT_MIN_PR_BODY)
     # @param message [String] The message to display if the length of the PR body is smaller than the minimum. (default: DEFAULT_MIN_PR_BODY_MESSAGE_FORMAT)
-    # @param fail_on_error [Boolean] If true, fail the PR check when the PR body length is too small. (default: false)
+    # @param report_type [Boolean] If true, fail the PR check when the PR body length is too small. (default: false)
     #
     # @return [void]
-    def check_pr_body(min_length: DEFAULT_MIN_PR_BODY, message: format(DEFAULT_MIN_PR_BODY_MESSAGE_FORMAT, min_length), fail_on_error: false)
+    def check_pr_body(min_length: DEFAULT_MIN_PR_BODY, message: format(DEFAULT_MIN_PR_BODY_MESSAGE_FORMAT, min_length), report_type: :warning)
       return if danger.github.pr_body.length > min_length
 
-      fail_on_error ? failure(message) : warn(message)
+      reporter.report(message: message, type: report_type)
     end
 
     # Calculate the total size of insertions in modified files that match the file selector.

--- a/spec/android_release_checker_spec.rb
+++ b/spec/android_release_checker_spec.rb
@@ -56,7 +56,7 @@ module Danger
           allow(@plugin.git).to receive(:modified_files).and_return(['./src/main/res/values/strings.xml'])
           allow(@plugin.github).to receive(:branch_for_base).and_return('develop')
 
-          @plugin.check_modified_strings_on_release(fail_on_error: true)
+          @plugin.check_modified_strings_on_release(report_type: :error)
 
           expect(@dangerfile).to report_errors([AndroidReleaseChecker::MESSAGE_STRINGS_FILE_UPDATED])
         end

--- a/spec/milestone_checker_spec.rb
+++ b/spec/milestone_checker_spec.rb
@@ -108,7 +108,7 @@ module Danger
           expect(@dangerfile).to not_report
         end
 
-        it 'reports a warning when a PR has a milestone with due date after the warning days threshold' do
+        it 'reports an error when a PR has a milestone with due date after the warning days threshold' do
           pr_json = {
             'milestone' => {
               'title' => 'Release Day',
@@ -123,10 +123,10 @@ module Danger
           allow(@plugin.github).to receive(:pr_json).and_return(pr_json)
           allow(DateTime).to receive(:now).and_return(date_one_day_after_due)
 
-          @plugin.check_milestone_due_date
+          @plugin.check_milestone_due_date(report_type: :error)
 
-          expected_warning = ["This PR is assigned to the milestone [Release Day](https://wp.com). The due date for this milestone has already passed.\nPlease make sure to get it merged by then or assign it to a milestone with a later deadline."]
-          expect(@dangerfile).to report_warnings(expected_warning)
+          expected_warning = ["This PR is assigned to the milestone [Release Day](https://wp.com). The due date for this milestone has already passed.\nPlease assign it to a milestone with a later deadline or check whether the release for this milestone has already been finished."]
+          expect(@dangerfile).to report_errors(expected_warning)
         end
 
         it 'reports a warning when a PR has a milestone with due date within a custom warning days threshold' do
@@ -186,7 +186,7 @@ module Danger
         it "reports a warning when asked to do so when a PR doesn't have a milestone set" do
           allow(@plugin.github).to receive(:pr_json).and_return({})
 
-          @plugin.check_milestone_due_date(if_no_milestone: :warn)
+          @plugin.check_milestone_due_date(report_if_no_milestone: :warning)
 
           expected_warning = ['PR is not assigned to a milestone.']
           expect(@dangerfile).to report_warnings(expected_warning)
@@ -195,7 +195,7 @@ module Danger
         it "reports an error when asked to do so when a PR doesn't have a milestone set" do
           allow(@plugin.github).to receive(:pr_json).and_return({})
 
-          @plugin.check_milestone_due_date(if_no_milestone: :error)
+          @plugin.check_milestone_due_date(report_if_no_milestone: :error)
 
           expected_error = ['PR is not assigned to a milestone.']
           expect(@dangerfile).to report_errors(expected_error)
@@ -204,7 +204,7 @@ module Danger
         it "does nothing when asked to do so when a PR doesn't have a milestone set" do
           allow(@plugin.github).to receive(:pr_json).and_return({})
 
-          @plugin.check_milestone_due_date(if_no_milestone: :none)
+          @plugin.check_milestone_due_date(report_if_no_milestone: :none)
 
           expect(@dangerfile).to not_report
         end
@@ -212,7 +212,7 @@ module Danger
         it "does nothing when nil is used and a PR doesn't have a milestone set" do
           allow(@plugin.github).to receive(:pr_json).and_return({})
 
-          @plugin.check_milestone_due_date(if_no_milestone: nil)
+          @plugin.check_milestone_due_date(report_if_no_milestone: nil)
 
           expect(@dangerfile).to not_report
         end

--- a/spec/milestone_checker_spec.rb
+++ b/spec/milestone_checker_spec.rb
@@ -28,7 +28,7 @@ module Danger
           it "reports an error when a PR doesn't have a milestone set" do
             allow(@plugin.github).to receive(:pr_json).and_return({})
 
-            @plugin.check_milestone_set(fail_on_error: true)
+            @plugin.check_milestone_set(report_type: :error)
 
             expected_error = ['PR is not assigned to a milestone.']
             expect(@dangerfile).to report_errors(expected_error)
@@ -59,7 +59,7 @@ module Danger
 
             allow(@plugin.github).to receive(:pr_json).and_return(pr_json)
 
-            @plugin.check_milestone_set(fail_on_error: true)
+            @plugin.check_milestone_set(report_type: :error)
 
             expect(@dangerfile).to not_report
           end

--- a/spec/milestone_checker_spec.rb
+++ b/spec/milestone_checker_spec.rb
@@ -186,7 +186,7 @@ module Danger
         it "reports a warning when asked to do so when a PR doesn't have a milestone set" do
           allow(@plugin.github).to receive(:pr_json).and_return({})
 
-          @plugin.check_milestone_due_date(report_if_no_milestone: :warning)
+          @plugin.check_milestone_due_date(report_type_if_no_milestone: :warning)
 
           expected_warning = ['PR is not assigned to a milestone.']
           expect(@dangerfile).to report_warnings(expected_warning)
@@ -195,7 +195,7 @@ module Danger
         it "reports an error when asked to do so when a PR doesn't have a milestone set" do
           allow(@plugin.github).to receive(:pr_json).and_return({})
 
-          @plugin.check_milestone_due_date(report_if_no_milestone: :error)
+          @plugin.check_milestone_due_date(report_type_if_no_milestone: :error)
 
           expected_error = ['PR is not assigned to a milestone.']
           expect(@dangerfile).to report_errors(expected_error)
@@ -204,7 +204,7 @@ module Danger
         it "does nothing when asked to do so when a PR doesn't have a milestone set" do
           allow(@plugin.github).to receive(:pr_json).and_return({})
 
-          @plugin.check_milestone_due_date(report_if_no_milestone: :none)
+          @plugin.check_milestone_due_date(report_type_if_no_milestone: :none)
 
           expect(@dangerfile).to not_report
         end
@@ -212,7 +212,7 @@ module Danger
         it "does nothing when nil is used and a PR doesn't have a milestone set" do
           allow(@plugin.github).to receive(:pr_json).and_return({})
 
-          @plugin.check_milestone_due_date(report_if_no_milestone: nil)
+          @plugin.check_milestone_due_date(report_type_if_no_milestone: nil)
 
           expect(@dangerfile).to not_report
         end

--- a/spec/pr_size_checker_spec.rb
+++ b/spec/pr_size_checker_spec.rb
@@ -55,19 +55,19 @@ module Danger
           end
 
           context 'when reporting a custom error or warning with a custom max_size' do
-            shared_examples 'reporting diff size custom warnings or errors' do |fail_on_error, message|
+            shared_examples 'reporting diff size custom warnings or errors' do |report_type, message|
               it 'reports an error using a custom message and a custom PR body size' do
                 allow(@plugin.git).to receive(diff_counter_for_type).and_return(600)
 
                 if message
-                  @plugin.check_diff_size(type: type, max_size: 599, message: message, fail_on_error: fail_on_error)
+                  @plugin.check_diff_size(type: type, max_size: 599, message: message, report_type: report_type)
                 else
-                  @plugin.check_diff_size(type: type, max_size: 599, fail_on_error: fail_on_error)
+                  @plugin.check_diff_size(type: type, max_size: 599, report_type: report_type)
                 end
 
                 message ||= format(described_class::DEFAULT_DIFF_SIZE_MESSAGE_FORMAT, 599)
 
-                expect_warning_or_error(fail_on_error: fail_on_error, message: message)
+                expect_warning_or_error(report_type: report_type, message: message)
               end
             end
 
@@ -112,7 +112,7 @@ module Danger
                 type: type,
                 max_size: max_sizes[1],
                 message: custom_message,
-                fail_on_error: true
+                report_type: :error
               )
 
               expect(@dangerfile).to report_errors([custom_message])
@@ -204,19 +204,19 @@ module Danger
         end
 
         context 'when reporting a custom error or warning with a custom min_length' do
-          shared_examples 'reporting PR length check custom warnings or errors' do |fail_on_error, message|
+          shared_examples 'reporting PR length check custom warnings or errors' do |report_type, message|
             it 'reports an error when using a custom message and a custom minimum PR body text length' do
               allow(@plugin.github).to receive(:pr_body).and_return('still too short message')
 
               if message
-                @plugin.check_pr_body(min_length: 25, message: message, fail_on_error: fail_on_error)
+                @plugin.check_pr_body(min_length: 25, message: message, report_type: report_type)
               else
-                @plugin.check_pr_body(min_length: 25, fail_on_error: fail_on_error)
+                @plugin.check_pr_body(min_length: 25, report_type: report_type)
               end
 
               message ||= format(described_class::DEFAULT_MIN_PR_BODY_MESSAGE_FORMAT, 25)
 
-              expect_warning_or_error(fail_on_error: fail_on_error, message: message)
+              expect_warning_or_error(report_type: report_type, message: message)
             end
           end
 
@@ -238,10 +238,10 @@ module Danger
         end
       end
 
-      def expect_warning_or_error(fail_on_error:, message:)
-        if fail_on_error
+      def expect_warning_or_error(report_type:, message:)
+        if report_type == :error
           expect(@dangerfile).to report_errors([message])
-        else
+        elsif report_type == :warning
           expect(@dangerfile).to report_warnings([message])
         end
       end


### PR DESCRIPTION
Previously, Dangermattic had a pattern on the public API to allow for some customization on error levels reporting: the parameter `fail_on_error [Boolean]`, though this wasn't strictly followed on all plugins.

This PR changes this pattern to a `report_type [Symbol]` parameter instead. I've also added this parameter on all APIs that I thought made sense. This is based on a few discussions I've had on this topic in other PRs (e.g. [last one](https://github.com/Automattic/dangermattic/pull/30#discussion_r1452888075) with @mokagio).
 
The reporting itself is implemented in the `Reporter` class, created as a plugin for easy access from other plugins.