### PR TITLE
Remove non intuitive defaults

### DIFF
--- a/lib/dangermattic/plugins/labels_checker.rb
+++ b/lib/dangermattic/plugins/labels_checker.rb
@@ -16,16 +16,11 @@ module Danger
   # @tags github, process
   #
   class LabelsChecker < Plugin
-    DEFAULT_DO_NOT_MERGE_LABELS = [
-      'Do Not Merge'
-    ].freeze
-
     # Checks if a PR is missing labels or is marked with labels for not merging.
     # If recommended labels are missing, the plugin will emit a warning. If a required label is missing, or the PR
     # has a label indicating that the PR should not be merged, an error will be emitted, preventing the final merge.
     #
-    # @param do_not_merge_labels [String] The possible labels indicating that a merge should not be allowed.
-    #   Defaults to DEFAULT_DO_NOT_MERGE_LABELS if not provided.
+    # @param do_not_merge_labels [Array<String>] The possible labels indicating that a merge should not be allowed.
     # @param required_labels [Array<Regexp>] The list of Regular Expressions describing all the type of labels that are *required* on PR (e.g. `[/^feature:/, `/^type:/]` or `bug|bugfix-exemption`).
     #   Defaults to an empty array if not provided.
     # @param required_labels_error [String] The error message displayed if the required labels are not present.
@@ -40,12 +35,12 @@ module Danger
     #  an array of a single empty regex `[//]` to match "a label with any name".
     #
     # @return [void]
-    def check(do_not_merge_labels: DEFAULT_DO_NOT_MERGE_LABELS, required_labels: [], required_labels_error: nil, recommended_labels: [], recommended_labels_warning: nil)
+    def check(do_not_merge_labels: [], required_labels: [], required_labels_error: nil, recommended_labels: [], recommended_labels_warning: nil)
       github_labels = danger.github.pr_labels
 
       # A PR shouldn't be merged with the 'DO NOT MERGE' label
       found_do_not_merge_labels = github_labels.select do |github_label|
-        do_not_merge_labels.any? { |label| github_label.casecmp?(label) }
+        do_not_merge_labels&.any? { |label| github_label.casecmp?(label) }
       end
 
       failure("This PR is tagged with #{markdown_list_string(found_do_not_merge_labels)} label(s).") unless found_do_not_merge_labels.empty?

--- a/lib/dangermattic/plugins/milestone_checker.rb
+++ b/lib/dangermattic/plugins/milestone_checker.rb
@@ -14,7 +14,7 @@ module Danger
   # @example Run a milestone check
   #
   #          # Check if milestone due date is approaching, reporting a warning if the milestone is in less than 5 days
-  #          checker.check_milestone_due_date
+  #          checker.check_milestone_due_date(days_before_due: 5)
   #
   # @example Run a milestone check with custom parameters
   #
@@ -30,8 +30,6 @@ module Danger
   # @tags milestone, github, process
   #
   class MilestoneChecker < Plugin
-    DEFAULT_DAYS_THRESHOLD = 5
-
     # Checks if the pull request is assigned to a milestone.
     #
     # @return [void]
@@ -44,12 +42,12 @@ module Danger
 
     # Checks if the pull request's milestone is due to finish within a certain number of days.
     #
-    # @param days_before_due [Integer] Number of days before the milestone due date for the check to apply (default: DEFAULT_DAYS_THRESHOLD).
+    # @param days_before_due [Integer] Number of days before the milestone due date for the check to apply.
     # @param report_type [Symbol] (optional) The type of message for when the PR is has passed over the `days_before_due` threshold. Types: :error, :warning (default), :message.
     # @param report_type_if_no_milestone [Symbol] The type of message for when the PR is not assigned to a milestone. Types: :error, :warning (default), :message. You can also pass :none to not leave a message when there is no milestone.
     #
     # @return [void]
-    def check_milestone_due_date(days_before_due: DEFAULT_DAYS_THRESHOLD, report_type: :warning, report_type_if_no_milestone: :warning)
+    def check_milestone_due_date(days_before_due:, report_type: :warning, report_type_if_no_milestone: :warning)
       if milestone.nil?
         check_milestone_set(report_type: report_type_if_no_milestone)
         return

--- a/lib/dangermattic/plugins/pr_size_checker.rb
+++ b/lib/dangermattic/plugins/pr_size_checker.rb
@@ -6,7 +6,7 @@ module Danger
   # @example Running a PR diff size check with default parameters
   #
   #          # Check the total size of changes in the PR using the default parameters, reporting a warning if the PR is larger than 500
-  #          pr_size_checker.check_diff_size
+  #          pr_size_checker.check_diff_size(max_size: 500)
   #
   # @example Running a PR diff size check customizing the size, message and type of report
   #
