### PR TITLE
Add check for `Package.swift` / `Package.resolved` using full paths

### DIFF
--- a/lib/dangermattic/plugins/manifest_pr_checker.rb
+++ b/lib/dangermattic/plugins/manifest_pr_checker.rb
@@ -29,6 +29,7 @@ module Danger
   #
   class ManifestPRChecker < Plugin
     MESSAGE = '`%s` was changed without updating its corresponding `%s`. %s.'
+    SWIFT_INSTRUCTION = 'Please resolve the Swift packages as appropriate to your project setup (e.g. in Xcode or by running `swift package resolve`)'
 
     # Performs all the checks, asserting that changes on `Gemfile`, `Podfile` and `Package.swift` must have corresponding
     # lock file changes.
@@ -79,7 +80,7 @@ module Danger
       check_manifest_lock_updated(
         file_name: 'Package.swift',
         lock_file_name: 'Package.resolved',
-        instruction: 'Please resolve the Swift packages as appropriate to your project setup (e.g. in Xcode or by running `swift package resolve`)',
+        instruction: SWIFT_INSTRUCTION,
         report_type: report_type
       )
     end
@@ -94,7 +95,7 @@ module Danger
       check_manifest_lock_updated_strict(
         manifest_path: manifest_path,
         manifest_lock_path: manifest_lock_path,
-        instruction: 'Please resolve the Swift packages as appropriate to your project setup (e.g. in Xcode or by running `swift package resolve`)',
+        instruction: SWIFT_INSTRUCTION,
         report_type: report_type
       )
     end

--- a/lib/dangermattic/plugins/manifest_pr_checker.rb
+++ b/lib/dangermattic/plugins/manifest_pr_checker.rb
@@ -79,7 +79,7 @@ module Danger
       check_manifest_lock_updated(
         file_name: 'Package.swift',
         lock_file_name: 'Package.resolved',
-        instruction: 'Please resolve the Swift packages in Xcode',
+        instruction: 'Please resolve the Swift packages as appropriate to your project setup (e.g. in Xcode or by running `swift package resolve`)',
         report_type: report_type
       )
     end
@@ -94,7 +94,7 @@ module Danger
       check_manifest_lock_updated_strict(
         manifest_path: manifest_path,
         manifest_lock_path: manifest_lock_path,
-        instruction: 'Please resolve the Swift packages in Xcode',
+        instruction: 'Please resolve the Swift packages as appropriate to your project setup (e.g. in Xcode or by running `swift package resolve`)',
         report_type: report_type
       )
     end

--- a/lib/dangermattic/plugins/manifest_pr_checker.rb
+++ b/lib/dangermattic/plugins/manifest_pr_checker.rb
@@ -46,7 +46,6 @@ module Danger
     #
     # @param report_type [Symbol] (optional) The type of report for the message. Types: :error, :warning (default), :message.
     #
