### PR TITLE
Extract common utils seen on Dangerfiles

### DIFF
--- a/lib/dangermattic/plugins/common/common_release_checker.rb
+++ b/lib/dangermattic/plugins/common/common_release_checker.rb
@@ -61,7 +61,7 @@ module Danger
     def check_file_changed(file_comparison:, message:, on_release_branch:, report_type: :warning)
       has_modified_file = git_utils.all_changed_files.any?(&file_comparison)
 
-      should_be_changed = (on_release_branch == release_branch?)
+      should_be_changed = (on_release_branch == github_utils.release_branch?)
       return unless should_be_changed && has_modified_file
 
       reporter.report(message: message, type: report_type)
@@ -108,12 +108,6 @@ module Danger
         on_release_branch: true,
         report_type: report_type
       )
-    end
-
-    private
-
-    def release_branch?
-      danger.github.branch_for_base.start_with?('release/') || danger.github.branch_for_base.start_with?('hotfix/')
     end
   end
 end

--- a/lib/dangermattic/plugins/common/github_utils.rb
+++ b/lib/dangermattic/plugins/common/github_utils.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+
+module Danger
+  # Provides common GitHub utility methods related to Pull Requests in a Danger context.
+  #
+  # @example Checking if the branch is a release or hotfix branch:
+  #   github_utils.release_branch? #=> true or false
+  #
+  # @example Checking if there are active reviewers on the PR:
+  #   github_utils.active_reviewers? #=> true or false
+  #
+  # @example Checking if there are requested teams or reviewers on the PR:
+  #   github_utils.requested_reviewers? #=> true or false
+  #
+  # @example Checking if the branch is a main branch (trunk, main, master, or develop):
+  #   github_utils.main_branch? #=> true or false
+  #
+  # @example Checking if the PR is a work-in-progress (WIP) based on labels or title:
+  #   github_utils.wip_feature? #=> true or false
+  #
+  # @see Automattic/dangermattic
+  # @tags tool, util
+  #
+  class GithubUtils < Plugin
+    # Checks if there are active reviewers providing feedback and potentially changing the state of the PR
+    # (e.g., approved, changes requested).
+    #
+    # @return [Boolean] True if there are active reviewers, otherwise false.
+    def active_reviewers?
+      repo_name = github.pr_json['base']['repo']['full_name']
+      pr_number = github.pr_json['number']
+
+      !github.api.pull_request_reviews(repo_name, pr_number).empty?
+    end
+
+    # Checks if there are requested teams or reviewers who haven't reacted yet.
+    #
+    # @return [Boolean] True if there are requested teams or reviewers, otherwise false.
+    def requested_reviewers?
+      has_requested_reviews = !github.pr_json['requested_teams'].to_a.empty? || !github.pr_json['requested_reviewers'].to_a.empty?
+      has_requested_reviews || active_reviewers?
+    end
+
+    # Checks if the current branch is a main branch (trunk, main, master, or develop).
+    #
+    # @return [Boolean] True if the branch is a main branch, otherwise false.
+    def main_branch?
+      %w[trunk main master develop].include?(github.branch_for_base)
+    end
+
+    # Checks if the current branch is a release or hotfix branch.
+    #
+    # @return [Boolean] True if the branch is a release or hotfix branch, otherwise false.
+    def release_branch?
+      github.branch_for_base.start_with?('release/') || github.branch_for_base.start_with?('hotfix/')
+    end
+
+    # Checks if the PR is a work-in-progress (WIP) based on labels or title.
+    #
+    # @return [Boolean] True if the PR is a work-in-progress, otherwise false.
+    def wip_feature?
+      has_wip_label = github.pr_labels.any? { |label| label.include?('WIP') }
+      has_wip_title = github.pr_title.include?('WIP')
+
+      has_wip_label || has_wip_title
+    end
+  end
+end