@@ -21,7 +21,7 @@ module Danger
   # @example Running a PR description length check
   #
   #          # Check the PR Body using the default parameters, reporting a warning if the PR is smaller than 10 characters
-  #          pr_size_checker.check_pr_body
+  #          pr_size_checker.check_pr_body(min_length: 10)
   #
   # @example Running a PR description length check with custom parameters
   #
@@ -32,21 +32,19 @@ module Danger
   # @tags github, pull request, process
   #
   class PRSizeChecker < Plugin
-    DEFAULT_MAX_DIFF_SIZE = 500
     DEFAULT_DIFF_SIZE_MESSAGE_FORMAT = 'This PR is larger than %d lines of changes. Please consider splitting it into smaller PRs for easier and faster reviews.'
-    DEFAULT_MIN_PR_BODY = 10
     DEFAULT_MIN_PR_BODY_MESSAGE_FORMAT = 'The PR description appears very short, less than %d characters long. Please provide a summary of your changes in the PR description.'
 
     # Check the size of the PR diff against a specified maximum size.
     #
+    # @param max_size [Integer] The maximum allowed size for the diff.
     # @param file_selector [Proc] Optional closure to filter the files in the diff to be used for size calculation.
     # @param type [:insertions, :deletions, :all] The type of diff size to check. (default: :all)
-    # @param max_size [Integer] The maximum allowed size for the diff. (default: DEFAULT_MAX_DIFF_SIZE)
     # @param message [String] The message to display if the diff size exceeds the maximum. (default: DEFAULT_DIFF_SIZE_MESSAGE)
     # @param report_type [Symbol] (optional) The type of report for the message. Types: :error, :warning (default), :message.
     #
     # @return [void]
-    def check_diff_size(file_selector: nil, type: :all, max_size: DEFAULT_MAX_DIFF_SIZE, message: format(DEFAULT_DIFF_SIZE_MESSAGE_FORMAT, max_size), report_type: :warning)
+    def check_diff_size(max_size:, file_selector: nil, type: :all, message: format(DEFAULT_DIFF_SIZE_MESSAGE_FORMAT, max_size), report_type: :warning)
       case type
       when :insertions
         reporter.report(message: message, type: report_type) if insertions_size(file_selector: file_selector) > max_size
@@ -59,12 +57,12 @@ module Danger
 
     # Check the size of the Pull Request description (PR body) against a specified minimum size.
     #
-    # @param min_length [Integer] The minimum allowed length for the PR body. (default: DEFAULT_MIN_PR_BODY)
+    # @param min_length [Integer] The minimum allowed length for the PR body.
     # @param message [String] The message to display if the length of the PR body is smaller than the minimum. (default: DEFAULT_MIN_PR_BODY_MESSAGE_FORMAT)
     # @param report_type [Boolean] If true, fail the PR check when the PR body length is too small. (default: false)
     #
     # @return [void]
-    def check_pr_body(min_length: DEFAULT_MIN_PR_BODY, message: format(DEFAULT_MIN_PR_BODY_MESSAGE_FORMAT, min_length), report_type: :warning)
+    def check_pr_body(min_length:, message: format(DEFAULT_MIN_PR_BODY_MESSAGE_FORMAT, min_length), report_type: :warning)
       return if danger.github.pr_body.length > min_length
 
       reporter.report(message: message, type: report_type)

--- a/spec/labels_checker_spec.rb
+++ b/spec/labels_checker_spec.rb
@@ -120,11 +120,11 @@ module Danger
       end
 
       context 'with \'do not merge\' labels' do
-        it 'reports an error when a PR has a \'do not merge\' label' do
+        it 'reports an error when a PR has a single \'do not merge\' label' do
           pr_label = 'DO NOT MERGE'
           allow(@plugin.github).to receive(:pr_labels).and_return([pr_label])
 
-          @plugin.check
+          @plugin.check(do_not_merge_labels: [pr_label])
 
           expect(@dangerfile).to report_errors(["This PR is tagged with `#{pr_label}` label(s)."])
         end

--- a/spec/milestone_checker_spec.rb
+++ b/spec/milestone_checker_spec.rb
@@ -82,7 +82,7 @@ module Danger
           allow(@plugin.github).to receive(:pr_json).and_return(pr_json)
           allow(DateTime).to receive(:now).and_return(date_one_day_before_due)
 
-          @plugin.check_milestone_due_date
+          @plugin.check_milestone_due_date(days_before_due: 5)
 
           expected_warning = ["This PR is assigned to the milestone [Release Day](https://wp.com). This milestone is due in less than 5 days.\nPlease make sure to get it merged by then or assign it to a milestone with a later deadline."]
           expect(@dangerfile).to report_warnings(expected_warning)
