### PR TITLE
Tracks Checker Improvements

### DIFF
--- a/lib/dangermattic/plugins/tracks_checker.rb
+++ b/lib/dangermattic/plugins/tracks_checker.rb
@@ -24,6 +24,8 @@ module Danger
       - Please consider registering any new events.
     MESSAGE
 
+    TRACKS_NO_LABEL_MESSAGE = 'Please ensure the PR has the `Tracks` label.'
+
     # Checks the PR diff for changes in Tracks-related files and provides instructions if changes are detected
     #
     # @param tracks_files [Array<String>] List of Tracks-related file names to check
@@ -31,6 +33,12 @@ module Danger
     # @return [void]
     def check_tracks_changes(tracks_files:, tracks_usage_matchers:)
       return unless changes_tracks_files?(tracks_files: tracks_files) || diff_has_tracks_changes?(tracks_usage_matchers: tracks_usage_matchers)
+
+      labels_checker.check(
+        do_not_merge_labels: [],
+        required_labels: [/Tracks/],
+        required_labels_error: TRACKS_NO_LABEL_MESSAGE
+      )
 
       # Tracks-related changes detected: publishing instructions
       message(TRACKS_PR_INSTRUCTIONS)

--- a/lib/dangermattic/plugins/tracks_checker.rb
+++ b/lib/dangermattic/plugins/tracks_checker.rb
@@ -15,32 +15,21 @@ module Danger
   # @tags github, pull request, tracks, process
   #
   class TracksChecker < Plugin
-    DEFAULT_TRACKS_FILES = [
-      'AnalyticsTracker.kt',
-      'AnalyticsEvent.kt',
-      'LoginAnalyticsTracker.kt',
-      'WooAnalyticsStat.swift'
-    ].freeze
-
-    DEFAULT_TRACKS_USE_MATCHERS = [
-      /AnalyticsTracker\.track/
-    ].freeze
-
     TRACKS_PR_INSTRUCTIONS = <<~MESSAGE
-      This PR contains changes to Tracks-related logic. Please ensure the following are completed:
-      **PR Author**
-      - The PR must be assigned the **Tracks** label
-      **PR Reviewer**
+      This PR contains changes to Tracks-related logic. Please ensure (**author and reviewer**) the following are completed:
+
+      - The PR must be assigned the **Tracks** label.
       - The tracks events must be validated in the Tracks system.
       - Verify the internal Tracks spreadsheet has also been updated.
+      - Please consider registering any new events.
     MESSAGE
 
     # Checks the PR diff for changes in Tracks-related files and provides instructions if changes are detected
     #
-    # @param tracks_files [Array<String>] List of Tracks-related file names to check (default: DEFAULT_TRACKS_FILES)
-    # @param tracks_usage_matchers [Array<Regexp>] List of regular expressions representing tracks usages to match the diff lines (default: DEFAULT_TRACKS_FILES)
+    # @param tracks_files [Array<String>] List of Tracks-related file names to check
+    # @param tracks_usage_matchers [Array<Regexp>] List of regular expressions representing tracks usages to match the diff lines
     # @return [void]
-    def check_tracks_changes(tracks_files: DEFAULT_TRACKS_FILES, tracks_usage_matchers: DEFAULT_TRACKS_USE_MATCHERS)
+    def check_tracks_changes(tracks_files:, tracks_usage_matchers:)
       return unless changes_tracks_files?(tracks_files: tracks_files) || diff_has_tracks_changes?(tracks_usage_matchers: tracks_usage_matchers)
 
       # Tracks-related changes detected: publishing instructions

--- a/spec/tracks_checker_spec.rb
+++ b/spec/tracks_checker_spec.rb
@@ -14,6 +14,21 @@ module Danger
         @plugin = @dangerfile.tracks_checker
       end
 
+      let(:track_files) do
+        [
+          'AnalyticsTracker.kt',
+          'AnalyticsEvent.kt',
+          'LoginAnalyticsTracker.kt',
+          'WooAnalyticsStat.swift'
+        ]
+      end
+
+      let(:tracks_matchers) do
+        [
+          /AnalyticsTracker\.track/
+        ]
+      end
+
       describe '#check_tracks_changes' do
         before do
           allow(@plugin.git).to receive_messages(modified_files: [], added_files: [], deleted_files: [])
