### PR TITLE
Add `sealed` and `value` classes as an exception when reporting missing Android unit tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ _None_
 
 ### Bug Fixes
 
-_None_
+- Add sealed classes as an exception when reporting missing Android unit tests [#94]
 
 ### Internal Changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ _None_
 
 ### Bug Fixes
 
-- Add sealed classes as an exception when reporting missing Android unit tests [#94]
+- `android_unit_test_checker`: add `sealed` and `value` classes as an exception when reporting missing Android unit tests [#94]
 
 ### Internal Changes
 

--- a/lib/dangermattic/plugins/android_unit_test_checker.rb
+++ b/lib/dangermattic/plugins/android_unit_test_checker.rb
@@ -24,13 +24,14 @@ module Danger
   #
   class AndroidUnitTestChecker < Plugin
     ANY_CLASS_DETECTOR = /class\s+([A-Z]\w+)\s*(.*?)\s*{/m
-    CLASS_MODIFIER_DETECTOR = /((?:\s|public|internal|protected|private|final|abstract|static|data|enum|sealed)*)class\s+([A-Z]\w+)\s*(.*?)\s*{/m
+    CLASS_MODIFIER_DETECTOR = /((?:\s|public|internal|protected|private|final|abstract|static|data|enum|sealed|value)*)class\s+([A-Z]\w+)\s*(.*?)\s*{/m
 
     CLASS_MODIFIER_EXCEPTIONS = [
       /\s*data\s*/,
       /\s*private\s*/,
       /\s*enum\s*/,
-      /\s*sealed\s*/
+      /\s*sealed\s*/,
+      /\s*value\s*/
     ].freeze
 
     DEFAULT_CLASSES_EXCEPTIONS = [

--- a/lib/dangermattic/plugins/android_unit_test_checker.rb
+++ b/lib/dangermattic/plugins/android_unit_test_checker.rb
@@ -24,12 +24,13 @@ module Danger
   #
   class AndroidUnitTestChecker < Plugin
     ANY_CLASS_DETECTOR = /class\s+([A-Z]\w+)\s*(.*?)\s*{/m
-    CLASS_MODIFIER_DETECTOR = /((?:\s|public|internal|protected|private|final|abstract|static|data|enum)*)class\s+([A-Z]\w+)\s*(.*?)\s*{/m
+    CLASS_MODIFIER_DETECTOR = /((?:\s|public|internal|protected|private|final|abstract|static|data|enum|sealed)*)class\s+([A-Z]\w+)\s*(.*?)\s*{/m
 
     CLASS_MODIFIER_EXCEPTIONS = [
       /\s*data\s*/,
       /\s*private\s*/,
-      /\s*enum\s*/
+      /\s*enum\s*/,
+      /\s*sealed\s*/
     ].freeze
 
     DEFAULT_CLASSES_EXCEPTIONS = [

--- a/spec/fixtures/android_unit_test_checker/TestsINeedThem2.kt
+++ b/spec/fixtures/android_unit_test_checker/TestsINeedThem2.kt
@@ -10,3 +10,21 @@ class TestsINeedThem2AnotherClass
         println("thisNeedsATest")
     }
 }
+
+enum class ProtocolState {
+    WAITING {
+        override fun signal() = TALKING
+    },
+
+    TALKING {
+        override fun signal() = WAITING
+    };
+
+    abstract fun signal(): ProtocolState
+}
+
+sealed class MySealed(val message: String) {
+    class NetworkError : Error("Network failure")
+    class DatabaseError : Error("Database cannot be reached")
+    class UnknownError : Error("An unknown error has occurred")
+}

--- a/spec/fixtures/android_unit_test_checker/TestsINeedThem2.kt
+++ b/spec/fixtures/android_unit_test_checker/TestsINeedThem2.kt
@@ -23,7 +23,9 @@ enum class ProtocolState {
     abstract fun signal(): ProtocolState
 }
 
-sealed class MySealed(val message: String) {
+value class Password(private val s: String)
+
+sealed class Error(val message: String) {
     class NetworkError : Error("Network failure")
     class DatabaseError : Error("Database cannot be reached")
     class UnknownError : Error("An unknown error has occurred")


### PR DESCRIPTION
I figured `sealed` classes, which are often used to model states similarly to `enum`s, should also be an exception when reporting missing unit tests, so this PR adds them.