### PR TITLE
Create new releases with Rake

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,24 @@
 
 ---
 
+## Trunk
+
+### Breaking Changes
+
+_None_
+
+### New Features
+
+_None_
+
+### Bug Fixes
+
+_None_
+
+### Internal Changes
+
+_None_
+
 ## 1.1.1
 
 ### Internal Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ _None_
 
 ### Internal Changes
 
-_None_
+- Bump Ruby dependencies (#76)
 
 ## 1.1.1
 

--- a/Rakefile
+++ b/Rakefile
@@ -11,7 +11,7 @@ task all: %i[specs lint]
 
 desc 'Ensure that the plugin passes `danger plugins lint`'
 task :danger_lint do
-  sh 'bundle exec danger plugins lint'
+  sh('bundle', 'exec', 'danger', 'plugins', 'lint')
 end
 
 desc 'Runs linting tasks: :rubocop and :danger_lint'
@@ -22,3 +22,90 @@ RSpec::Core::RakeTask.new(:specs)
 
 desc 'Run RuboCop on the lib/specs directory'
 RuboCop::RakeTask.new(:rubocop)
+
+desc 'Generate the docs using YARD'
+task :doc do
+  sh('yard', 'doc')
+  # Open generated doc in browser
+  sh('open', 'yard-doc/index.html')
+end
+
+desc "Print stats about undocumented methods. Provide an optional path relative to 'lib/dangermattic/plugins' to only show stats for that subdirectory"
+task :docstats, [:path] do |_, args|
+  path = File.join('lib/dangermattic/plugins', args[:path] || '.')
+  sh('yard', 'stats', '--list-undoc', path)
+end
+
+VERSION_FILE = File.join('lib', 'dangermattic', 'gem_version.rb')
+
+desc 'Create a new version of the dangermattic gem'
+task :new_release do
+  require_relative(VERSION_FILE)
+
+  parser = ChangelogParser.new(file: 'CHANGELOG.md')
+  latest_version = parser.parse_pending_section
+
+  ## Print current info
+  Console.header "Current version is: #{Dangermattic::VERSION}"
+  Console.warning "Warning: Latest version number does not match latest version title in CHANGELOG (#{latest_version})!" unless latest_version == Dangermattic::VERSION
+
+  Console.header 'Pending CHANGELOG:'
+  changelog = parser.cleaned_pending_changelog_lines
+  Console.print_indented_lines(changelog)
+
+  ## Prompt for next version number
+  guess = parser.guessed_next_semantic_version(current: Dangermattic::VERSION)
+  new_version = Console.prompt('New version to release', guess)
+
+  ## Checkout branch, update files
+  GitHelper.check_or_create_branch(new_version)
+  Console.header 'Update `VERSION` constant in `version.rb`...'
+  update_version_constant(VERSION_FILE, new_version)
+  Console.header 'Updating CHANGELOG...'
+  parser.update_for_new_release(new_version: new_version)
+
+  # Commit and push
+  Console.header 'Commit and push changes...'
+  GitHelper.commit_files("Bumped to version #{new_version}", [VERSION_FILE, 'Gemfile.lock', 'CHANGELOG.md'])
+
+  Console.header 'Opening PR draft in your default browser...'
+  pr_body = <<~BODY
+    Releasing new version #{new_version}.
+
+    # What's Next
+
+    PR Author: Be sure to create and publish a GitHub Release pointing to `trunk` once this PR gets merged,
+    copy/pasting the following text as the GitHub Release's description:
+    ```
+    #{changelog.join}
+    ```
+  BODY
+  GitHelper.prepare_github_pr("release/#{new_version}", 'trunk', "Release #{new_version} into trunk", pr_body)
+
+  Console.info <<~INSTRUCTIONS
+
+    ---------------
+
+    >>> WHAT'S NEXT
+
+    Once the PR is merged, publish a GitHub release for `#{new_version}`, targeting `trunk`,
+    with the following text as description:
+
+    ```
+    #{changelog.join}
+    ```
+
+    The publication of the new GitHub release will create a git tag, which in turn will trigger
+    a CI workflow that will take care of doing the `gem push` of the new version to RubyGems.
+
+  INSTRUCTIONS
+end
+
+def update_version_constant(version_file, new_version)
+  content = File.read(version_file)
+  content.gsub!(/VERSION = .*/, "VERSION = '#{new_version}'")
+  File.write(version_file, content)
+
+  # Updates the Gemfile.lock with the new dangermattic version
+  sh('bundle', 'install', '--quiet')
+end

--- a/Rakefile
+++ b/Rakefile
@@ -25,7 +25,7 @@ RuboCop::RakeTask.new(:rubocop)
 
 desc 'Generate the docs using YARD'
 task :doc do
-  sh('yard', 'doc')
+  sh('bundle', 'exec', 'yard', 'doc')
   # Open generated doc in browser
   sh('open', 'yard-doc/index.html')
 end

--- a/rakelib/changelog_parser.rake
+++ b/rakelib/changelog_parser.rake
@@ -1,6 +1,19 @@
+# frozen_string_literal: true
+
+# Parses and updates changelog files for software projects.
+#
+# This class provides functionality to parse a changelog file, identify pending
+# sections for upcoming releases, and update the changelog for new releases based on
+# semantic versioning conventions.
+#
+# @example
+#   parser = ChangelogParser.new(file: 'CHANGELOG.md')
+#   latest_version = parser.parse_pending_section
+#   new_version = parser.guessed_next_semantic_version(current: '1.0.0')
+#   parser.update_for_new_release(new_version: new_version)
 class ChangelogParser
-  PENDING_SECTION_TITLE = 'Trunk'.freeze
-  EMPTY_PLACEHOLDER = '_None_'.freeze
+  PENDING_SECTION_TITLE = 'Trunk'
+  EMPTY_PLACEHOLDER = '_None_'
   SUBSECTIONS_SEMVER_MAP = { 'Breaking Changes': 3, 'New Features': 2, 'Bug Fixes': 1, 'Internal Changes': 1 }.freeze
 
   def initialize(file: 'CHANGELOG.md')

--- a/rakelib/changelog_parser.rake
+++ b/rakelib/changelog_parser.rake
@@ -1,0 +1,95 @@
+class ChangelogParser
+  PENDING_SECTION_TITLE = 'Trunk'.freeze
+  EMPTY_PLACEHOLDER = '_None_'.freeze
+  SUBSECTIONS_SEMVER_MAP = { 'Breaking Changes': 3, 'New Features': 2, 'Bug Fixes': 1, 'Internal Changes': 1 }.freeze
+
+  def initialize(file: 'CHANGELOG.md')
+    @lines = File.readlines(file)
+    @current_index = nil
+    @pending_section = nil
+  end
+
+  # @return the title of the section after the pending one -- which should match the latest released version
+  def parse_pending_section
+    (lines_before_first_section, _, title) = advance_to_next_header(level: 2)
+    raise "Expected #{PENDING_SECTION_TITLE} as first section but found #{title} instead." unless title == PENDING_SECTION_TITLE
+
+    subsections = []
+    prev_subtitle = nil
+    loop do
+      (lines, next_level, next_subtitle) = advance_to_next_header(level: 2..3)
+      subsections.append({ title: prev_subtitle, lines: lines }) unless lines.reject { |l| l.chomp.empty? || l.chomp == EMPTY_PLACEHOLDER }.empty?
+      prev_subtitle = next_subtitle
+
+      break if next_level < 3
+    end
+    @pending_section = { lines_before: lines_before_first_section, subsections: subsections, next_title: prev_subtitle }
+    prev_subtitle
+  end
+
+  def cleaned_pending_changelog_lines
+    lines = []
+    @pending_section[:subsections].map do |s|
+      lines.append "### #{s[:title]}\n" unless s[:title].nil? # subsection title is nil for lines between h2 and first h3
+      lines += s[:lines]
+    end
+    lines
+  end
+
+  def guessed_next_semantic_version(current:)
+    comps = current.split('.')
+    idx_to_bump = 3 - semver_category
+    comps[idx_to_bump] = (comps[idx_to_bump].to_i + 1).to_s
+    ((idx_to_bump + 1)...(comps.length)).each { |i| comps[i] = '0' }
+    comps.join('.')
+  end
+
+  def update_for_new_release(new_version:, new_file: 'CHANGELOG.md')
+    raise 'You need to call #parse_pending_section first' if @pending_section.nil?
+
+    File.open(new_file, 'w') do |f|
+      f.puts @pending_section[:lines_before]
+      # Empty placeholder section for next version after this one
+      f.puts placeholder_section
+      # Section for new version, with the non-empty subsections found while parsing first section
+      f.puts "## #{new_version}\n\n"
+      f.puts cleaned_pending_changelog_lines
+      f.puts "## #{@pending_section[:next_title]}"
+      f.puts read_up_to_end
+    end
+  end
+
+  private
+
+  # Advance line pointer to next index of provided `level`
+  # @return [Array] A 3-item array of [scanned_lines, next_header_level, next_header_title]
+  def advance_to_next_header(level:)
+    range = level.is_a?(Range) ? level : level..level
+    regex = /^(\#{#{range.min},#{range.max}}) ?([^#].*)$/ # A line starting with {range.min,range.max} times '#' then optional space then a title
+    start_idx = @current_index.nil? ? 0 : @current_index + 1
+    offset = @lines[start_idx...].index { |l| l =~ regex }
+    @current_index = offset.nil? ? -1 : start_idx + offset
+
+    m = regex.match(@lines[@current_index])
+    [@lines[start_idx...@current_index], m[1].length, m[2]]
+  end
+
+  def read_up_to_end
+    idx = @current_index + 1
+    @current_index = -1
+    @lines[idx...]
+  end
+
+  def placeholder_section
+    lines = ["## #{PENDING_SECTION_TITLE}\n\n"]
+    lines += SUBSECTIONS_SEMVER_MAP.keys.map { |s| "### #{s}\n\n#{EMPTY_PLACEHOLDER}\n\n" }
+    lines.join
+  end
+
+  # @return the SemVer category (as described in Gem::Version doc). 3=major, 2=minor, 1=patch
+  def semver_category
+    raise 'You need to call #parse_pending_section first' if @pending_section.nil?
+
+    @pending_section[:subsections].map { |s| SUBSECTIONS_SEMVER_MAP[s[:title].to_sym] || 1 }.max || 1
+  end
+end

--- a/rakelib/console.rake
+++ b/rakelib/console.rake
@@ -1,3 +1,9 @@
+# frozen_string_literal: true
+
+# Provides methods for colored console output and user interaction.
+#
+# The Console module contains methods for printing colored text to the terminal using
+# ANSI escape codes. It also includes utility methods for prompting user input.
 module Console
   # ANSI colors
   RED = 1
@@ -18,7 +24,7 @@ module Console
   end
 
   def self.warning(text)
-    color_puts(title, color_code: RED) # red
+    color_puts(text, color_code: RED) # red
   end
 
   def self.print_indented_lines(lines)

--- a/rakelib/console.rake
+++ b/rakelib/console.rake
@@ -1,0 +1,40 @@
+module Console
+  # ANSI colors
+  RED = 1
+  GREEN = 2
+  YELLOW = 3
+  PURPLE = 4
+
+  def self.color_puts(lines, color_code:)
+    puts "\x1b[3#{color_code}m#{lines}\x1b[0m"
+  end
+
+  def self.header(title)
+    color_puts(">>> #{title}", color_code: GREEN) # green
+  end
+
+  def self.info(text)
+    color_puts(text, color_code: YELLOW) # yellow
+  end
+
+  def self.warning(text)
+    color_puts(title, color_code: RED) # red
+  end
+
+  def self.print_indented_lines(lines)
+    color_puts(lines.map { |l| "| #{l}" }.join, color_code: YELLOW)
+  end
+
+  def self.prompt(text, default_value)
+    color_puts("#{text}? [default: #{default_value}] ", color_code: GREEN)
+    answer = $stdin.gets.chomp
+    answer = default_value if answer.empty?
+    answer
+  end
+
+  def self.confirm(text)
+    color_puts("#{text} [y/n]?", color_code: GREEN)
+    answer = $stdin.gets.chomp
+    answer.downcase == 'y'
+  end
+end

--- a/rakelib/git_helpers.rake
+++ b/rakelib/git_helpers.rake
@@ -1,0 +1,35 @@
+require 'cgi'
+
+module GitHelper
+  def self.current_branch
+    `git --no-pager branch --show-current`.chomp
+  end
+
+  def self.check_or_create_branch(new_version)
+    release_branch = "release/#{new_version}"
+    branch_exists = !`git --no-pager branch -a --list --no-color #{release_branch}`.chomp.empty?
+    if current_branch == release_branch
+      puts 'Already on release branch'
+    elsif branch_exists
+      Rake.sh('git', 'checkout', release_branch)
+    else # create it
+      abort('Aborted, as not run from trunk nor release branch') unless current_branch == 'trunk' || Console.confirm("You are not on 'trunk', nor already on '#{release_branch}'. Do you really want to cut the release branch from #{current_branch}?")
+
+      Rake.sh('git', 'checkout', '-b', release_branch)
+    end
+  end
+
+  def self.prepare_github_pr(head, base, title, body)
+    require 'open-uri'
+    qtitle = CGI.escape(title)
+    qbody = CGI.escape(body)
+    uri = "https://github.com/Automattic/dangermattic/compare/#{base}...#{head}?expand=1&title=#{qtitle}&body=#{qbody}"
+    Rake.sh('open', uri)
+  end
+
+  def self.commit_files(message, files, push: true)
+    Rake.sh('git', 'add', *files)
+    Rake.sh('git', 'commit', '-m', message)
+    Rake.sh('git', 'push', '-q', '-u', 'origin', current_branch) if push
+  end
+end

--- a/rakelib/git_helpers.rake
+++ b/rakelib/git_helpers.rake
@@ -1,5 +1,9 @@
+# frozen_string_literal: true
+
 require 'cgi'
 
+# Helper methods for common Git operations: checking / creating branches, preparing a pull request and
+# committing / pushing files.
 module GitHelper
   def self.current_branch
     `git --no-pager branch --show-current`.chomp


### PR DESCRIPTION
Add new release `Rake` functionality.

I mostly copied over [release-toolkit](https://github.com/wordpress-mobile/release-toolkit)'s `rakelib`.
I considered other alternatives such as creating a separate Gem (seemed like a bigger effort for not a lot of code) or using a Submodule (seemed odd to have a dependency from Dangermattic to release-toolkit), so just copying the code to start with seemed like an ok trade-off for now.