### PR TITLE
Add `README.md` for GitHub reusable workflows

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -1,0 +1,71 @@
+# Dangermattic GitHub Workflows Documentation
+
+We provide reusable GitHub workflows to be used with Dangermattic.
+Each workflow is designed to be called from other workflows using the `workflow_call` event and input parameters.
+All jobs are run on `ubuntu-latest`.
+
+## Check Labels on Issues
+
+**File:** `workflows/reusable-check-labels-on-issues.yml`
+
+This workflow is an independent check (not using Danger) to verify if the labels on an issue match specified regex patterns.
+
+### Inputs:
+- `label-format-list`: JSON list of regex formats expected for the labels (default: `[".*"]`)
+- `label-error-message`: Error message when labels don't match
+- `label-success-message`: Success message when labels match
+- `cancel-running-jobs`: Cancel in-progress jobs when new ones are created (default: `true`)
+
+### Secrets:
+- `github-token`: Required GitHub token
+
+### Job: `check-issue-labels`
+- Permissions: `issues: write`
+- Main step: "🏷️ Check Issue Labels"
+  - Checks if issue labels match the specified regex patterns
+  - Posts a comment on the issue with success or error message
+
+## Retry Buildkite Step on Pull Request Events
+
+**File:** `workflows/reusable-retry-buildkite-step-on-events.yml`
+
+This workflow retries a specific job in a Buildkite pipeline.
+
+### Inputs:
+- `org-slug`: Buildkite organization slug
+- `pipeline-slug`: Slug of the Buildkite pipeline to be run
+- `retry-step-key`: Key of the Buildkite job to be retried
+- `build-commit-sha`: Commit to check for running Buildkite Builds
+- `cancel-running-github-jobs`: Cancel in-progress GitHub jobs when new ones are created (default: `true`)
+
+### Secrets:
+- `buildkite-api-token`: Required Buildkite API token
+
+### Job: `retry-buildkite-job`
+- Main step: "🔄 Retry job on the latest Buildkite Build"
+  - Retrieves the latest Buildkite build for the specified commit
+  - Identifies the job to retry based on the provided step key
+  - Retries the job if it's in an appropriate state (passed, failed, canceled, or finished)
+
+## Run Danger on GitHub
+
+**File:** `workflows/reusable-run-danger.yml`
+
+This workflow runs Danger directly on GitHub Actions.
+
+### Inputs:
+- `remove-previous-comments`: Remove previous Danger comments and add a new one (default: `false`)
+- `cancel-running-jobs`: Cancel in-progress jobs when new ones are created (default: `true`)
+
+### Secrets:
+- `github-token`: Required GitHub token
+
+### Job: `dangermattic`
+- Steps:
+  1. Checkout repository
+  2. Set up Ruby
+  3. Run Danger PR Check
+     - Executes Danger in read-only mode for forks and Dependabot PRs
+     - Runs Danger with full functionality for PRs where the configured token has access to the repo
+
+These reusable workflows can be incorporated into other workflows in your repository to perform specific tasks related to issue labeling, Buildkite job management, and pull request checks using Danger.

--- a/.github/workflows/reusable-check-labels-on-issues.yml
+++ b/.github/workflows/reusable-check-labels-on-issues.yml
@@ -1,25 +1,28 @@
+# yaml-language-server: $schema=https://json.schemastore.org/github-workflow.json
+
 on:
   workflow_call:
     inputs:
       label-format-list:
-        description: 'The Regex formats expected for the labels; must be a JSON list'
-        default: '[
-          ".*"
-        ]'
+        description: The Regex formats expected for the labels; must be a JSON list
+        default: |
+          [
+            ".*"
+          ]
         type: string
         required: false
       label-error-message:
-        description: 'Error message to be posted when the labels set don''t match the required list of formats.'
-        default: 'At least one label is required.'
+        description: Error message to be posted when the labels set don't match the required list of formats.
+        default: At least one label is required.
         type: string
         required: false
       label-success-message:
-        description: 'Message to be posted when the labels set fulfill the entire list of expected formats.'
-        default: '✅ Yay, issue looks great!'
+        description: Message to be posted when the labels set fulfill the entire list of expected formats.
+        default: ✅ Yay, issue looks great!
         type: string
         required: false
       cancel-running-jobs:
-        description: 'Cancel currently in progress jobs when new ones are added.'
+        description: Cancel currently in progress jobs when new ones are added.
         default: true
         type: boolean
         required: false
@@ -37,7 +40,7 @@ jobs:
     permissions:
       issues: write
     steps:
-      - name: "🏷️ Check Issue Labels"
+      - name: 🏷️ Check Issue Labels
         env:
           GITHUB_TOKEN: ${{ secrets.github-token }}
           GH_REPO: ${{ github.repository }}

