### PR TITLE
Update REXML to 3.3.2

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -107,8 +107,8 @@ GEM
       ffi (~> 1.0)
     rchardet (1.8.0)
     regexp_parser (2.9.2)
-    rexml (3.2.8)
-      strscan (>= 3.0.9)
+    rexml (3.3.2)
+      strscan
     rspec (3.13.0)
       rspec-core (~> 3.13.0)
       rspec-expectations (~> 3.13.0)


### PR DESCRIPTION
To address https://github.com/Automattic/dangermattic/security/dependabot/4

(FYI, fixed simply by running `bundle update rexml`)