@@ -25,7 +40,7 @@ module Danger
           it 'reports a message with instructions for review when there are changes in Tracks-related files' do
             allow(@plugin.git_utils).to receive(:all_changed_files).and_return(['Test.kt', 'LoginAnalyticsTracker.kt', 'Test.java'])
 
-            @plugin.check_tracks_changes
+            @plugin.check_tracks_changes(tracks_files: track_files, tracks_usage_matchers: tracks_matchers)
 
             expect(@dangerfile).to report_messages([TracksChecker::TRACKS_PR_INSTRUCTIONS])
           end
@@ -33,7 +48,7 @@ module Danger
           it 'reports a message with instructions for review when there are changes in Tracks-related files using a custom file list' do
             allow(@plugin.git_utils).to receive(:all_changed_files).and_return(['MyClass.swift', 'MyClass1.swift', 'MyClass2.swift'])
 
-            @plugin.check_tracks_changes(tracks_files: ['MyClass1.swift'])
+            @plugin.check_tracks_changes(tracks_files: ['MyClass1.swift'], tracks_usage_matchers: tracks_matchers)
 
             expect(@dangerfile).to report_messages([TracksChecker::TRACKS_PR_INSTRUCTIONS])
           end
@@ -43,7 +58,7 @@ module Danger
             allow(@plugin.git_utils).to receive(:all_changed_files).and_return(modified_files)
             allow(@plugin.git_utils).to receive(:matching_lines_in_diff_files).with(files: modified_files, line_matcher: kind_of(Proc), change_type: nil).and_return([])
 
-            @plugin.check_tracks_changes
+            @plugin.check_tracks_changes(tracks_files: track_files, tracks_usage_matchers: tracks_matchers)
 
             expect(@dangerfile).to not_report
           end
@@ -53,7 +68,7 @@ module Danger
             allow(@plugin.git_utils).to receive(:all_changed_files).and_return(modified_files)
             allow(@plugin.git_utils).to receive(:matching_lines_in_diff_files).with(files: modified_files, line_matcher: kind_of(Proc), change_type: nil).and_return([])
 
-            @plugin.check_tracks_changes(tracks_files: ['MyClass1.swift'])
+            @plugin.check_tracks_changes(tracks_files: ['MyClass1.swift'], tracks_usage_matchers: tracks_matchers)
 
             expect(@dangerfile).to not_report
           end
@@ -71,7 +86,7 @@ module Danger
               [analytics_call_in_diff]
             end
 
-            @plugin.check_tracks_changes
+            @plugin.check_tracks_changes(tracks_files: track_files, tracks_usage_matchers: tracks_matchers)
 
             expect(@dangerfile).to report_messages([TracksChecker::TRACKS_PR_INSTRUCTIONS])
           end
@@ -87,7 +102,7 @@ module Danger
               [analytics_call_in_diff]
             end
 
-            @plugin.check_tracks_changes(tracks_usage_matchers: [/AnalyticsHelper\.log/])
+            @plugin.check_tracks_changes(tracks_files: track_files, tracks_usage_matchers: [/AnalyticsHelper\.log/])
 
             expect(@dangerfile).to report_messages([TracksChecker::TRACKS_PR_INSTRUCTIONS])
           end
@@ -103,7 +118,7 @@ module Danger
               []
             end
 
-            @plugin.check_tracks_changes
+            @plugin.check_tracks_changes(tracks_files: track_files, tracks_usage_matchers: tracks_matchers)
 
             expect(@dangerfile).to not_report
           end
@@ -119,7 +134,7 @@ module Danger
               []
             end
 
-            @plugin.check_tracks_changes(tracks_usage_matchers: [/AnalyticsHelper\.log$/])
+            @plugin.check_tracks_changes(tracks_files: track_files, tracks_usage_matchers: [/AnalyticsHelper\.log$/])
 
             expect(@dangerfile).to not_report
           end

--- a/spec/tracks_checker_spec.rb
+++ b/spec/tracks_checker_spec.rb
@@ -33,15 +33,24 @@ module Danger
         before do
           allow(@plugin.git).to receive_messages(modified_files: [], added_files: [], deleted_files: [])
 
-          allow(@plugin.github).to receive(:pr_labels).and_return(['Tracks'])
           stub_const('GitDiffStruct', Struct.new(:type, :path, :patch))
         end
 
         context 'when checking changes in Tracks-related files' do
           it 'reports a message with instructions for review when there are changes in Tracks-related files' do