@@ -103,7 +103,7 @@ module Danger
           allow(@plugin.github).to receive(:pr_json).and_return(pr_json)
           allow(DateTime).to receive(:now).and_return(more_than_five_days_before_due)
 
-          @plugin.check_milestone_due_date
+          @plugin.check_milestone_due_date(days_before_due: 5)
 
           expect(@dangerfile).to not_report
         end
@@ -123,7 +123,7 @@ module Danger
           allow(@plugin.github).to receive(:pr_json).and_return(pr_json)
           allow(DateTime).to receive(:now).and_return(date_one_day_after_due)
 
-          @plugin.check_milestone_due_date(report_type: :error)
+          @plugin.check_milestone_due_date(days_before_due: 5, report_type: :error)
 
           expected_warning = ["This PR is assigned to the milestone [Release Day](https://wp.com). The due date for this milestone has already passed.\nPlease assign it to a milestone with a later deadline or check whether the release for this milestone has already been finished."]
           expect(@dangerfile).to report_errors(expected_warning)
@@ -161,7 +161,7 @@ module Danger
 
           allow(@plugin.github).to receive(:pr_json).and_return(pr_json)
 
-          @plugin.check_milestone_due_date
+          @plugin.check_milestone_due_date(days_before_due: 5)
 
           expect(@dangerfile).to not_report
         end
@@ -178,7 +178,7 @@ module Danger
 
           allow(@plugin.github).to receive(:pr_json).and_return(pr_json)
 
-          @plugin.check_milestone_due_date
+          @plugin.check_milestone_due_date(days_before_due: 5)
 
           expect(@dangerfile).to not_report
         end
@@ -186,7 +186,7 @@ module Danger
         it "reports a warning when asked to do so when a PR doesn't have a milestone set" do
           allow(@plugin.github).to receive(:pr_json).and_return({})
 
-          @plugin.check_milestone_due_date(report_type_if_no_milestone: :warning)
+          @plugin.check_milestone_due_date(days_before_due: 5, report_type_if_no_milestone: :warning)
 
           expected_warning = ['PR is not assigned to a milestone.']
           expect(@dangerfile).to report_warnings(expected_warning)
@@ -195,7 +195,7 @@ module Danger
         it "reports an error when asked to do so when a PR doesn't have a milestone set" do
           allow(@plugin.github).to receive(:pr_json).and_return({})
 
-          @plugin.check_milestone_due_date(report_type_if_no_milestone: :error)
+          @plugin.check_milestone_due_date(days_before_due: 5, report_type_if_no_milestone: :error)
 
           expected_error = ['PR is not assigned to a milestone.']
           expect(@dangerfile).to report_errors(expected_error)
@@ -204,7 +204,7 @@ module Danger
         it "does nothing when asked to do so when a PR doesn't have a milestone set" do
           allow(@plugin.github).to receive(:pr_json).and_return({})
 
-          @plugin.check_milestone_due_date(report_type_if_no_milestone: :none)
+          @plugin.check_milestone_due_date(days_before_due: 5, report_type_if_no_milestone: :none)
 
           expect(@dangerfile).to not_report
         end
@@ -212,7 +212,7 @@ module Danger
         it "does nothing when nil is used and a PR doesn't have a milestone set" do
           allow(@plugin.github).to receive(:pr_json).and_return({})
 
-          @plugin.check_milestone_due_date(report_type_if_no_milestone: nil)
+          @plugin.check_milestone_due_date(days_before_due: 5, report_type_if_no_milestone: nil)
 
           expect(@dangerfile).to not_report
         end

--- a/spec/pr_size_checker_spec.rb
+++ b/spec/pr_size_checker_spec.rb
@@ -30,26 +30,26 @@ module Danger
             type_hash[type]
           end
 
-          it 'reports a warning when using default parameters in a PR that has larger diff than the default maximum' do
+          it 'reports a warning when using default parameters in a PR that has larger diff than the maximum' do
             allow(@plugin.git).to receive(diff_counter_for_type).and_return(501)
 
-            @plugin.check_diff_size(type: type)
+            @plugin.check_diff_size(max_size: 500, type: type)
 
-            expect(@dangerfile).to report_warnings([format(described_class::DEFAULT_DIFF_SIZE_MESSAGE_FORMAT, described_class::DEFAULT_MAX_DIFF_SIZE)])
+            expect(@dangerfile).to report_warnings([format(described_class::DEFAULT_DIFF_SIZE_MESSAGE_FORMAT, 500)])
           end
 
-          it 'does nothing when using default parameters in a PR that has equal diff than the default maximum' do
+          it 'does nothing when using default parameters in a PR that has equal diff than the maximum' do
             allow(@plugin.git).to receive(diff_counter_for_type).and_return(500)
 
