### PR TITLE
Add check for multiple `Package.resolved` files

### DIFF
--- a/lib/dangermattic/plugins/manifest_pr_checker.rb
+++ b/lib/dangermattic/plugins/manifest_pr_checker.rb
@@ -99,6 +99,23 @@ module Danger
       )
     end
 
+    # Check for duplicate Package.resolved files across all provided SwiftPM package directories
+    #
+    # @param report_type [Symbol] (optional) The type of report for the message. Types: :error, :warning (default), :message.
+    # @param spm_root_paths [Array<String>] Array of paths to SwiftPM package root directories (e.g. ['Modules'])
+    #
+    # @return [void]
+    def check_duplicate_package_resolved(spm_root_paths:, report_type: :warning)
+      resolved_files = spm_root_paths.flat_map { |root_path| Dir.glob("#{root_path}/**/Package.resolved") }
+      return if resolved_files.length <= 1
+
+      reporter.report(
+        message: "Multiple Package.resolved files found:\n#{resolved_files.join("\n")}\n" \
+                 'Please ensure only one Package.resolved exists.',
+        type: report_type
+      )
+    end
+
     private
 
     def check_manifest_lock_updated(file_name:, lock_file_name:, instruction:, report_type: :warning)

--- a/lib/dangermattic/plugins/manifest_pr_checker.rb
+++ b/lib/dangermattic/plugins/manifest_pr_checker.rb
@@ -102,16 +102,16 @@ module Danger
     # Check for duplicate Package.resolved files across all provided SwiftPM package directories
     #
     # @param report_type [Symbol] (optional) The type of report for the message. Types: :error, :warning (default), :message.
-    # @param spm_root_paths [Array<String>] Array of paths to SwiftPM package root directories (e.g. ['Modules'])
     #
     # @return [void]
-    def check_duplicate_package_resolved(spm_root_paths:, report_type: :warning)
-      resolved_files = spm_root_paths.flat_map { |root_path| Dir.glob("#{root_path}/**/Package.resolved") }
-      return if resolved_files.length <= 1
+    def check_swift_duplicate_package_resolved(report_type: :warning)
+      package_files = Dir.glob('./**/Package.swift')
+      resolved_files = Dir.glob('./**/Package.resolved')
+      return if package_files.length == resolved_files.length
 
       reporter.report(
-        message: "Multiple Package.resolved files found:\n#{resolved_files.join("\n")}\n" \
-                 'Please ensure only one Package.resolved exists.',
+        message: "Multiple `Package.resolved` files found:\n```#{resolved_files.join("\n")}```\n" \
+                 'Please ensure only one `Package.resolved` exists for each `Package.swift` file.',
         type: report_type
       )
     end

--- a/spec/manifest_pr_checker_spec.rb
+++ b/spec/manifest_pr_checker_spec.rb
@@ -175,6 +175,39 @@ module Danger
             expect(@dangerfile).to not_report
           end
         end
+
+        describe '#check_duplicate_package_resolved' do
+          it 'reports a warning when multiple Package.resolved files are found' do
+            allow(Dir).to receive(:glob).with('Modules/**/Package.resolved').and_return(['Modules/Package.resolved'])
+            allow(Dir).to receive(:glob).with('MyApp.xcworkspace/**/Package.resolved').and_return(['MyApp.xcworkspace/xcshareddata/swiftpm/Package.resolved'])
+
+            @plugin.check_duplicate_package_resolved(spm_root_paths: ['Modules', 'MyApp.xcworkspace'])
+
+            expected_warning = "Multiple Package.resolved files found:\n" \
+                               "Modules/Package.resolved\n" \
+                               "MyApp.xcworkspace/xcshareddata/swiftpm/Package.resolved\n" \
+                               'Please ensure only one Package.resolved exists.'
+            expect(@dangerfile).to report_warnings([expected_warning])
+          end
+
+          it 'reports no warning when only one Package.resolved file is found' do
+            allow(Dir).to receive(:glob).with('Modules/**/Package.resolved').and_return(['Modules/Package.resolved'])
+            allow(Dir).to receive(:glob).with('MyApp.xcworkspace/**/Package.resolved').and_return([])
+
+            @plugin.check_duplicate_package_resolved(spm_root_paths: ['Modules', 'MyApp.xcworkspace'])
+
+            expect(@dangerfile).to not_report
+          end
+
+          it 'reports no warning when no Package.resolved files are found' do
+            allow(Dir).to receive(:glob).with('Modules/**/Package.resolved').and_return([])
+            allow(Dir).to receive(:glob).with('MyApp.xcworkspace/**/Package.resolved').and_return([])
+
+            @plugin.check_duplicate_package_resolved(spm_root_paths: ['Modules', 'MyApp.xcworkspace'])
+
+            expect(@dangerfile).to not_report
+          end
+        end
       end
     end
   end

