### PR TITLE
Ignore private classes in unit test checker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ _None_
 
 ### Bug Fixes
 
-_None_
+- Fix `android_unit_test_checker` plugin so it doesn't detect private, enum, and data classes. [#92]
 
 ### Internal Changes
 

--- a/lib/dangermattic/plugins/android_unit_test_checker.rb
+++ b/lib/dangermattic/plugins/android_unit_test_checker.rb
@@ -24,7 +24,14 @@ module Danger
   #
   class AndroidUnitTestChecker < Plugin
     ANY_CLASS_DETECTOR = /class\s+([A-Z]\w+)\s*(.*?)\s*{/m
-    NON_PRIVATE_CLASS_DETECTOR = /(?:\s|public|internal|protected|final|abstract|static)*class\s+([A-Z]\w+)\s*(.*?)\s*{/m
+    CLASS_MODIFIER_DETECTOR = /((?:\s|public|internal|protected|private|final|abstract|static|data|enum)*)class\s+([A-Z]\w+)\s*(.*?)\s*{/m
+
+    CLASS_MODIFIER_EXCEPTIONS = [
+      /\s*data\s*/,
+      /\s*private\s*/,
+      /\s*enum\s*/,
+    ].freeze
+
     DEFAULT_CLASSES_EXCEPTIONS = [
       /ViewHolder$/,
       /Module$/,
@@ -142,7 +149,7 @@ module Danger
     # @return [Array<ClassViolation>] An array of ClassViolation objects representing the violations found.
     def find_violations(path:, diff_patch:, classes_exceptions:, subclasses_exceptions:)
       added_lines = git_utils.added_lines(diff_patch: diff_patch)
-      matches = added_lines.scan(NON_PRIVATE_CLASS_DETECTOR)
+      matches = added_lines.scan(CLASS_MODIFIER_DETECTOR)
       matches.reject! do |m|
         class_match_is_exception?(
           m,
@@ -152,7 +159,7 @@ module Danger
         )
       end
 
-      matches.map { |m| ClassViolation.new(m[0], path) }
+      matches.map { |m| ClassViolation.new(m[1], path) }
     end
 
     # Finds the names of removed classes based on the removals the diff patch.
@@ -173,10 +180,11 @@ module Danger
     #
     # @return [void]
     def class_match_is_exception?(match, file, classes_exceptions, subclasses_exceptions)
-      return true if classes_exceptions.any? { |re| match[0] =~ re }
+      return true if classes_exceptions.any? { |re| match[1] =~ re }
+      return true if CLASS_MODIFIER_EXCEPTIONS.any? { |re| match[0] =~ re }
 
       subclass_regexp = File.extname(file) == '.java' ? /extends\s+([A-Z]\w+)/m : /\s*:\s*([A-Z]\w+)/m
-      subclass = match[1].scan(subclass_regexp)&.last&.last
+      subclass = match[2].scan(subclass_regexp)&.last&.last
       subclasses_exceptions.any? { |re| subclass =~ re }
     end
 

--- a/lib/dangermattic/plugins/android_unit_test_checker.rb
+++ b/lib/dangermattic/plugins/android_unit_test_checker.rb
@@ -29,7 +29,7 @@ module Danger
     CLASS_MODIFIER_EXCEPTIONS = [
       /\s*data\s*/,
       /\s*private\s*/,
-      /\s*enum\s*/,
+      /\s*enum\s*/
     ].freeze
 
     DEFAULT_CLASSES_EXCEPTIONS = [

--- a/spec/android_unit_test_checker_spec.rb
+++ b/spec/android_unit_test_checker_spec.rb
@@ -283,6 +283,20 @@ module Danger
 
         expect(@dangerfile).to not_report
       end
+
+      it 'does not report private class' do
+        added_files = %w[
+          PublicAndPrivateType.kt
+          src/androidTest/java/org/test/PublicTypeTest.kt
+        ]
+
+        diff = generate_add_diff_from_fixtures(added_files)
+        allow(@dangerfile.git).to receive(:diff).and_return(diff)
+
+        @plugin.check_missing_tests
+
+        expect(@dangerfile).to not_report
+      end
     end
 
     def generate_add_diff_from_fixtures(paths)
@@ -334,7 +348,7 @@ module Danger
     end
 
     def expect_class_names_match_report(class_names:, error_report:)
-      expect(class_names.length).to eq(error_report.length)
+      # expect(class_names.length).to eq(error_report.length)
       class_names.zip(error_report).each do |cls, error|
         expect(error).to include "Please add tests for class `#{cls}`"
       end

--- a/spec/android_unit_test_checker_spec.rb
+++ b/spec/android_unit_test_checker_spec.rb
@@ -348,7 +348,7 @@ module Danger
     end
 
     def expect_class_names_match_report(class_names:, error_report:)
-      # expect(class_names.length).to eq(error_report.length)
+      expect(class_names.length).to eq(error_report.length)
       class_names.zip(error_report).each do |cls, error|
         expect(error).to include "Please add tests for class `#{cls}`"
       end

--- a/spec/fixtures/android_unit_test_checker/PublicAndPrivateType.kt
+++ b/spec/fixtures/android_unit_test_checker/PublicAndPrivateType.kt
@@ -1,0 +1,7 @@
+class PublicType {
+    fun print() = "Hello, ${PrivateType().print()}!"
+}
+
+private class PrivateType {
+    fun print() = "World"
+}

--- a/spec/fixtures/android_unit_test_checker/src/androidTest/java/org/test/PublicTypeTest.kt
+++ b/spec/fixtures/android_unit_test_checker/src/androidTest/java/org/test/PublicTypeTest.kt
@@ -1,0 +1,4 @@
+class PublicTypeTest
+{
+    fun test() { PublicType().print() }
+}


### PR DESCRIPTION
This PR updates the regex used to detect non-private classes. The previous regex was flawed as it captured classes like `private class Foo` due to the `\s` expression in the first non-capturing group. The new regex captures the same data as before but now includes class modifiers and filters based on them.

Closes #72