--- a/spec/github_utils_spec.rb
+++ b/spec/github_utils_spec.rb
@@ -1,0 +1,110 @@
+# frozen_string_literal: true
+
+require_relative 'spec_helper'
+
+module Danger
+  describe Danger::GithubUtils do
+    it 'is a plugin' do
+      expect(described_class.new(nil)).to be_a Danger::Plugin
+    end
+
+    describe 'with the common_release_checker plugin' do
+      let(:github) do
+        instance_double(Danger::DangerfileGitHubPlugin, {
+                          pr_json: {
+                            'base' => { 'repo' => { 'full_name' => 'Automattic/dangermattic' } },
+                            'number' => 42,
+                            'requested_teams' => [],
+                            'requested_reviewers' => []
+                          },
+                          api: instance_double(Octokit::Client),
+                          branch_for_base: 'main',
+                          pr_labels: [],
+                          pr_title: 'Some PR Title'
+                        })
+      end
+
+      before do
+        @dangerfile = testing_dangerfile
+        @plugin = @dangerfile.github_utils
+
+        allow(@plugin).to receive(:github).and_return(github)
+      end
+
+      describe '#active_reviewers?' do
+        it 'returns true when there are active reviewers' do
+          allow(github.api).to receive(:pull_request_reviews).and_return(%w[review1 review2])
+          expect(@plugin.active_reviewers?).to be(true)
+        end
+
+        it 'returns false when there are no active reviewers' do
+          allow(github.api).to receive(:pull_request_reviews).and_return([])
+          expect(@plugin.active_reviewers?).to be(false)
+        end
+      end
+
+      describe '#requested_reviewers?' do
+        it 'returns true when there are requested reviewers' do
+          allow(github.pr_json).to receive(:[]).with('requested_teams').and_return(['team1'])
+          expect(@plugin.requested_reviewers?).to be(true)
+        end
+
+        it 'returns true when there are active reviewers' do
+          allow(github.api).to receive(:pull_request_reviews).and_return(%w[review1 review2])
+          expect(@plugin.requested_reviewers?).to be(true)
+        end
+
+        it 'returns false when there are no requested reviewers or active reviewers' do
+          allow(github.api).to receive(:pull_request_reviews).and_return([])
+          expect(@plugin.requested_reviewers?).to be(false)
+        end
+      end
+
+      describe '#main_branch?' do
+        it 'returns true when the branch is a main branch' do
+          allow(github).to receive(:branch_for_base).and_return('develop')
+          expect(@plugin.main_branch?).to be(true)
+        end
+
+        it 'returns false when the branch is not a main branch' do
+          allow(github).to receive(:branch_for_base).and_return('feature-branch')
+          expect(@plugin.main_branch?).to be(false)
+        end
+      end
+
+      describe '#release_branch?' do
+        it 'returns true when the branch is a release branch' do
+          allow(github).to receive(:branch_for_base).and_return('release/30.6.0')
+          expect(@plugin.release_branch?).to be(true)
+        end
+
+        it 'returns true when the branch is a hotfix branch' do
+          allow(github).to receive(:branch_for_base).and_return('hotfix/fix-bug')
+          expect(@plugin.release_branch?).to be(true)
+        end
+
+        it 'returns false when the branch is neither a release nor a hotfix branch' do
+          allow(github).to receive(:branch_for_base).and_return('feature-branch')
+          expect(@plugin.release_branch?).to be(false)
+        end
+      end
+
+      describe '#wip_feature?' do
+        it 'returns true when there is a WIP label' do
+          allow(github).to receive(:pr_labels).and_return(['WIP'])
+          expect(@plugin.wip_feature?).to be(true)
+        end
+
+        it 'returns true when there is WIP in the title' do
+          allow(github).to receive(:pr_title).and_return('WIP: Some PR Title')
+          expect(@plugin.wip_feature?).to be(true)
+        end
+
+        it 'returns false when there is no WIP label or WIP in the title' do
+          allow(github).to receive_messages(pr_labels: [], pr_title: 'Some PR Title')
+          expect(@plugin.wip_feature?).to be(false)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
While integrating Dangermattic across apps, some methods implemented in the `Dangerfile` (ex [1](https://github.com/woocommerce/woocommerce-android/blob/4a77c340cf9673f93d77268b3e6425f1055030b6/Dangerfile#L11), [2](https://github.com/Automattic/pocket-casts-ios/blob/1afeb23b42a2113b0000c4b7ae8e7662cadcae3f/Dangerfile#L11), [3](https://github.tumblr.net/Tumblr/ios/blob/54a3a67a491b3aab7fb345b225ac3d2507f98857/Dangerfile#L8), but all apps need some of these utils) itself ended up being repeated across several apps.

This PR introduces the `github_utils` plugin gathering common utils seen in `Dangerfile`s.