### PR TITLE
Add cancel parameter to Issue Validation workflow

### DIFF
--- a/.github/workflows/reusable-check-labels-on-issues.yml
+++ b/.github/workflows/reusable-check-labels-on-issues.yml
@@ -28,7 +28,7 @@ on:
         required: true
 
 concurrency:
-  group: danger-${{ github.event.issue.number }}
+  group: ${{ github.workflow }}-${{ github.event.issue.number }}
   cancel-in-progress: ${{ inputs.cancel-running-jobs }}
 
 jobs:

--- a/.github/workflows/reusable-check-labels-on-issues.yml
+++ b/.github/workflows/reusable-check-labels-on-issues.yml
@@ -18,13 +18,18 @@ on:
         default: '✅ Yay, issue looks great!'
         type: string
         required: false
+      cancel-running-jobs:
+        description: 'Cancel currently in progress jobs when new ones are added.'
+        default: true
+        type: boolean
+        required: false
     secrets:
       github-token:
         required: true
 
 concurrency:
   group: danger-${{ github.event.issue.number }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ inputs.cancel-running-jobs }}
 
 jobs:
   check-issue-labels:

--- a/.github/workflows/reusable-retry-buildkite-step-on-events.yml
+++ b/.github/workflows/reusable-retry-buildkite-step-on-events.yml
@@ -27,7 +27,7 @@ on:
         required: true
 
 concurrency:
-  group: danger-buildkite-retry-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: ${{ inputs.cancel-running-github-jobs }}
 
 jobs:

--- a/.github/workflows/reusable-run-danger.yml
+++ b/.github/workflows/reusable-run-danger.yml
@@ -16,7 +16,7 @@ on:
         required: true
 
 concurrency:
-  group: danger-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: ${{ inputs.cancel-running-jobs }}
 
 jobs:


### PR DESCRIPTION
This PR adds the parameter `cancel-running-jobs` to the Issue Validation workflow, so that users can choose not to cancel currently running jobs.