--- a/.github/workflows/reusable-retry-buildkite-step-on-events.yml
+++ b/.github/workflows/reusable-retry-buildkite-step-on-events.yml
@@ -1,24 +1,26 @@
+# yaml-language-server: $schema=https://json.schemastore.org/github-workflow.json
+
 on:
   workflow_call:
     inputs:
       org-slug:
-        description: 'Buildkite organization slug'
+        description: Buildkite organization slug
         required: true
         type: string
       pipeline-slug:
-        description: 'Slug of the Buildkite pipeline to be run'
+        description: Slug of the Buildkite pipeline to be run
         required: true
         type: string
       retry-step-key:
-        description: 'Key of the Buildkite job to be retried'
+        description: Key of the Buildkite job to be retried
         required: true
         type: string
       build-commit-sha:
-        description: 'Commit to check for running Buildkite Builds on. Usually github.event.pull_request.head.sha .'
+        description: Commit to check for running Buildkite Builds on. Usually github.event.pull_request.head.sha .
         required: true
         type: string
       cancel-running-github-jobs:
-        description: 'Cancel currently in progress Github jobs when new ones are added.'
+        description: Cancel currently in progress Github jobs when new ones are added.
         default: true
         type: boolean
         required: false
@@ -34,7 +36,7 @@ jobs:
   retry-buildkite-job:
     runs-on: ubuntu-latest
     steps:
-      - name: "🔄 Retry job on the latest Buildkite Build"
+      - name: 🔄 Retry job on the latest Buildkite Build
         env:
           READ_ONLY_MODE: ${{ github.event.pull_request.head.repo.fork || github.actor == 'dependabot[bot]' }}
         run: |

--- a/.github/workflows/reusable-run-danger.yml
+++ b/.github/workflows/reusable-run-danger.yml
@@ -1,13 +1,15 @@
+# yaml-language-server: $schema=https://json.schemastore.org/github-workflow.json
+
 on:
   workflow_call:
     inputs:
       remove-previous-comments:
-        description: 'Configures Danger to always remove previous comments and add a new one instead of editing the same comment.'
+        description: Configures Danger to always remove previous comments and add a new one instead of editing the same comment.
         default: false
         type: boolean
         required: false
       cancel-running-jobs:
-        description: 'Cancel currently in progress jobs when new ones are added.'
+        description: Cancel currently in progress jobs when new ones are added.
         default: true
         type: boolean
         required: false
@@ -23,15 +25,15 @@ jobs:
   dangermattic:
     runs-on: ubuntu-latest
     steps:
-      - name: "📥 Checkout Repo"
+      - name: 📥 Checkout Repo
         uses: actions/checkout@v4
         with:
           fetch-depth: 100
-      - name: "💎 Ruby Setup"
+      - name: 💎 Ruby Setup
         uses: ruby/setup-ruby@v1
         with:
           bundler-cache: true
-      - name: "☢️ Danger PR Check"
+      - name: ☢️ Danger PR Check
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}
           READ_ONLY_MODE: ${{ github.event.pull_request.head.repo.fork || github.actor == 'dependabot[bot]' }}

--- a/README.md
+++ b/README.md
@@ -35,6 +35,10 @@ Once the main Gem is installed, all Dangermattic plugins are available in your `
 
 All available plugins are defined here: https://github.com/Automattic/dangermattic/tree/trunk/lib/dangermattic/plugins
 
+## GitHub Workflows
+
+Dangermattic also provides some useful reusable GitHub workflows. For more information on available workflows and how to use them, please refer to the [Workflows README](.github/workflows/README.md).
+
 ## Development
 
 - Clone the repo and run `bundle install` to setup dependencies
@@ -66,3 +70,26 @@ my_new_plugin_checker.check_method(param: my_param_value)
 ```
 
 Please follow the existing naming convention for validation and check plugins: classes end with a `*Checker` suffix and the main validation methods are named with a `check_*` prefix.
+
+## Releasing a new version
+
+To create a new release of the Dangermattic gem, use the `new_release` Rake task:
+
+```
+bundle exec rake new_release
+```
+
+This task will:
+
+1. Parse the `CHANGELOG.md` file to get the latest version and pending changes.
+1. Prompt for the new version number.
+1. Update the `VERSION` constant in the `gem_version.rb` file.
+1. Update the `CHANGELOG.md` file with the new version.
+1. Create a new branch, commit the changes, and push to GitHub.
+1. Open a draft Pull Request for the release.
+
+After running the task, follow the instructions provided to complete the release process:
+
+1. Review and merge the Pull Request.
+1. Create a GitHub release targeting the `trunk` branch, using the changelog content provided.
+1. Publishing the GitHub release with a tag will trigger a CI workflow to publish the new gem version to RubyGems.


### PR DESCRIPTION
This PR:
- Adds a new `README.md` for the GitHub reusable workflows in `.github/workflows/` describing their usage
- Cleans up the workflow YAML files removing unnecessary quotes/double quotes
- Adds releasing instructions to the main `README.md`