+            tracks_label = '[Tracks]'
+            allow(@plugin.github).to receive(:pr_labels).and_return([tracks_label])
             allow(@plugin.git_utils).to receive(:all_changed_files).and_return(['Test.kt', 'LoginAnalyticsTracker.kt', 'Test.java'])
 
-            @plugin.check_tracks_changes(tracks_files: track_files, tracks_usage_matchers: tracks_matchers)
+            @plugin.check_tracks_changes(tracks_files: track_files, tracks_usage_matchers: tracks_matchers, tracks_label: tracks_label)
+
+            expect(@dangerfile).to report_messages([TracksChecker::TRACKS_PR_INSTRUCTIONS + format(TracksChecker::TRACKS_NO_LABEL_INSTRUCTION_FORMAT, tracks_label)])
+          end
+
+          it 'reports a message with instructions for review without the label check when there are changes in Tracks-related files and no label parameter' do
+            allow(@plugin.git_utils).to receive(:all_changed_files).and_return(['Test.kt', 'LoginAnalyticsTracker.kt', 'Test.java'])
+
+            @plugin.check_tracks_changes(tracks_files: track_files, tracks_usage_matchers: tracks_matchers, tracks_label: nil)
 
             expect(@dangerfile).to report_messages([TracksChecker::TRACKS_PR_INSTRUCTIONS])
           end
@@ -50,18 +59,21 @@ module Danger
             allow(@plugin.github).to receive(:pr_labels).and_return([])
             allow(@plugin.git_utils).to receive(:all_changed_files).and_return(['Test.kt', 'LoginAnalyticsTracker.kt', 'Test.java'])
 
-            @plugin.check_tracks_changes(tracks_files: track_files, tracks_usage_matchers: tracks_matchers)
+            tracks_label = 'TRACKS'
+            @plugin.check_tracks_changes(tracks_files: track_files, tracks_usage_matchers: tracks_matchers, tracks_label: tracks_label)
 
-            expect(@dangerfile.status_report[:messages]).to eq [TracksChecker::TRACKS_PR_INSTRUCTIONS]
-            expect(@dangerfile.status_report[:errors]).to eq [TracksChecker::TRACKS_NO_LABEL_MESSAGE]
+            expect(@dangerfile.status_report[:messages]).to eq [TracksChecker::TRACKS_PR_INSTRUCTIONS + format(TracksChecker::TRACKS_NO_LABEL_INSTRUCTION_FORMAT, tracks_label)]
+            expect(@dangerfile.status_report[:errors]).to eq [format(TracksChecker::TRACKS_NO_LABEL_MESSAGE_FORMAT, tracks_label)]
           end
 
           it 'reports a message with instructions for review when there are changes in Tracks-related files using a custom file list' do
+            tracks_label = 'tracks'
+            allow(@plugin.github).to receive(:pr_labels).and_return([tracks_label])
             allow(@plugin.git_utils).to receive(:all_changed_files).and_return(['MyClass.swift', 'MyClass1.swift', 'MyClass2.swift'])
 
-            @plugin.check_tracks_changes(tracks_files: ['MyClass1.swift'], tracks_usage_matchers: tracks_matchers)
+            @plugin.check_tracks_changes(tracks_files: ['MyClass1.swift'], tracks_usage_matchers: tracks_matchers, tracks_label: tracks_label)
 
-            expect(@dangerfile).to report_messages([TracksChecker::TRACKS_PR_INSTRUCTIONS])
+            expect(@dangerfile).to report_messages([TracksChecker::TRACKS_PR_INSTRUCTIONS + format(TracksChecker::TRACKS_NO_LABEL_INSTRUCTION_FORMAT, tracks_label)])
           end
 
           it 'does nothing when there are no changes in Tracks-related files' do
@@ -69,7 +81,7 @@ module Danger
             allow(@plugin.git_utils).to receive(:all_changed_files).and_return(modified_files)
             allow(@plugin.git_utils).to receive(:matching_lines_in_diff_files).with(files: modified_files, line_matcher: kind_of(Proc), change_type: nil).and_return([])
 
