### PR TITLE
View Checker Plugin: update view checker regex to cover GHE user storage URLs

### DIFF
--- a/lib/dangermattic/plugins/view_changes_checker.rb
+++ b/lib/dangermattic/plugins/view_changes_checker.rb
@@ -19,6 +19,7 @@ module Danger
       %r{https?://\S*\.(gif|jpg|jpeg|png|svg)},
       %r{https?://\S*\.(mp4|avi|mov|mkv)},
       %r{https?://\S*github\S+/\S+/assets/},
+      %r{https?://\S*github\S+/storage/user/},
       /!\[(.*?)\]\((.*?)\)/,
       /<img\s+[^>]*src\s*=\s*[^>]*>/,
       /<video\s+[^>]*src\s*=\s*[^>]*>/

--- a/spec/view_changes_checker_spec.rb
+++ b/spec/view_changes_checker_spec.rb
@@ -92,6 +92,15 @@ module Danger
 
         expect(@dangerfile).to not_report
       end
+
+      it 'does nothing when a PR with view code changes has a video defined with a simple GHE storage user files URL' do
+        allow(@plugin.github).to receive(:pr_body)
+          .and_return("see image:\nhttps://github.tumblr.net/storage/user/1327/files/9b6fde2b-b20e-4d82-938a-6fab63897723 body body")
+
+        @plugin.check
+
+        expect(@dangerfile).to not_report
+      end
     end
 
     shared_examples 'PR without view code changes' do |modified_files|


### PR DESCRIPTION
Similar to https://github.com/Automattic/dangermattic/pull/89

Dangermattic reported a warning about missing screenshots / video, even though the PR contained a video in the format `https://github.tumblr.net/storage/user/<num>/files/<id>`

The present PR updates the View Checker plugin Regex to also cover this case.