### PR TITLE
Check for Tracks only in added / removed diff lines

### DIFF
--- a/lib/dangermattic/plugins/common/git_utils.rb
+++ b/lib/dangermattic/plugins/common/git_utils.rb
@@ -84,6 +84,7 @@ module Danger
     # @param change_type [Symbol, nil] Change type to filter lines (e.g., :added, :removed) or nil for no filter
     # @return [Array<MatchedData>] Array of MatchedData objects representing matched lines in files
     def matching_lines_in_diff_files(files:, line_matcher:, change_type: nil)
+      change_types = Array(change_type).map(&:to_sym)
       matched_data = []
 
       files.each do |file|
@@ -92,7 +93,7 @@ module Danger
         diff = danger.git.diff_for_file(file)
 
         diff.patch.each_line do |line|
-          matched_lines << line if line_matcher.call(line) && (change_type.nil? || change_type(diff_line: line) == change_type)
+          matched_lines << line if line_matcher.call(line) && (change_type.nil? || change_types.include?(change_type(diff_line: line)))
         end
 
         matched_data << MatchedData.new(file, matched_lines) unless matched_lines.empty?

--- a/lib/dangermattic/plugins/common/git_utils.rb
+++ b/lib/dangermattic/plugins/common/git_utils.rb
@@ -81,7 +81,8 @@ module Danger
     #
     # @param files [Array<String>] List of file names to check
     # @param line_matcher [Proc] A callable that takes a line and returns true if it matches the desired pattern
-    # @param change_type [Symbol, nil] Change type to filter lines (e.g., :added, :removed) or nil for no filter
+    # @param change_type [Symbol, Array<Symbol>, nil] Change type(s) to filter lines (e.g., `:added`, `:removed`,
+    #                    `:context`, `[:added, :removed]`, …), or nil for no filter
     # @return [Array<MatchedData>] Array of MatchedData objects representing matched lines in files
     def matching_lines_in_diff_files(files:, line_matcher:, change_type: nil)
       change_types = Array(change_type).map(&:to_sym)

--- a/lib/dangermattic/plugins/tracks_checker.rb
+++ b/lib/dangermattic/plugins/tracks_checker.rb
@@ -60,24 +60,10 @@ module Danger
     end
 
     def diff_has_tracks_changes?(tracks_usage_matchers:)
-      tracks_changes_on_additions = diff_has_tracks_changes_for_change_type?(
-        tracks_usage_matchers: tracks_usage_matchers,
-        change_type: :added
-      )
-
-      tracks_changes_on_removals = diff_has_tracks_changes_for_change_type?(
-        tracks_usage_matchers: tracks_usage_matchers,
-        change_type: :removed
-      )
-
-      tracks_changes_on_additions || tracks_changes_on_removals
-    end
-
-    def diff_has_tracks_changes_for_change_type?(tracks_usage_matchers:, change_type:)
       matched_lines = git_utils.matching_lines_in_diff_files(
         files: git_utils.all_changed_files,
         line_matcher: ->(line) { tracks_usage_matchers.any? { |tracks_usage_match| line.match(tracks_usage_match) } },
-        change_type: change_type
+        change_type: %i[added removed]
       )
 
       !matched_lines.empty?

--- a/lib/dangermattic/plugins/tracks_checker.rb
+++ b/lib/dangermattic/plugins/tracks_checker.rb
@@ -60,10 +60,24 @@ module Danger
     end
 
     def diff_has_tracks_changes?(tracks_usage_matchers:)
+      tracks_changes_on_additions = diff_has_tracks_changes_for_change_type?(
+        tracks_usage_matchers: tracks_usage_matchers,
+        change_type: :added
+      )
+
+      tracks_changes_on_removals = diff_has_tracks_changes_for_change_type?(
+        tracks_usage_matchers: tracks_usage_matchers,
+        change_type: :removed
+      )
+
+      tracks_changes_on_additions || tracks_changes_on_removals
+    end
+
+    def diff_has_tracks_changes_for_change_type?(tracks_usage_matchers:, change_type:)
       matched_lines = git_utils.matching_lines_in_diff_files(
         files: git_utils.all_changed_files,
         line_matcher: ->(line) { tracks_usage_matchers.any? { |tracks_usage_match| line.match(tracks_usage_match) } },
-        change_type: nil
+        change_type: change_type
       )
 
       !matched_lines.empty?