-            @plugin.check_tracks_changes(tracks_files: track_files, tracks_usage_matchers: tracks_matchers)
+            @plugin.check_tracks_changes(tracks_files: track_files, tracks_usage_matchers: tracks_matchers, tracks_label: nil)
 
             expect(@dangerfile).to not_report
           end
@@ -79,7 +91,7 @@ module Danger
             allow(@plugin.git_utils).to receive(:all_changed_files).and_return(modified_files)
             allow(@plugin.git_utils).to receive(:matching_lines_in_diff_files).with(files: modified_files, line_matcher: kind_of(Proc), change_type: nil).and_return([])
 
-            @plugin.check_tracks_changes(tracks_files: ['MyClass1.swift'], tracks_usage_matchers: tracks_matchers)
+            @plugin.check_tracks_changes(tracks_files: ['MyClass1.swift'], tracks_usage_matchers: tracks_matchers, tracks_label: nil)
 
             expect(@dangerfile).to not_report
           end
@@ -87,6 +99,8 @@ module Danger
 
         context 'when checking Tracks-related changes within a diff' do
           it 'reports a message with instructions for review when there are matching changes' do
+            tracks_label = 'Tracks'
+            allow(@plugin.github).to receive(:pr_labels).and_return([tracks_label])
             modified_files = ['MyClass.kt']
             allow(@plugin.git_utils).to receive(:all_changed_files).and_return(modified_files)
 
@@ -97,12 +111,14 @@ module Danger
               [analytics_call_in_diff]
             end
 
-            @plugin.check_tracks_changes(tracks_files: track_files, tracks_usage_matchers: tracks_matchers)
+            @plugin.check_tracks_changes(tracks_files: track_files, tracks_usage_matchers: tracks_matchers, tracks_label: tracks_label)
 
-            expect(@dangerfile).to report_messages([TracksChecker::TRACKS_PR_INSTRUCTIONS])
+            expect(@dangerfile).to report_messages([TracksChecker::TRACKS_PR_INSTRUCTIONS + format(TracksChecker::TRACKS_NO_LABEL_INSTRUCTION_FORMAT, tracks_label)])
           end
 
           it 'reports a message with instructions for review when there are changes using a custom line matcher expression' do
+            tracks_label = 'Tracks'
+            allow(@plugin.github).to receive(:pr_labels).and_return([tracks_label])
             modified_files = ['MyClass.kt']
             allow(@plugin.git_utils).to receive(:all_changed_files).and_return(modified_files)
 
@@ -113,9 +129,9 @@ module Danger
               [analytics_call_in_diff]
             end
 
-            @plugin.check_tracks_changes(tracks_files: track_files, tracks_usage_matchers: [/AnalyticsHelper\.log/])
+            @plugin.check_tracks_changes(tracks_files: track_files, tracks_usage_matchers: [/AnalyticsHelper\.log/], tracks_label: tracks_label)
 
-            expect(@dangerfile).to report_messages([TracksChecker::TRACKS_PR_INSTRUCTIONS])
+            expect(@dangerfile).to report_messages([TracksChecker::TRACKS_PR_INSTRUCTIONS + format(TracksChecker::TRACKS_NO_LABEL_INSTRUCTION_FORMAT, tracks_label)])
           end
 
           it 'does nothing when there are no matching changes' do
@@ -129,7 +145,7 @@ module Danger
               []
             end
 
-            @plugin.check_tracks_changes(tracks_files: track_files, tracks_usage_matchers: tracks_matchers)
+            @plugin.check_tracks_changes(tracks_files: track_files, tracks_usage_matchers: tracks_matchers, tracks_label: nil)
 
             expect(@dangerfile).to not_report
           end
@@ -145,7 +161,7 @@ module Danger
               []
             end
 
-            @plugin.check_tracks_changes(tracks_files: track_files, tracks_usage_matchers: [/AnalyticsHelper\.log$/])
+            @plugin.check_tracks_changes(tracks_files: track_files, tracks_usage_matchers: [/AnalyticsHelper\.log$/], tracks_label: nil)
 
             expect(@dangerfile).to not_report
           end


### PR DESCRIPTION
As a long overdue follow up to https://wp.me/p91TBi-aE9-p2, this PR updates the Tracks Checker plugin.

The changes:
- Removal of the over specific defaults.
- A new `Tracks` label check, instead of just a text instruction.
- Update of the reported message