### PR TITLE
Release 1.2.1 into trunk

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,12 +14,18 @@ _None_
 
 ### Bug Fixes
 
-- Fix `android_unit_test_checker` plugin so it doesn't detect private, enum, and data classes. [#92]
-- `view_changes_checker`:  update view checker regex to cover GHE user storage URLs [#91]
+_None_
 
 ### Internal Changes
 
 _None_
+
+## 1.2.1
+
+### Bug Fixes
+
+- Fix `android_unit_test_checker` plugin so it doesn't detect private, enum, and data classes. [#92]
+- `view_changes_checker`:  update view checker regex to cover GHE user storage URLs [#91]
 
 ## 1.2.0
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    danger-dangermattic (1.2.0)
+    danger-dangermattic (1.2.1)
       danger (~> 9.4)
       danger-plugin-api (~> 1.0)
       danger-rubocop (~> 0.13)

--- a/lib/dangermattic/gem_version.rb
+++ b/lib/dangermattic/gem_version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Dangermattic
-  VERSION = '1.2.0'
+  VERSION = '1.2.1'
 end


### PR DESCRIPTION
Releasing new version 1.2.1.

# What's Next

PR Author: Be sure to create and publish a GitHub Release pointing to `trunk` once this PR gets merged,
copy/pasting the following text as the GitHub Release's description:
```
### Bug Fixes

- Fix `android_unit_test_checker` plugin so it doesn't detect private, enum, and data classes. [#92]
- `view_changes_checker`:  update view checker regex to cover GHE user storage URLs [#91]


```
