### PR TITLE
Fix for Danger executions from `Dependabot`

### DIFF
--- a/.github/workflows/reusable-run-danger.yml
+++ b/.github/workflows/reusable-run-danger.yml
@@ -34,13 +34,13 @@ jobs:
       - name: "☢️ Danger PR Check"
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}
-          RUNNING_ON_FORK: ${{ github.event.pull_request.head.repo.fork }}
+          READ_ONLY_MODE: ${{ github.event.pull_request.head.repo.fork || github.actor == 'dependabot[bot]' }}
           REMOVE_PREVIOUS_COMMENTS: ${{ inputs.remove-previous-comments }}
           DANGER_GITHUB_API_TOKEN: ${{ secrets.github-token }}
         run: |
           echo "--- 🏃 Running Danger: PR Check"
 
-          if [ "$RUNNING_ON_FORK" = true ]; then
+          if [ "$READ_ONLY_MODE" = true ]; then
             danger_output=$(bundle exec danger pr "$PR_URL" --verbose)
 
             echo "$danger_output"


### PR DESCRIPTION
This PR changes the shared Danger workflow to run Dependabot-triggered jobs on "read only mode", similarly to forks.

See:
- [GitHub Actions: Workflows triggered by Dependabot PRs will run with read-only permissions](https://github.blog/changelog/2021-02-19-github-actions-workflows-triggered-by-dependabot-prs-will-run-with-read-only-permissions/)
- https://github.com/dependabot/dependabot-core/issues/3253#issuecomment-852541544