### PR TITLE
Reusable GHA Workflow for retrying Buildkite jobs

### DIFF
--- a/.github/workflows/reusable-retry-buildkite-step-on-events.yml
+++ b/.github/workflows/reusable-retry-buildkite-step-on-events.yml
@@ -1,0 +1,110 @@
+on:
+  workflow_call:
+    inputs:
+      org-slug:
+        required: true
+        type: string
+      pipeline-slug:
+        required: true
+        type: string
+      retry-step-key:
+        required: true
+        type: string
+      commit-sha:
+        required: true
+        type: string
+    secrets:
+      buildkite-api-token:
+        required: true
+
+jobs:
+  retry-buildkite-job:
+    runs-on: ubuntu-latest
+    steps:
+      - name: "🔄 Retry job on the latest Buildkite Build"
+        run: |
+          ORG_SLUG="${{ inputs.org-slug }}"
+          PIPELINE_SLUG="${{ inputs.pipeline-slug }}"
+          RETRY_STEP_KEY="${{ inputs.retry-step-key }}"
+          BUILDKITE_API_ACCESS_TOKEN="${{ secrets.buildkite-api-token }}"
+          COMMIT_SHA="${{ inputs.commit-sha }}"
+
+          # Performs a Buildkite request using a http method ($1) and an api path ($2)
+          perform_buildkite_request() {
+            local METHOD=$1
+            local BUILDKITE_API_PATH=$2
+
+            local BUILDKITE_API_URL="https://api.buildkite.com/v2/organizations/$ORG_SLUG/pipelines/$PIPELINE_SLUG/$BUILDKITE_API_PATH"
+
+            local RAW_RESPONSE=$(
+              curl \
+                --fail-with-body \
+                --silent \
+                --show-error \
+                -X "$METHOD" \
+                -H "Authorization: Bearer $BUILDKITE_API_ACCESS_TOKEN" \
+                "$BUILDKITE_API_URL"
+            )
+
+            echo "$RAW_RESPONSE" | tr -d '\n' | jq -R -r
+          }
+
+          # Gets the build(s) associated with the commit
+          get_buildkite_build() {
+            perform_buildkite_request "GET" "builds?commit=$COMMIT_SHA"
+          }
+
+          # Given a build id ($1) and a job id ($2), retry the given job
+          retry_buildkite_job() {
+            local BUILD_ID=$1
+            local JOB_ID=$2
+
+            perform_buildkite_request "PUT" "builds/$BUILD_ID/jobs/$JOB_ID/retry"
+          }
+
+          # Validates a Buildkite response ($1)
+          check_buildkite_error() {
+            local RESPONSE=$1
+
+            # Check if the response is empty
+            if [ -z "$RESPONSE" ] || [ "$(echo "$RESPONSE" | jq 'length')" -eq 0 ]; then
+              echo "❌ Buildkite API call returned an empty response."
+              exit 1
+            fi
+
+            # Check if the response contains an error message
+            RESPONSE_ERROR=$(echo "$RESPONSE" | jq .message 2>/dev/null || true)
+            # if [[ -n "$RESPONSE_ERROR" ]]; then
+            if [[ -n "$RESPONSE_ERROR" && "$RESPONSE_ERROR" != 'null' ]]; then
+              echo "❌ Buildkite API call failed: $RESPONSE_ERROR"
+              exit 1
+            fi
+          }
+
+          BUILDKITE_GET_BUILD_RESPONSE=$(get_buildkite_build)
+          check_buildkite_error "$BUILDKITE_GET_BUILD_RESPONSE"
+
+          LATEST_BUILD=$(echo "$BUILDKITE_GET_BUILD_RESPONSE" | jq -r '.[0]')
+          LATEST_BUILD_NUMBER=$(echo "$LATEST_BUILD" | jq -r '.number')
+
+          SELECTED_JOB=$(echo "$LATEST_BUILD" | jq -r --arg step_key "$RETRY_STEP_KEY" '.jobs[] | select(.step_key == $step_key)')
+          SELECTED_JOB_ID=$(echo "$SELECTED_JOB" | jq -r '.id')
+          SELECTED_JOB_STATE=$(echo "$SELECTED_JOB" | jq -r '.state')
+
+          echo "ℹ️ Build Number: $LATEST_BUILD_NUMBER"
+          echo "ℹ️ Job ID for step '$RETRY_STEP_KEY': $SELECTED_JOB_ID"
+          echo "ℹ️ Job state for step '$RETRY_STEP_KEY': $SELECTED_JOB_STATE"
+
+          # all states: running, scheduled, passed, failing, failed, blocked, canceled, canceling, skipped, not_run, finished
+          ALLOWED_JOB_STATES=("passed" "failed" "canceled" "finished")
+          if [[ " ${ALLOWED_JOB_STATES[@]} " =~ " $SELECTED_JOB_STATE " ]]; then
+            BUILDKITE_RETRY_JOB_RESPONSE=$(retry_buildkite_job "$LATEST_BUILD_NUMBER" "$SELECTED_JOB_ID")
+            check_buildkite_error "$BUILDKITE_RETRY_JOB_RESPONSE"
+
+            JOB_WEB_URL=$(echo "$BUILDKITE_RETRY_JOB_RESPONSE" | jq -r '.web_url')
+            echo "✅ Job succesfully retried: $JOB_WEB_URL"
+          elif [[ "$SELECTED_JOB_STATE" == "running" || "$SELECTED_JOB_STATE" == "scheduled" ]]; then
+            echo "⚠️ Job is already in state '$SELECTED_JOB_STATE', no need to retry."
+          else
+            echo "❌ Cannot retry job in state '$SELECTED_JOB_STATE'"
+          fi