-            @plugin.check_diff_size(type: type)
+            @plugin.check_diff_size(max_size: 500, type: type)
 
             expect(@dangerfile).to not_report
           end
 
-          it 'does nothing when using default parameters in a PR that has smaller diff than the default maximum' do
+          it 'does nothing when using default parameters in a PR that has smaller diff than the maximum' do
             allow(@plugin.git).to receive(diff_counter_for_type).and_return(499)
 
-            @plugin.check_diff_size(type: type)
+            @plugin.check_diff_size(max_size: 500, type: type)
 
             expect(@dangerfile).to not_report
           end
@@ -60,9 +60,9 @@ module Danger
                 allow(@plugin.git).to receive(diff_counter_for_type).and_return(600)
 
                 if message
-                  @plugin.check_diff_size(type: type, max_size: 599, message: message, report_type: report_type)
+                  @plugin.check_diff_size(max_size: 599, type: type, message: message, report_type: report_type)
                 else
-                  @plugin.check_diff_size(type: type, max_size: 599, report_type: report_type)
+                  @plugin.check_diff_size(max_size: 599, type: type, report_type: report_type)
                 end
 
                 message ||= format(described_class::DEFAULT_DIFF_SIZE_MESSAGE_FORMAT, 599)
@@ -95,9 +95,9 @@ module Danger
               prepare_diff_with_test_files
 
               @plugin.check_diff_size(
+                max_size: max_sizes[0],
                 file_selector: ->(path) { File.dirname(path).start_with?('src/test/java') },
-                type: type,
-                max_size: max_sizes[0]
+                type: type
               )
 
               expect(@dangerfile).to report_warnings([format(described_class::DEFAULT_DIFF_SIZE_MESSAGE_FORMAT, max_sizes[0])])
@@ -108,9 +108,9 @@ module Danger
 
               custom_message = 'diff size too large custom file filter and error message'
               @plugin.check_diff_size(
+                max_size: max_sizes[1],
                 file_selector: ->(path) { File.extname(path) == '.java' },
                 type: type,
-                max_size: max_sizes[1],
                 message: custom_message,
                 report_type: :error
               )
@@ -123,9 +123,9 @@ module Danger
             prepare_diff_with_test_files
 
             @plugin.check_diff_size(
+              max_size: max_sizes[2],
               file_selector: ->(path) { File.extname(path).match(/^(.java|.kt)$/) },
-              type: type,
-              max_size: max_sizes[2]
+              type: type
             )
 
             expect(@dangerfile).to not_report
@@ -179,28 +179,28 @@ module Danger
       end
 
       context 'when checking a PR body size' do
-        it 'reports a warning when using default parameters in a PR that has a smaller body text length than the default minimum' do
+        it 'reports a warning when using default parameters in a PR that has a smaller body text length than the minimum' do
           allow(@plugin.github).to receive(:pr_body).and_return('PR body')
 
-          @plugin.check_pr_body
+          @plugin.check_pr_body(min_length: 15)
 
-          expect(@dangerfile).to report_warnings([format(described_class::DEFAULT_MIN_PR_BODY_MESSAGE_FORMAT, described_class::DEFAULT_MIN_PR_BODY)])
+          expect(@dangerfile).to report_warnings([format(described_class::DEFAULT_MIN_PR_BODY_MESSAGE_FORMAT, 15)])
         end
 
-        it 'does nothing when using default parameters in a PR that has a bigger PR body text length than the default minimum' do
+        it 'does nothing when using default parameters in a PR that has a bigger PR body text length than the minimum' do
           allow(@plugin.github).to receive(:pr_body).and_return('some test PR body')
 
-          @plugin.check_pr_body
+          @plugin.check_pr_body(min_length: 10)
 
           expect(@dangerfile).to not_report
         end
 
-        it 'reports a warning when using default parameters in a PR that has an equal PR body text length than the default minimum' do
+        it 'reports a warning when using default parameters in a PR that has an equal PR body text length than the minimum' do
           allow(@plugin.github).to receive(:pr_body).and_return('some test-')
 
-          @plugin.check_pr_body
+          @plugin.check_pr_body(min_length: 10)
 
-          expect(@dangerfile).to report_warnings([format(described_class::DEFAULT_MIN_PR_BODY_MESSAGE_FORMAT, described_class::DEFAULT_MIN_PR_BODY)])
+          expect(@dangerfile).to report_warnings([format(described_class::DEFAULT_MIN_PR_BODY_MESSAGE_FORMAT, 10)])
         end
 
         context 'when reporting a custom error or warning with a custom min_length' do


### PR DESCRIPTION
This PR was based on a few other discussions we had in the apps' side on whether some of the default values in a few plugins would create "obscure" behavior.
This PR removes these values so that the apps will have to provide them, improving the readability of the check call in the `Dangerfile`s.