--- a/spec/tracks_checker_spec.rb
+++ b/spec/tracks_checker_spec.rb
@@ -68,8 +68,7 @@ module Danger
           it 'does nothing when there are no changes in Tracks-related files' do
             modified_files = ['MyClass.swift']
             allow(@plugin.git_utils).to receive(:all_changed_files).and_return(modified_files)
-            allow(@plugin.git_utils).to receive(:matching_lines_in_diff_files).with(files: modified_files, line_matcher: kind_of(Proc), change_type: :added).and_return([])
-            allow(@plugin.git_utils).to receive(:matching_lines_in_diff_files).with(files: modified_files, line_matcher: kind_of(Proc), change_type: :removed).and_return([])
+            allow(@plugin.git_utils).to receive(:matching_lines_in_diff_files).with(files: modified_files, line_matcher: kind_of(Proc), change_type: %i[added removed]).and_return([])
 
             @plugin.check_tracks_changes(tracks_files: track_files, tracks_usage_matchers: tracks_matchers, tracks_label: nil)
 
@@ -84,8 +83,7 @@ module Danger
             modified_files = ['MyClass.kt']
             allow(@plugin.git_utils).to receive(:all_changed_files).and_return(modified_files)
 
-            allow_diff_match_with_change_type(modified_files: modified_files, diff_line: '-      AnalyticsTracker.track("myEvent1")', change_type: :removed, expect_match: true)
-            allow_diff_match_with_change_type(modified_files: modified_files, diff_line: '      diff text', change_type: :added, expect_match: false)
+            allow_diff_match(modified_files: modified_files, diff_line: '-      AnalyticsTracker.track("myEvent1")', expect_match: true)
 
             @plugin.check_tracks_changes(tracks_files: track_files, tracks_usage_matchers: tracks_matchers, tracks_label: tracks_label)
 
@@ -96,8 +94,7 @@ module Danger
             modified_files = ['MyClass.kt']
             allow(@plugin.git_utils).to receive(:all_changed_files).and_return(modified_files)
 
-            allow_diff_match_with_change_type(modified_files: modified_files, diff_line: '-      diff', change_type: :removed, expect_match: false)
-            allow_diff_match_with_change_type(modified_files: modified_files, diff_line: '+      AnalyticsTracker.track("evento")', change_type: :added, expect_match: true)
+            allow_diff_match(modified_files: modified_files, diff_line: '+      AnalyticsTracker.track("evento")', expect_match: true)
 
             @plugin.check_tracks_changes(tracks_files: track_files, tracks_usage_matchers: tracks_matchers, tracks_label: nil)
 
@@ -109,8 +106,7 @@ module Danger
             modified_files = ['MyClass.kt']
             allow(@plugin.git_utils).to receive(:all_changed_files).and_return(modified_files)
 
-            allow_diff_match_with_change_type(modified_files: modified_files, diff_line: '-      AnalyticsTracker.track("evento")', change_type: :removed, expect_match: true)
-            allow_diff_match_with_change_type(modified_files: modified_files, diff_line: '+      AnalyticsTracker.track("myEvent1")', change_type: :added, expect_match: true)
+            allow_diff_match(modified_files: modified_files, diff_line: '-      AnalyticsTracker.track("evento")', expect_match: true)
 
             tracks_label = 'TRACKS PR'
             @plugin.check_tracks_changes(tracks_files: track_files, tracks_usage_matchers: tracks_matchers, tracks_label: tracks_label)
@@ -122,8 +118,7 @@ module Danger
             modified_files = ['MyClass.kt']
             allow(@plugin.git_utils).to receive(:all_changed_files).and_return(modified_files)
 
-            allow_diff_match_with_change_type(modified_files: modified_files, diff_line: '-      AnalyticsHelper.log("event_1")', change_type: :removed, expect_match: false)
-            allow_diff_match_with_change_type(modified_files: modified_files, diff_line: '+      AnalyticsHelper.log("event_2")', change_type: :added, expect_match: false)
+            allow_diff_match(modified_files: modified_files, diff_line: '-      AnalyticsHelper.log("event_1")', expect_match: false)
 
             @plugin.check_tracks_changes(tracks_files: track_files, tracks_usage_matchers: tracks_matchers, tracks_label: nil)
 