--- a/.github/workflows/reusable-retry-buildkite-step-on-events.yml
+++ b/.github/workflows/reusable-retry-buildkite-step-on-events.yml
@@ -111,7 +111,7 @@ jobs:
 
           # all states: running, scheduled, passed, failing, failed, blocked, canceled, canceling, skipped, not_run, finished
           ALLOWED_JOB_STATES=("passed" "failed" "canceled" "finished")
-          if [[ " ${ALLOWED_JOB_STATES[*]} " =~ $SELECTED_JOB_STATE ]]; then
+          if [[ " ${ALLOWED_JOB_STATES[*]} " =~ [[:space:]]${SELECTED_JOB_STATE}[[:space:]] ]]; then
             BUILDKITE_RETRY_JOB_RESPONSE=$(retry_buildkite_job "$LATEST_BUILD_NUMBER" "$SELECTED_JOB_ID")
             check_buildkite_error "$BUILDKITE_RETRY_JOB_RESPONSE"
 

--- a/.github/workflows/reusable-retry-buildkite-step-on-events.yml
+++ b/.github/workflows/reusable-retry-buildkite-step-on-events.yml
@@ -49,7 +49,9 @@ jobs:
 
             local BUILDKITE_API_URL="https://api.buildkite.com/v2/organizations/$ORG_SLUG/pipelines/$PIPELINE_SLUG/$BUILDKITE_API_PATH"
 
-            local RAW_RESPONSE=$(
+            local RAW_RESPONSE
+
+            RAW_RESPONSE=$(
               curl \
                 --fail-with-body \
                 --silent \
@@ -59,7 +61,7 @@ jobs:
                 "$BUILDKITE_API_URL"
             )
 
-            echo "$RAW_RESPONSE" | tr -d '\n' | jq -R -r
+            echo "$RAW_RESPONSE" | jq
           }
 
           # Gets the build(s) associated with the commit
@@ -87,7 +89,6 @@ jobs:
 
             # Check if the response contains an error message
             RESPONSE_ERROR=$(echo "$RESPONSE" | jq .message 2>/dev/null || true)
-            # if [[ -n "$RESPONSE_ERROR" ]]; then
             if [[ -n "$RESPONSE_ERROR" && "$RESPONSE_ERROR" != 'null' ]]; then
               echo "❌ Buildkite API call failed: $RESPONSE_ERROR"
               exit 1
@@ -106,11 +107,11 @@ jobs:
 
           echo "ℹ️ Build Number: $LATEST_BUILD_NUMBER"
           echo "ℹ️ Job ID for step '$RETRY_STEP_KEY': $SELECTED_JOB_ID"
-          echo "ℹ️ Job state for step '$RETRY_STEP_KEY': $SELECTED_JOB_STATE"
+          echo "ℹ️ Current job state for step '$RETRY_STEP_KEY': $SELECTED_JOB_STATE"
 
           # all states: running, scheduled, passed, failing, failed, blocked, canceled, canceling, skipped, not_run, finished
           ALLOWED_JOB_STATES=("passed" "failed" "canceled" "finished")
-          if [[ " ${ALLOWED_JOB_STATES[@]} " =~ " $SELECTED_JOB_STATE " ]]; then
+          if [[ " ${ALLOWED_JOB_STATES[*]} " =~ $SELECTED_JOB_STATE ]]; then
             BUILDKITE_RETRY_JOB_RESPONSE=$(retry_buildkite_job "$LATEST_BUILD_NUMBER" "$SELECTED_JOB_ID")
             check_buildkite_error "$BUILDKITE_RETRY_JOB_RESPONSE"
 

--- a/.github/workflows/reusable-retry-buildkite-step-on-events.yml
+++ b/.github/workflows/reusable-retry-buildkite-step-on-events.yml
@@ -2,20 +2,33 @@ on:
   workflow_call:
     inputs:
       org-slug:
+        description: 'Buildkite organization slug'
         required: true
         type: string
       pipeline-slug:
+        description: 'Slug of the Buildkite pipeline to be run'
         required: true
         type: string
       retry-step-key:
+        description: 'Key of the Buildkite job to be retried'
         required: true
         type: string
-      commit-sha:
+      build-commit-sha:
+        description: 'Commit to check for running Buildkite Builds on. Usually github.event.pull_request.head.sha .'
         required: true
         type: string
+      cancel-running-github-jobs:
+        description: 'Cancel currently in progress Github jobs when new ones are added.'
+        default: true
+        type: boolean
+        required: false
     secrets:
       buildkite-api-token:
         required: true
+
+concurrency:
+  group: danger-buildkite-retry-${{ github.ref }}
+  cancel-in-progress: ${{ inputs.cancel-running-github-jobs }}
 
 jobs:
   retry-buildkite-job:
@@ -27,7 +40,7 @@ jobs:
           PIPELINE_SLUG="${{ inputs.pipeline-slug }}"
           RETRY_STEP_KEY="${{ inputs.retry-step-key }}"
           BUILDKITE_API_ACCESS_TOKEN="${{ secrets.buildkite-api-token }}"
-          COMMIT_SHA="${{ inputs.commit-sha }}"
+          COMMIT_SHA="${{ inputs.build-commit-sha }}"
 
           # Performs a Buildkite request using a http method ($1) and an api path ($2)
           perform_buildkite_request() {


### PR DESCRIPTION
This PR is the implementation of the idea of using GHA to trigger a job retry on the Buildkite, as opposed to running the entirety of a Danger job on GHA.
This becomes more important now to leverage the new Linter Agents currently running on Buildkite.

A PR using the present reusable workflow can be seen here: https://github.com/Automattic/pocket-casts-ios/pull/1630

See the original thread on paaHJt-5Qn-p2 for more details.