-    #
     # @return [void]
     def check_gemfile_lock_updated(report_type: :warning)
       check_manifest_lock_updated(
@@ -60,7 +59,6 @@ module Danger
     # Check if the `Podfile` file was modified without a corresponding `Podfile.lock` update
     #
     # @param report_type [Symbol] (optional) The type of report for the message. Types: :error, :warning (default), :message.
-    #
     #
     # @return [void]
     def check_podfile_lock_updated(report_type: :warning)
@@ -76,12 +74,26 @@ module Danger
     #
     # @param report_type [Symbol] (optional) The type of report for the message. Types: :error, :warning (default), :message.
     #
-    #
     # @return [void]
     def check_swift_package_resolved_updated(report_type: :warning)
       check_manifest_lock_updated(
         file_name: 'Package.swift',
         lock_file_name: 'Package.resolved',
+        instruction: 'Please resolve the Swift packages in Xcode',
+        report_type: report_type
+      )
+    end
+
+    # Check if the `Package.swift` file was modified without a corresponding `Package.resolved` update,
+    # checking for exact path matches
+    #
+    # @param report_type [Symbol] (optional) The type of report for the message. Types: :error, :warning (default), :message.
+    #
+    # @return [void]
+    def check_swift_package_resolved_updated_strict(manifest_path:, manifest_lock_path:, report_type: :warning)
+      check_manifest_lock_updated_strict(
+        manifest_path: manifest_path,
+        manifest_lock_path: manifest_lock_path,
         instruction: 'Please resolve the Swift packages in Xcode',
         report_type: report_type
       )
@@ -101,6 +113,17 @@ module Danger
         message = format(MESSAGE, manifest_file, lock_file_name, instruction)
         reporter.report(message: message, type: report_type)
       end
+    end
+
+    def check_manifest_lock_updated_strict(manifest_path:, manifest_lock_path:, instruction:, report_type: :warning)
+      manifest_modified = git.modified_files.include?(manifest_path)
+      return unless manifest_modified
+
+      lockfile_modified = git.modified_files.include?(manifest_lock_path)
+      return if lockfile_modified
+
+      message = format(MESSAGE, manifest_path, File.basename(manifest_lock_path), instruction)
+      reporter.report(message: message, type: report_type)
     end
   end
 end

--- a/lib/dangermattic/plugins/manifest_pr_checker.rb
+++ b/lib/dangermattic/plugins/manifest_pr_checker.rb
@@ -103,11 +103,11 @@ module Danger
 
     def check_manifest_lock_updated(file_name:, lock_file_name:, instruction:, report_type: :warning)
       # Find all the modified manifest files
-      manifest_modified_files = git.modified_files.select { |f| File.basename(f) == file_name }
+      manifest_modified_files = git_utils.all_changed_files.select { |f| File.basename(f) == file_name }
 
       # For each manifest file, check if the corresponding lockfile (in the same dir) was also modified
       manifest_modified_files.each do |manifest_file|
-        lockfile_modified = git.modified_files.any? { |f| File.dirname(f) == File.dirname(manifest_file) && File.basename(f) == lock_file_name }
+        lockfile_modified = git_utils.all_changed_files.any? { |f| File.dirname(f) == File.dirname(manifest_file) && File.basename(f) == lock_file_name }
         next if lockfile_modified
 
         message = format(MESSAGE, manifest_file, lock_file_name, instruction)
@@ -116,10 +116,10 @@ module Danger
     end
 
     def check_manifest_lock_updated_strict(manifest_path:, manifest_lock_path:, instruction:, report_type: :warning)
-      manifest_modified = git.modified_files.include?(manifest_path)
+      manifest_modified = git_utils.all_changed_files.include?(manifest_path)
       return unless manifest_modified
 
-      lockfile_modified = git.modified_files.include?(manifest_lock_path)
+      lockfile_modified = git_utils.all_changed_files.include?(manifest_lock_path)
       return if lockfile_modified
 
       message = format(MESSAGE, manifest_path, File.basename(manifest_lock_path), instruction)

--- a/spec/manifest_pr_checker_spec.rb
+++ b/spec/manifest_pr_checker_spec.rb
@@ -107,32 +107,73 @@ module Danger
       end
 
       describe 'Swift Package Manager' do
-        it 'reports a warning when a PR changed the Package.swift but not the Package.resolved' do
-          modified_files = ['Package.swift']
-          allow(@plugin.git).to receive(:modified_files).and_return(modified_files)
+        describe '#check_swift_package_resolved_updated' do
+          it 'reports a warning when a PR changed the Package.swift but not the Package.resolved' do
+            modified_files = ['Package.swift']
+            allow(@plugin.git).to receive(:modified_files).and_return(modified_files)
 
-          @plugin.check_swift_package_resolved_updated
+            @plugin.check_swift_package_resolved_updated
 
-          expected_warning = format(ManifestPRChecker::MESSAGE, 'Package.swift', 'Package.resolved', 'Please resolve the Swift packages in Xcode')
-          expect(@dangerfile).to report_warnings([expected_warning])
+            expected_warning = format(ManifestPRChecker::MESSAGE, 'Package.swift', 'Package.resolved', 'Please resolve the Swift packages in Xcode')
+            expect(@dangerfile).to report_warnings([expected_warning])
+          end
+
+          it 'reports no warnings when both the Package.swift and the Package.resolved were updated' do
+            modified_files = ['Package.swift', 'Package.resolved']
+            allow(@plugin.git).to receive(:modified_files).and_return(modified_files)
+
+            @plugin.check_swift_package_resolved_updated
+
+            expect(@dangerfile).to not_report
+          end
+
+          it 'reports no warnings when only the Package.resolved was updated' do
+            modified_files = ['Package.resolved']
+            allow(@plugin.git).to receive(:modified_files).and_return(modified_files)
+
+            @plugin.check_swift_package_resolved_updated
+
+            expect(@dangerfile).to not_report
+          end
         end
 
-        it 'reports no warnings when both the Package.swift and the Package.resolved were updated' do
-          modified_files = ['Package.swift', 'Package.resolved']
-          allow(@plugin.git).to receive(:modified_files).and_return(modified_files)
+        describe '#check_swift_package_resolved_updated_strict' do
+          it 'reports a warning when a PR changed the specific Package.swift but not its Package.resolved' do
+            modified_files = ['Apps/App1/Package.swift', 'Apps/App2/Package.swift', 'Apps/App2/Package.resolved']
+            allow(@plugin.git).to receive(:modified_files).and_return(modified_files)
 
-          @plugin.check_swift_package_resolved_updated
+            @plugin.check_swift_package_resolved_updated_strict(
+              manifest_path: 'Apps/App1/Package.swift',
+              manifest_lock_path: 'Apps/App1/Package.resolved'
+            )
 
-          expect(@dangerfile).to not_report
-        end
+            expected_warning = format(ManifestPRChecker::MESSAGE, 'Apps/App1/Package.swift', 'Package.resolved', 'Please resolve the Swift packages in Xcode')
+            expect(@dangerfile).to report_warnings([expected_warning])
+          end
 
-        it 'reports no warnings when only the Package.resolved was updated' do
-          modified_files = ['Package.resolved']
-          allow(@plugin.git).to receive(:modified_files).and_return(modified_files)
+          it 'reports no warning when both the specific Package.swift and Package.resolved were updated' do
+            modified_files = ['Apps/App1/Package.swift', 'Apps/App1/Package.resolved']
+            allow(@plugin.git).to receive(:modified_files).and_return(modified_files)
 
-          @plugin.check_swift_package_resolved_updated
+            @plugin.check_swift_package_resolved_updated_strict(
+              manifest_path: 'Apps/App1/Package.swift',
+              manifest_lock_path: 'Apps/App1/Package.resolved'
+            )
 
-          expect(@dangerfile).to not_report
+            expect(@dangerfile).to not_report
+          end
+
+          it 'reports no warning when the specific Package.swift was not modified' do
+            modified_files = ['Apps/App2/Package.swift', 'Apps/App2/Package.resolved']
+            allow(@plugin.git).to receive(:modified_files).and_return(modified_files)
+
+            @plugin.check_swift_package_resolved_updated_strict(
+              manifest_path: 'Apps/App1/Package.swift',
+              manifest_lock_path: 'Apps/App1/Package.resolved'
+            )
+
+            expect(@dangerfile).to not_report
+          end
         end
       end
     end

--- a/spec/manifest_pr_checker_spec.rb
+++ b/spec/manifest_pr_checker_spec.rb
@@ -17,7 +17,7 @@ module Danger
       describe 'Bundler' do
         it 'reports a warning when a PR changed the Gemfile but not the Gemfile.lock' do
           modified_files = ['Gemfile']
-          allow(@plugin.git).to receive(:modified_files).and_return(modified_files)
+          allow(@plugin.git_utils).to receive(:all_changed_files).and_return(modified_files)
 
           @plugin.check_gemfile_lock_updated
 
@@ -27,7 +27,7 @@ module Danger
 
         it 'reports no warnings when both the Gemfile and the Gemfile.lock were updated' do
           modified_files = ['Gemfile', 'Gemfile.lock']
-          allow(@plugin.git).to receive(:modified_files).and_return(modified_files)
+          allow(@plugin.git_utils).to receive(:all_changed_files).and_return(modified_files)
 
           @plugin.check_gemfile_lock_updated
 
@@ -36,7 +36,7 @@ module Danger
 
         it 'reports no warnings when only the Gemfile.lock was updated' do
           modified_files = ['Gemfile.lock']
-          allow(@plugin.git).to receive(:modified_files).and_return(modified_files)
+          allow(@plugin.git_utils).to receive(:all_changed_files).and_return(modified_files)
 
           @plugin.check_gemfile_lock_updated
 
@@ -47,7 +47,7 @@ module Danger
       describe 'CocoaPods' do
         it 'reports a warning when a PR changed the Podfile but not the Podfile.lock' do
           modified_files = ['Podfile']
-          allow(@plugin.git).to receive(:modified_files).and_return(modified_files)
+          allow(@plugin.git_utils).to receive(:all_changed_files).and_return(modified_files)
 
           @plugin.check_podfile_lock_updated
 
@@ -57,7 +57,7 @@ module Danger
 
         it 'reports no warnings when both the Podfile and the Podfile.lock were updated' do
           modified_files = ['Podfile', 'Podfile.lock']
-          allow(@plugin.git).to receive(:modified_files).and_return(modified_files)
+          allow(@plugin.git_utils).to receive(:all_changed_files).and_return(modified_files)
 
           @plugin.check_podfile_lock_updated
 
@@ -66,7 +66,7 @@ module Danger
 
         it 'reports a warning when a PR changed a custom located Podfile but not the corresponding Podfile.lock' do
           modified_files = ['./path/to/Podfile', './my/Podfile.lock']
-          allow(@plugin.git).to receive(:modified_files).and_return(modified_files)
+          allow(@plugin.git_utils).to receive(:all_changed_files).and_return(modified_files)
 
           @plugin.check_podfile_lock_updated
 
@@ -76,7 +76,7 @@ module Danger
 
         it 'reports multiple warnings when a PR changed multiple custom located Podfiles but not the corresponding Podfile.lock' do
           modified_files = ['./dir1/Podfile', './dir2/Podfile', './dir3/Podfile', './dir1/Podfile.lock']
-          allow(@plugin.git).to receive(:modified_files).and_return(modified_files)
+          allow(@plugin.git_utils).to receive(:all_changed_files).and_return(modified_files)
 
           @plugin.check_podfile_lock_updated
 
@@ -89,7 +89,7 @@ module Danger
 
         it 'reports no warnings when both custom located Podfile`s and their corresponding Podfile.lock were updated' do
           modified_files = ['./my/path/to/Podfile', './another/path/to/Podfile', './my/path/to/Podfile.lock', './another/path/to/Podfile.lock']
-          allow(@plugin.git).to receive(:modified_files).and_return(modified_files)
+          allow(@plugin.git_utils).to receive(:all_changed_files).and_return(modified_files)
 
           @plugin.check_podfile_lock_updated
 
@@ -98,7 +98,7 @@ module Danger
 
         it 'reports no warnings when only the Podfile.lock was updated' do
           modified_files = ['Podfile.lock']
-          allow(@plugin.git).to receive(:modified_files).and_return(modified_files)
+          allow(@plugin.git_utils).to receive(:all_changed_files).and_return(modified_files)
 
           @plugin.check_podfile_lock_updated
 
@@ -110,7 +110,7 @@ module Danger
         describe '#check_swift_package_resolved_updated' do
           it 'reports a warning when a PR changed the Package.swift but not the Package.resolved' do
             modified_files = ['Package.swift']
-            allow(@plugin.git).to receive(:modified_files).and_return(modified_files)
+            allow(@plugin.git_utils).to receive(:all_changed_files).and_return(modified_files)
 
             @plugin.check_swift_package_resolved_updated
 
@@ -120,7 +120,7 @@ module Danger
 
           it 'reports no warnings when both the Package.swift and the Package.resolved were updated' do
             modified_files = ['Package.swift', 'Package.resolved']
-            allow(@plugin.git).to receive(:modified_files).and_return(modified_files)
+            allow(@plugin.git_utils).to receive(:all_changed_files).and_return(modified_files)
 
             @plugin.check_swift_package_resolved_updated
 
@@ -129,7 +129,7 @@ module Danger
 
           it 'reports no warnings when only the Package.resolved was updated' do
             modified_files = ['Package.resolved']
-            allow(@plugin.git).to receive(:modified_files).and_return(modified_files)
+            allow(@plugin.git_utils).to receive(:all_changed_files).and_return(modified_files)
 
             @plugin.check_swift_package_resolved_updated
 
@@ -140,7 +140,7 @@ module Danger
         describe '#check_swift_package_resolved_updated_strict' do
           it 'reports a warning when a PR changed the specific Package.swift but not its Package.resolved' do
             modified_files = ['Apps/App1/Package.swift', 'Apps/App2/Package.swift', 'Apps/App2/Package.resolved']
-            allow(@plugin.git).to receive(:modified_files).and_return(modified_files)
+            allow(@plugin.git_utils).to receive(:all_changed_files).and_return(modified_files)
 
             @plugin.check_swift_package_resolved_updated_strict(
               manifest_path: 'Apps/App1/Package.swift',
@@ -153,7 +153,7 @@ module Danger
 
           it 'reports no warning when both the specific Package.swift and Package.resolved were updated' do
             modified_files = ['Apps/App1/Package.swift', 'Apps/App1/Package.resolved']
-            allow(@plugin.git).to receive(:modified_files).and_return(modified_files)
+            allow(@plugin.git_utils).to receive(:all_changed_files).and_return(modified_files)
 
             @plugin.check_swift_package_resolved_updated_strict(
               manifest_path: 'Apps/App1/Package.swift',
@@ -165,7 +165,7 @@ module Danger
 
           it 'reports no warning when the specific Package.swift was not modified' do
             modified_files = ['Apps/App2/Package.swift', 'Apps/App2/Package.resolved']
-            allow(@plugin.git).to receive(:modified_files).and_return(modified_files)
+            allow(@plugin.git_utils).to receive(:all_changed_files).and_return(modified_files)
 
             @plugin.check_swift_package_resolved_updated_strict(
               manifest_path: 'Apps/App1/Package.swift',

--- a/spec/manifest_pr_checker_spec.rb
+++ b/spec/manifest_pr_checker_spec.rb
@@ -114,7 +114,7 @@ module Danger
 
             @plugin.check_swift_package_resolved_updated
 
-            expected_warning = format(ManifestPRChecker::MESSAGE, 'Package.swift', 'Package.resolved', 'Please resolve the Swift packages in Xcode')
+            expected_warning = format(ManifestPRChecker::MESSAGE, 'Package.swift', 'Package.resolved', ManifestPRChecker::SWIFT_INSTRUCTION)
             expect(@dangerfile).to report_warnings([expected_warning])
           end
 
@@ -147,7 +147,7 @@ module Danger
               manifest_lock_path: 'Apps/App1/Package.resolved'
             )
 
-            expected_warning = format(ManifestPRChecker::MESSAGE, 'Apps/App1/Package.swift', 'Package.resolved', 'Please resolve the Swift packages in Xcode')
+            expected_warning = format(ManifestPRChecker::MESSAGE, 'Apps/App1/Package.swift', 'Package.resolved', ManifestPRChecker::SWIFT_INSTRUCTION)
             expect(@dangerfile).to report_warnings([expected_warning])
           end
 


### PR DESCRIPTION
This PR introduces the method `check_swift_package_resolved_updated_strict` to the `ManifestPRChecker` plugin to validate Swift Package Manager manifest changes, now considering a full path:

```ruby
manifest_pr_checker.check_swift_package_resolved_updated_strict(
  manifest_path: "Modules/Package.swift",
  manifest_lock_path: "MyApp.xcworkspace/xcshareddata/swiftpm/Package.resolved"
)
```

I've considered keeping a single method but ended up splitting them to make things clearer, though I'm open to feedback and ideas.

Additionally, I've also changed the plugin to consider in Manifest checks ALL modified files, including added / removed ones.

### Testing
I've covered the method with unit tests, so they should succeed and CI should be 🟢 

You can also run this check by pointing directly to this branch in a `Gemfile` in an existing project with a `Dangerfile`, then calling the check as in the example above.