### PR TITLE
Use default GITHUB_TOKEN when the `github-token` parameter isn't available

### DIFF
--- a/.github/workflows/reusable-run-danger.yml
+++ b/.github/workflows/reusable-run-danger.yml
@@ -36,7 +36,7 @@ jobs:
           PR_URL: ${{ github.event.pull_request.html_url }}
           READ_ONLY_MODE: ${{ github.event.pull_request.head.repo.fork || github.actor == 'dependabot[bot]' }}
           REMOVE_PREVIOUS_COMMENTS: ${{ inputs.remove-previous-comments }}
-          DANGER_GITHUB_API_TOKEN: ${{ secrets.github-token }}
+          DANGER_GITHUB_API_TOKEN: ${{ secrets.github-token || secrets.GITHUB_TOKEN }}
         run: |
           echo "--- 🏃 Running Danger: PR Check"
 


### PR DESCRIPTION
For read-only runs, the main repo secrets aren't forwarded to the GHA run, except a read-only `GITHUB_TOKEN`.
This PR changes the shared workflow so that it uses the `GITHUB_TOKEN` when the parameter isn't available.