--- a/spec/manifest_pr_checker_spec.rb
+++ b/spec/manifest_pr_checker_spec.rb
@@ -176,34 +176,37 @@ module Danger
           end
         end
 
-        describe '#check_duplicate_package_resolved' do
-          it 'reports a warning when multiple Package.resolved files are found' do
-            allow(Dir).to receive(:glob).with('Modules/**/Package.resolved').and_return(['Modules/Package.resolved'])
-            allow(Dir).to receive(:glob).with('MyApp.xcworkspace/**/Package.resolved').and_return(['MyApp.xcworkspace/xcshareddata/swiftpm/Package.resolved'])
+        describe '#check_swift_duplicate_package_resolved' do
+          it 'reports a warning when there are more Package.resolved files than Package.swift files' do
+            allow(Dir).to receive(:glob).with('./**/Package.swift').and_return(['./App/Package.swift'])
+            allow(Dir).to receive(:glob).with('./**/Package.resolved').and_return([
+                                                                                    './App/Package.resolved',
+                                                                                    './App/xcshareddata/Package.resolved'
+                                                                                  ])
 
-            @plugin.check_duplicate_package_resolved(spm_root_paths: ['Modules', 'MyApp.xcworkspace'])
+            @plugin.check_swift_duplicate_package_resolved
 
-            expected_warning = "Multiple Package.resolved files found:\n" \
-                               "Modules/Package.resolved\n" \
-                               "MyApp.xcworkspace/xcshareddata/swiftpm/Package.resolved\n" \
-                               'Please ensure only one Package.resolved exists.'
+            expected_warning = "Multiple `Package.resolved` files found:\n" \
+                               "```./App/Package.resolved\n" \
+                               "./App/xcshareddata/Package.resolved```\n" \
+                               'Please ensure only one `Package.resolved` exists for each `Package.swift` file.'
             expect(@dangerfile).to report_warnings([expected_warning])
           end
 
-          it 'reports no warning when only one Package.resolved file is found' do
-            allow(Dir).to receive(:glob).with('Modules/**/Package.resolved').and_return(['Modules/Package.resolved'])
-            allow(Dir).to receive(:glob).with('MyApp.xcworkspace/**/Package.resolved').and_return([])
+          it 'reports no warning when Package.resolved count matches Package.swift count' do
+            allow(Dir).to receive(:glob).with('./**/Package.swift').and_return(['./App/Package.swift'])
+            allow(Dir).to receive(:glob).with('./**/Package.resolved').and_return(['./App/Package.resolved'])
 
-            @plugin.check_duplicate_package_resolved(spm_root_paths: ['Modules', 'MyApp.xcworkspace'])
+            @plugin.check_swift_duplicate_package_resolved
 
             expect(@dangerfile).to not_report
           end
 
-          it 'reports no warning when no Package.resolved files are found' do
-            allow(Dir).to receive(:glob).with('Modules/**/Package.resolved').and_return([])
-            allow(Dir).to receive(:glob).with('MyApp.xcworkspace/**/Package.resolved').and_return([])
+          it 'reports no warning when no Package files are found' do
+            allow(Dir).to receive(:glob).with('./**/Package.swift').and_return([])
+            allow(Dir).to receive(:glob).with('./**/Package.resolved').and_return([])
 
-            @plugin.check_duplicate_package_resolved(spm_root_paths: ['Modules', 'MyApp.xcworkspace'])
+            @plugin.check_swift_duplicate_package_resolved
 
             expect(@dangerfile).to not_report
           end


### PR DESCRIPTION
This PR adds a new method `check_duplicate_package_resolved` to the `ManifestPRChecker` plugin that helps identify duplicate `Package.resolved` files across SwiftPM root directories.

Example:
```ruby
manifest_pr_checker.check_duplicate_package_resolved(
  spm_root_paths: ['Modules', 'MyApp.xcworkspace']
)
```

### Testing
I've covered the method with unit tests, so they should succeed and CI should be 🟢 

You can also run this check by pointing directly to this branch in a `Gemfile` in an existing project with a `Dangerfile`, then calling the check as in the example above.