### PR TITLE
Release 1.1.2 into trunk

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,12 @@ _None_
 
 ### Internal Changes
 
+_None_
+
+## 1.1.2
+
+### Internal Changes
+
 - Bump Ruby dependencies (#76)
 
 ## 1.1.1

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    danger-dangermattic (1.1.1)
+    danger-dangermattic (1.1.2)
       danger (~> 9.4)
       danger-plugin-api (~> 1.0)
       danger-rubocop (~> 0.13)

--- a/lib/dangermattic/gem_version.rb
+++ b/lib/dangermattic/gem_version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Dangermattic
-  VERSION = '1.1.1'
+  VERSION = '1.1.2'
 end


### PR DESCRIPTION
Releasing new version 1.1.2.

# What's Next

PR Author: Be sure to create and publish a GitHub Release pointing to `trunk` once this PR gets merged,
copy/pasting the following text as the GitHub Release's description:
```
### Internal Changes

- Bump Ruby dependencies (#76)


```