@@ -159,8 +154,8 @@ module Danger
         end
       end
 
-      def allow_diff_match_with_change_type(modified_files:, diff_line:, change_type:, expect_match:)
-        allow(@plugin.git_utils).to receive(:matching_lines_in_diff_files).with(files: modified_files, line_matcher: kind_of(Proc), change_type: change_type) do |args|
+      def allow_diff_match(modified_files:, diff_line:, expect_match:)
+        allow(@plugin.git_utils).to receive(:matching_lines_in_diff_files).with(files: modified_files, line_matcher: kind_of(Proc), change_type: %i[added removed]) do |args|
           expect(args[:line_matcher].call(diff_line)).to be expect_match
 
           result = []

--- a/spec/tracks_checker_spec.rb
+++ b/spec/tracks_checker_spec.rb
@@ -68,7 +68,8 @@ module Danger
           it 'does nothing when there are no changes in Tracks-related files' do
             modified_files = ['MyClass.swift']
             allow(@plugin.git_utils).to receive(:all_changed_files).and_return(modified_files)
-            allow(@plugin.git_utils).to receive(:matching_lines_in_diff_files).with(files: modified_files, line_matcher: kind_of(Proc), change_type: nil).and_return([])
+            allow(@plugin.git_utils).to receive(:matching_lines_in_diff_files).with(files: modified_files, line_matcher: kind_of(Proc), change_type: :added).and_return([])
+            allow(@plugin.git_utils).to receive(:matching_lines_in_diff_files).with(files: modified_files, line_matcher: kind_of(Proc), change_type: :removed).and_return([])
 
             @plugin.check_tracks_changes(tracks_files: track_files, tracks_usage_matchers: tracks_matchers, tracks_label: nil)
 
@@ -83,12 +84,8 @@ module Danger
             modified_files = ['MyClass.kt']
             allow(@plugin.git_utils).to receive(:all_changed_files).and_return(modified_files)
 
-            allow(@plugin.git_utils).to receive(:matching_lines_in_diff_files).with(files: modified_files, line_matcher: kind_of(Proc), change_type: nil) do |args|
-              analytics_call_in_diff = '-                AnalyticsTracker.track("myEvent1")'
-              expect(args[:line_matcher].call(analytics_call_in_diff)).to be true
-
-              [analytics_call_in_diff]
-            end
+            allow_diff_match_with_change_type(modified_files: modified_files, diff_line: '-      AnalyticsTracker.track("myEvent1")', change_type: :removed, expect_match: true)
+            allow_diff_match_with_change_type(modified_files: modified_files, diff_line: '      diff text', change_type: :added, expect_match: false)
 
             @plugin.check_tracks_changes(tracks_files: track_files, tracks_usage_matchers: tracks_matchers, tracks_label: tracks_label)
 
@@ -99,12 +96,8 @@ module Danger
             modified_files = ['MyClass.kt']
             allow(@plugin.git_utils).to receive(:all_changed_files).and_return(modified_files)
 
-            allow(@plugin.git_utils).to receive(:matching_lines_in_diff_files).with(files: modified_files, line_matcher: kind_of(Proc), change_type: nil) do |args|
-              analytics_call_in_diff = '-                AnalyticsTracker.track("evento")'
-              expect(args[:line_matcher].call(analytics_call_in_diff)).to be true
-
-              [analytics_call_in_diff]
-            end
+            allow_diff_match_with_change_type(modified_files: modified_files, diff_line: '-      diff', change_type: :removed, expect_match: false)
+            allow_diff_match_with_change_type(modified_files: modified_files, diff_line: '+      AnalyticsTracker.track("evento")', change_type: :added, expect_match: true)
 
             @plugin.check_tracks_changes(tracks_files: track_files, tracks_usage_matchers: tracks_matchers, tracks_label: nil)
 
@@ -116,12 +109,8 @@ module Danger
             modified_files = ['MyClass.kt']
             allow(@plugin.git_utils).to receive(:all_changed_files).and_return(modified_files)
 
