### PR TITLE
Add instructions on adding new plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Adding a new plugin to Dangermattic is very simple: just create a new subclass o
 
 ```ruby
 module Danger
-  class MyNewPlugin < Plugin
+  class MyNewPluginChecker < Plugin
     def check_method(param:)
       # ...
     end
@@ -62,5 +62,7 @@ It will be [automatically imported](https://github.com/Automattic/dangermattic/b
 
 ```ruby
 # In a Dangerfile
-my_new_plugin.check_method(param: my_param_value)
+my_new_plugin_checker.check_method(param: my_param_value)
 ```
+
+Please follow the existing naming convention for validation and check plugins: classes end with a `*Checker` suffix and the main validation methods are named with a `check_*` prefix.

--- a/README.md
+++ b/README.md
@@ -43,3 +43,24 @@ All available plugins are defined here: https://github.com/Automattic/dangermatt
 - Run `bundle exec rake lint` to run only the linting tasks: RuboCop and Danger Lint
 - Use `bundle exec guard` to automatically have tests run as you make changes.
 - You can generate the documentation using `bundle exec yard doc`. The documentation is generated locally in the `yard-doc/` folder.
+
+### Adding a new plugin
+
+Adding a new plugin to Dangermattic is very simple: just create a new subclass of `Danger::Plugin` inside `./lib/dangermattic/plugins/`, similarly to the other classes you'll find there:
+
+```ruby
+module Danger
+  class MyNewPlugin < Plugin
+    def check_method(param:)
+      # ...
+    end
+  end
+end
+```
+
+It will be [automatically imported](https://github.com/Automattic/dangermattic/blob/trunk/lib/danger_plugin.rb), exposed by Dangermattic's Gem and visible in your `Dangerfile` once you add it as a dependency:
+
+```ruby
+# In a Dangerfile
+my_new_plugin.check_method(param: my_param_value)
+```


### PR DESCRIPTION
Simple PR adding instructions on how to add new plugins (discussed on https://wp.me/pbMoDN-4lB#comment-7124) on Dangermattic.