### PR TITLE
View Checker Plugin: update GitHub assets URL regex to be less strict

### DIFF
--- a/lib/dangermattic/plugins/view_changes_checker.rb
+++ b/lib/dangermattic/plugins/view_changes_checker.rb
@@ -31,7 +31,7 @@ module Danger
     # displaying a warning if view files have been modified but no screenshot or video is included.
     #
     # @return [void]
-    def check
+    def check(report_type: :warning)
       view_files_modified = git.modified_files.any? do |file|
         VIEW_EXTENSIONS_IOS =~ file || VIEW_EXTENSIONS_ANDROID =~ file
       end
@@ -40,7 +40,7 @@ module Danger
         github.pr_body =~ pattern
       end
 
-      warn(MESSAGE) if view_files_modified && !pr_has_media
+      reporter.report(message: MESSAGE, type: report_type) if view_files_modified && !pr_has_media
     end
   end
 end

--- a/lib/dangermattic/plugins/view_changes_checker.rb
+++ b/lib/dangermattic/plugins/view_changes_checker.rb
@@ -18,7 +18,7 @@ module Danger
     MEDIA_IN_PR_BODY_PATTERNS = [
       %r{https?://\S*\.(gif|jpg|jpeg|png|svg)},
       %r{https?://\S*\.(mp4|avi|mov|mkv)},
-      %r{https?://\S*github\S+/\S+/assets/\d+/},
+      %r{https?://\S*github\S+/\S+/assets/},
       /!\[(.*?)\]\((.*?)\)/,
       /<img\s+[^>]*src\s*=\s*[^>]*>/,
       /<video\s+[^>]*src\s*=\s*[^>]*>/

--- a/spec/view_changes_checker_spec.rb
+++ b/spec/view_changes_checker_spec.rb
@@ -75,9 +75,18 @@ module Danger
         expect(@dangerfile).to not_report
       end
 
-      it 'does nothing when a PR with view code changes has a video defined with a simple URL' do
+      it 'does nothing when a PR with view code changes has a video defined with a simple repo assets URL' do
         allow(@plugin.github).to receive(:pr_body)
           .and_return("see video:\nhttps://github.com/woocommerce/woocommerce-ios/assets/1864060/0e983305-5047-40a3-8829-734e0b582b96 body body")
+
+        @plugin.check
+
+        expect(@dangerfile).to not_report
+      end
+
+      it 'does nothing when a PR with view code changes has a video defined with a simple GitHub assets URL' do
+        allow(@plugin.github).to receive(:pr_body)
+          .and_return("see video:\nhttps://github.com/user-attachments/assets/f3461fec-f96c-4376-9e00-f8faf65f3457 body body")
 
         @plugin.check
 


### PR DESCRIPTION
The PR https://github.com/woocommerce/woocommerce-ios/pull/14265 has Dangermattic reporting a warning about missing screenshots / video, even though the restriction contains images in the format of `https://github.com/user-attachments/assets/f3461fec-f96c-4376-9e00-f8faf65f3457`.

This happened because our regex expected URLs in the format `https://github.com/woocommerce/woocommerce-ios/assets/1864060/0e983305-5047-40a3-8829-734e0b582b96` (that is, with digits after `/assets/`).

The present PR updates the regex to cover both cases.