-            allow(@plugin.git_utils).to receive(:matching_lines_in_diff_files).with(files: modified_files, line_matcher: kind_of(Proc), change_type: nil) do |args|
-              analytics_call_in_diff = '-                AnalyticsTracker.track("myEvent1")'
-              expect(args[:line_matcher].call(analytics_call_in_diff)).to be true
-
-              [analytics_call_in_diff]
-            end
+            allow_diff_match_with_change_type(modified_files: modified_files, diff_line: '-      AnalyticsTracker.track("evento")', change_type: :removed, expect_match: true)
+            allow_diff_match_with_change_type(modified_files: modified_files, diff_line: '+      AnalyticsTracker.track("myEvent1")', change_type: :added, expect_match: true)
 
             tracks_label = 'TRACKS PR'
             @plugin.check_tracks_changes(tracks_files: track_files, tracks_usage_matchers: tracks_matchers, tracks_label: tracks_label)
@@ -133,17 +122,51 @@ module Danger
             modified_files = ['MyClass.kt']
             allow(@plugin.git_utils).to receive(:all_changed_files).and_return(modified_files)
 
-            allow(@plugin.git_utils).to receive(:matching_lines_in_diff_files).with(files: modified_files, line_matcher: kind_of(Proc), change_type: nil) do |args|
-              analytics_call_in_diff = '+                AnalyticsHelper.log("event_1")'
-              expect(args[:line_matcher].call(analytics_call_in_diff)).to be false
-
-              []
-            end
+            allow_diff_match_with_change_type(modified_files: modified_files, diff_line: '-      AnalyticsHelper.log("event_1")', change_type: :removed, expect_match: false)
+            allow_diff_match_with_change_type(modified_files: modified_files, diff_line: '+      AnalyticsHelper.log("event_2")', change_type: :added, expect_match: false)
 
             @plugin.check_tracks_changes(tracks_files: track_files, tracks_usage_matchers: tracks_matchers, tracks_label: nil)
 
             expect(@dangerfile).to not_report
           end
+
+          it 'does nothing when there are matching changes but in the context parts of the diff' do
+            modified_file = 'MyClass.kt'
+            allow(@plugin.git_utils).to receive(:all_changed_files).and_return([modified_file])
+
+            tracks_diff = <<~STRINGS
+              diff --git a/MyClass.kt b/MyClass.kt
+              index 5794d472..772e2b99 100644
+              - a/MyClass
+              + b/MyClass
+              @@ -1,3 +1,6 @@
+                AnalyticsTracker.track("myMagicEvent1")
+                // call magic
+              +  AnalyticsHelper.log("event_1")
+              +  AnalyticsHelper.log("event_2")
+              +  AnotherUtil.callMagic()
+                AnalyticsTracker.track("myMagicEvent2")
+            STRINGS
+
+            diff = GitDiffStruct.new('modified', modified_file, tracks_diff)
+
+            allow(@plugin.git).to receive(:diff_for_file).with(modified_file).and_return(diff)
+
+            @plugin.check_tracks_changes(tracks_files: track_files, tracks_usage_matchers: tracks_matchers, tracks_label: nil)
+
+            expect(@dangerfile).to not_report
+          end
+        end
+      end
+
+      def allow_diff_match_with_change_type(modified_files:, diff_line:, change_type:, expect_match:)
+        allow(@plugin.git_utils).to receive(:matching_lines_in_diff_files).with(files: modified_files, line_matcher: kind_of(Proc), change_type: change_type) do |args|
+          expect(args[:line_matcher].call(diff_line)).to be expect_match
+
+          result = []
+          result.append(diff_line) if expect_match
+
+          result
         end
       end
 


### PR DESCRIPTION
It was brought to my attention by @kidinov that the PR https://github.com/woocommerce/woocommerce-android/pull/10816 had the Tracks check flagged but no actual Tracks-related calls or files changed.

Checking [the diff used by Dangermattic](https://patch-diff.githubusercontent.com/raw/woocommerce/woocommerce-android/pull/10816.diff), I noticed that there are some Tracks calls in the context parts of the diff, which shouldn't be considered in the check.
This PR changes the code so that only additions / removals are considered.