### PR TITLE
`android_unit_test_checker`: add exception for `annotation class`

### DIFF
--- a/lib/dangermattic/plugins/android_unit_test_checker.rb
+++ b/lib/dangermattic/plugins/android_unit_test_checker.rb
@@ -24,7 +24,7 @@ module Danger
   #
   class AndroidUnitTestChecker < Plugin
     ANY_CLASS_DETECTOR = /class\s+([A-Z]\w+)\s*(.*?)\s*{/m
-    CLASS_MODIFIER_DETECTOR = /((?:\s|public|internal|protected|private|final|abstract|static|data|enum|sealed|value|annotation)*)class\s+([A-Z]\w+)\s*(.*?)\s*{/m
+    CLASS_MODIFIER_DETECTOR = /((?:\s|public|internal|protected|private|final|abstract|static|data|enum|sealed|value|annotation)*)class\s+([A-Z]\w+)\s*(.*?)\s*(?:{|\n\n)/m
 
     CLASS_MODIFIER_EXCEPTIONS = [
       /\s*data\s*/,

--- a/lib/dangermattic/plugins/android_unit_test_checker.rb
+++ b/lib/dangermattic/plugins/android_unit_test_checker.rb
@@ -153,7 +153,7 @@ module Danger
     # @return [Array<ClassViolation>] An array of ClassViolation objects representing the violations found.
     def find_violations(path:, diff_patch:, classes_exceptions:, subclasses_exceptions:)
       added_lines = git_utils.added_lines(diff_patch: diff_patch)
-      matches = added_lines.scan(CLASS_MODIFIER_DETECTOR)
+      matches = "#{added_lines}\n".scan(CLASS_MODIFIER_DETECTOR) # add a newline to ensure the regex matches the last class in the file
       matches.reject! do |m|
         class_match_is_exception?(
           m,

--- a/lib/dangermattic/plugins/android_unit_test_checker.rb
+++ b/lib/dangermattic/plugins/android_unit_test_checker.rb
@@ -24,7 +24,7 @@ module Danger
   #
   class AndroidUnitTestChecker < Plugin
     ANY_CLASS_DETECTOR = /class\s+([A-Z]\w+)\s*(.*?)\s*{/m
-    CLASS_MODIFIER_DETECTOR = /((?:\s|public|internal|protected|private|final|abstract|static|data|enum|sealed|value|annotation)*)class\s+([A-Z]\w+)\s*(.*?)\s*(?:{|\n\n)/m
+    CLASS_MODIFIER_DETECTOR = /((?:\s|public|internal|protected|private|final|abstract|static|data|enum|sealed|value|annotation)*)class\s+([A-Z]\w+)\s*(.*?)\s*({|\n\n)/m
 
     CLASS_MODIFIER_EXCEPTIONS = [
       /\s*data\s*/,
@@ -186,6 +186,7 @@ module Danger
     def class_match_is_exception?(match, file, classes_exceptions, subclasses_exceptions)
       return true if classes_exceptions.any? { |re| match[1] =~ re }
       return true if CLASS_MODIFIER_EXCEPTIONS.any? { |re| match[0] =~ re }
+      return true unless match[3].include?('{') # Ignore classes that don't have a body
 
       subclass_regexp = File.extname(file) == '.java' ? /extends\s+([A-Z]\w+)/m : /\s*:\s*([A-Z]\w+)/m
       subclass = match[2].scan(subclass_regexp)&.last&.last

--- a/lib/dangermattic/plugins/android_unit_test_checker.rb
+++ b/lib/dangermattic/plugins/android_unit_test_checker.rb
@@ -182,7 +182,7 @@ module Danger
     # @param classes_exceptions [Array<String>] Regexes matching class names to exclude from the check.
     # @param subclasses_exceptions [Array<String>] Regexes matching base class names to exclude from the check
     #
-    # @return [void]
+    # @return [Boolean]
     def class_match_is_exception?(match, file, classes_exceptions, subclasses_exceptions)
       return true if classes_exceptions.any? { |re| match[1] =~ re }
       return true if CLASS_MODIFIER_EXCEPTIONS.any? { |re| match[0] =~ re }

--- a/lib/dangermattic/plugins/android_unit_test_checker.rb
+++ b/lib/dangermattic/plugins/android_unit_test_checker.rb
@@ -24,14 +24,15 @@ module Danger
   #
   class AndroidUnitTestChecker < Plugin
     ANY_CLASS_DETECTOR = /class\s+([A-Z]\w+)\s*(.*?)\s*{/m
-    CLASS_MODIFIER_DETECTOR = /((?:\s|public|internal|protected|private|final|abstract|static|data|enum|sealed|value)*)class\s+([A-Z]\w+)\s*(.*?)\s*{/m
+    CLASS_MODIFIER_DETECTOR = /((?:\s|public|internal|protected|private|final|abstract|static|data|enum|sealed|value|annotation)*)class\s+([A-Z]\w+)\s*(.*?)\s*{/m
 
     CLASS_MODIFIER_EXCEPTIONS = [
       /\s*data\s*/,
       /\s*private\s*/,
       /\s*enum\s*/,
       /\s*sealed\s*/,
-      /\s*value\s*/
+      /\s*value\s*/,
+      /\s*annotation\s*/
     ].freeze
 
     DEFAULT_CLASSES_EXCEPTIONS = [

--- a/spec/android_unit_test_checker_spec.rb
+++ b/spec/android_unit_test_checker_spec.rb
@@ -363,7 +363,7 @@ module Danger
     end
 
     def expect_class_names_match_report(class_names:, error_report:)
-      expect(class_names.length).to eq(error_report.length)
+      expect(error_report.length).to eq(class_names.length)
       class_names.zip(error_report).each do |cls, error|
         expect(error).to include "Please add tests for class `#{cls}`"
       end

--- a/spec/android_unit_test_checker_spec.rb
+++ b/spec/android_unit_test_checker_spec.rb
@@ -159,61 +159,76 @@ module Danger
         expect_class_names_match_report(class_names: ['DummyClassMissingTest'], error_report: @dangerfile.status_report[:errors])
       end
 
-      it 'detects all types of class modifiers' do
-        dayone_source_fixtures_subdir = %w[src main java com dayoneapp dayone]
-        added_files = Dir.glob('**/*.kt', base: fixture_path('android_unit_test_checker', dayone_source_fixtures_subdir))
-                         .map { |file| File.join(dayone_source_fixtures_subdir, file) }
-
-        diff = generate_add_diff_from_fixtures(added_files)
-        allow(@dangerfile.git).to receive(:diff).and_return(diff)
+      context 'when detecting classes and class modifiers' do
+        let(:dayone_source_fixtures_subdir) { %w[src main java com dayoneapp dayone] }
+        let(:added_files) do
+          Dir.glob('**/*.kt', base: fixture_path('android_unit_test_checker', dayone_source_fixtures_subdir))
+             .map { |file| File.join(dayone_source_fixtures_subdir, file) }
+        end
+        let(:diff) { generate_add_diff_from_fixtures(added_files) }
 
         # ClassName => Expected to be detected (true) or ignored (false)
-        expected_detected_classes = {
-          # ApiResult.kt
-          'ApiResult' => false,   # `sealed class ApiResult<T>`
-          'Success' => false,     # `data class Success<T>`
-          'Empty' => true,        # `class Empty<T> : ApiResult<T>`
-          'Failure' => false,     # `data class Failure<T>(…)`
-          'FailureType' => false, # `enum class FailureType`
+        let(:expected_detected_classes) do
+          {
+            # ApiResult.kt
+            'ApiResult' => false,   # `sealed class ApiResult<T>`
+            'Success' => false,     # `data class Success<T>`
+            'Empty' => true,        # `class Empty<T> : ApiResult<T>`
+            'Failure' => false,     # `data class Failure<T>(…)`
+            'FailureType' => false, # `enum class FailureType`
 
-          # WebRecordApi.kt
-          'CursorTime' => false,       # `value class CursorTime`
-          'WebRecordChanges' => false, # `data class WebRecordChanges`
+            # WebRecordApi.kt
+            'CursorTime' => false,       # `value class CursorTime`
+            'WebRecordChanges' => false, # `data class WebRecordChanges`
 
-          # UiStates.kt
-          'LoadKeyUiState' => false, # `sealed class LoadKeyUiState`
+            # UiStates.kt
+            'LoadKeyUiState' => false, # `sealed class LoadKeyUiState`
 
-          # AppIntegrationModule.kt
-          'AppIntegrationHandlers' => false, # `annotation class AppIntegrationHandlers`
+            # AppIntegrationModule.kt
+            'AppIntegrationHandlers' => false, # `annotation class AppIntegrationHandlers`
 
-          # StreaksViewModel.kt
-          'StreaksViewModel' => true,    # `class StreaksViewModel`
-          'Streaks' => false,            # `data class Streaks`
-          'JournalOptionsState' => true, # `class JournalOptionsState`
-          'StreakWeekDay' => false,      # `data class StreakWeekDay`
-          'DayJournaled' => false,       # `value class DayJournaled`
-          'StreakJournal' => false,      # `data class StreakJournal`
-          'DaysOfWeekList' => false,     # `private class DaysOfWeekList`
-          'PreviousDays' => true,        # `class PreviousDays`
+            # StreaksViewModel.kt
+            'StreaksViewModel' => true,    # `class StreaksViewModel`
+            'Streaks' => false,            # `data class Streaks`
+            'JournalOptionsState' => true, # `class JournalOptionsState`
+            'StreakWeekDay' => false,      # `data class StreakWeekDay`
+            'DayJournaled' => false,       # `value class DayJournaled`
+            'StreakJournal' => false,      # `data class StreakJournal`
+            'DaysOfWeekList' => false,     # `private class DaysOfWeekList`
+            'PreviousDays' => true,        # `class PreviousDays`
 
-          # MediaStorageConfiguration.kt
-          'CompressQuality' => false,          # `value class CompressQuality`
-          'MediaStorageConfiguration' => true, # `class MediaStorageConfiguration`
-          'ThumbnailsConfiguration' => true,   # `class ThumbnailsConfiguration`
+            # MediaStorageConfiguration.kt
+            'CompressQuality' => false,          # `value class CompressQuality`
+            'MediaStorageConfiguration' => true, # `class MediaStorageConfiguration`
+            'ThumbnailsConfiguration' => true,   # `class ThumbnailsConfiguration`
 
-          # AccountType.kt
-          'AccountType' => false, # `enum class AccountType`
+            # AccountType.kt
+            'AccountType' => false, # `enum class AccountType`
 
-          # SelectPhotoUseCase.kt
-          'SelectPhotoUseCase' => true, # `class SelectPhotoUseCase`
-          'GetMultipleImages' => false, # `private class GetMultipleImages`
-          'GetSingleImage' => false # `private class GetSingleImage`
-        }
+            # SelectPhotoUseCase.kt
+            'SelectPhotoUseCase' => true, # `class SelectPhotoUseCase`
+            'GetMultipleImages' => false, # `private class GetMultipleImages`
+            'GetSingleImage' => false # `private class GetSingleImage`
+          }
+        end
 
-        # Test with `CLASS_MODIFIER_EXCEPTIONS` excluded (real behavior)
-        @plugin.check_missing_tests
-        expected_violating_classes = expected_detected_classes.filter_map { |k, v| k if v }
-        expect_class_names_match_report(class_names: expected_violating_classes, error_report: @dangerfile.status_report[:errors])
+        before do
+          allow(@dangerfile.git).to receive(:diff).and_return(diff)
+        end
+
+        it 'reports only classes that don\'t have a modifier that is part of modifier exceptions' do
+          @plugin.check_missing_tests
+          expected_violating_classes = expected_detected_classes.filter_map { |k, v| k if v } # only keys whose value is true
+          expect_class_names_match_report(class_names: expected_violating_classes, error_report: @dangerfile.status_report[:errors])
+        end
+
+        it 'validates that the RegEx matches all classes from source code' do
+          # Mock detection of exceptions in order to make `check_missing_tests` report all classes regardless of modifiers
+          # This allows us to validate that our RegEx matches all classes from the source code in the first place
+          allow(@plugin).to receive(:class_match_is_exception?).and_return(false)
+          @plugin.check_missing_tests
+          expect_class_names_match_report(class_names: expected_detected_classes.keys, error_report: @dangerfile.status_report[:errors])
+        end
       end
 
       it 'does not report that a PR with the tests bypass label is missing tests' do

--- a/spec/android_unit_test_checker_spec.rb
+++ b/spec/android_unit_test_checker_spec.rb
@@ -144,6 +144,21 @@ module Danger
         expect(@dangerfile).to not_report
       end
 
+      it 'detects data classes with no {…} body' do
+        # Ensure the CLASS_MODIFIER_DETECTOR regex doesn't assume class declaration always ends with `{` marking the class body
+        # (which would lead the regex to either miss the data class or extend the regex to the next `{`… that potentially belongs to the next class)
+        # This is especially important given data classes might not have a body at all
+
+        mix_data_plus_normal_class_file = 'MixDataPlusNormalClass.kt'
+        data_and_normal_class_diff = generate_add_diff_from_fixtures([mix_data_plus_normal_class_file])
+
+        allow(@dangerfile.git).to receive(:diff).and_return(data_and_normal_class_diff)
+
+        @plugin.check_missing_tests
+
+        expect_class_names_match_report(class_names: ['DummyClassMissingTest'], error_report: @dangerfile.status_report[:errors])
+      end
+
       it 'does not report that a PR with the tests bypass label is missing tests' do
         added_files = %w[
           Abc.java

--- a/spec/android_unit_test_checker_spec.rb
+++ b/spec/android_unit_test_checker_spec.rb
@@ -173,7 +173,7 @@ module Danger
             # ApiResult.kt
             'ApiResult' => false,   # `sealed class ApiResult<T>`
             'Success' => false,     # `data class Success<T>`
-            'Empty' => true,        # `class Empty<T> : ApiResult<T>`
+            'Empty' => false,       # `class Empty<T> : ApiResult<T>()` (but no body)
             'Failure' => false,     # `data class Failure<T>(…)`
             'FailureType' => false, # `enum class FailureType`
 
@@ -188,19 +188,19 @@ module Danger
             'AppIntegrationHandlers' => false, # `annotation class AppIntegrationHandlers`
 
             # StreaksViewModel.kt
-            'StreaksViewModel' => true,    # `class StreaksViewModel`
-            'Streaks' => false,            # `data class Streaks`
-            'JournalOptionsState' => true, # `class JournalOptionsState`
-            'StreakWeekDay' => false,      # `data class StreakWeekDay`
-            'DayJournaled' => false,       # `value class DayJournaled`
-            'StreakJournal' => false,      # `data class StreakJournal`
-            'DaysOfWeekList' => false,     # `private class DaysOfWeekList`
-            'PreviousDays' => true,        # `class PreviousDays`
+            'StreaksViewModel' => true,     # `class StreaksViewModel`
+            'Streaks' => false,             # `data class Streaks`
+            'JournalOptionsState' => false, # `class JournalOptionsState` (but no body)
+            'StreakWeekDay' => false,       # `data class StreakWeekDay`
+            'DayJournaled' => false,        # `value class DayJournaled`
+            'StreakJournal' => false,       # `data class StreakJournal`
+            'DaysOfWeekList' => false,      # `private class DaysOfWeekList`
+            'PreviousDays' => false,        # `class PreviousDays` (but no body)
 
             # MediaStorageConfiguration.kt
-            'CompressQuality' => false,          # `value class CompressQuality`
-            'MediaStorageConfiguration' => true, # `class MediaStorageConfiguration`
-            'ThumbnailsConfiguration' => true,   # `class ThumbnailsConfiguration`
+            'CompressQuality' => false,           # `value class CompressQuality`
+            'MediaStorageConfiguration' => false, # `class MediaStorageConfiguration` (but no body)
+            'ThumbnailsConfiguration' => false,   # `class ThumbnailsConfiguration` (but no body)
 
             # AccountType.kt
             'AccountType' => false, # `enum class AccountType`

--- a/spec/android_unit_test_checker_spec.rb
+++ b/spec/android_unit_test_checker_spec.rb
@@ -144,7 +144,7 @@ module Danger
         expect(@dangerfile).to not_report
       end
 
-      it 'detects data classes with no {…} body' do
+      it 'ensures data classes with no {…} body don\'t mess up detection of subsequent classes in the same file' do
         # Ensure the CLASS_MODIFIER_DETECTOR regex doesn't assume class declaration always ends with `{` marking the class body
         # (which would lead the regex to either miss the data class or extend the regex to the next `{`… that potentially belongs to the next class)
         # This is especially important given data classes might not have a body at all

--- a/spec/android_unit_test_checker_spec.rb
+++ b/spec/android_unit_test_checker_spec.rb
@@ -159,6 +159,63 @@ module Danger
         expect_class_names_match_report(class_names: ['DummyClassMissingTest'], error_report: @dangerfile.status_report[:errors])
       end
 
+      it 'detects all types of class modifiers' do
+        dayone_source_fixtures_subdir = %w[src main java com dayoneapp dayone]
+        added_files = Dir.glob('**/*.kt', base: fixture_path('android_unit_test_checker', dayone_source_fixtures_subdir))
+                         .map { |file| File.join(dayone_source_fixtures_subdir, file) }
+
+        diff = generate_add_diff_from_fixtures(added_files)
+        allow(@dangerfile.git).to receive(:diff).and_return(diff)
+
+        # ClassName => Expected to be detected (true) or ignored (false)
+        expected_detected_classes = {
+          # ApiResult.kt
+          'ApiResult' => false,   # `sealed class ApiResult<T>`
+          'Success' => false,     # `data class Success<T>`
+          'Empty' => true,        # `class Empty<T> : ApiResult<T>`
+          'Failure' => false,     # `data class Failure<T>(…)`
+          'FailureType' => false, # `enum class FailureType`
+
+          # WebRecordApi.kt
+          'CursorTime' => false,       # `value class CursorTime`
+          'WebRecordChanges' => false, # `data class WebRecordChanges`
+
+          # UiStates.kt
+          'LoadKeyUiState' => false, # `sealed class LoadKeyUiState`
+
+          # AppIntegrationModule.kt
+          'AppIntegrationHandlers' => false, # `annotation class AppIntegrationHandlers`
+
+          # StreaksViewModel.kt
+          'StreaksViewModel' => true,    # `class StreaksViewModel`
+          'Streaks' => false,            # `data class Streaks`
+          'JournalOptionsState' => true, # `class JournalOptionsState`
+          'StreakWeekDay' => false,      # `data class StreakWeekDay`
+          'DayJournaled' => false,       # `value class DayJournaled`
+          'StreakJournal' => false,      # `data class StreakJournal`
+          'DaysOfWeekList' => false,     # `private class DaysOfWeekList`
+          'PreviousDays' => true,        # `class PreviousDays`
+
+          # MediaStorageConfiguration.kt
+          'CompressQuality' => false,          # `value class CompressQuality`
+          'MediaStorageConfiguration' => true, # `class MediaStorageConfiguration`
+          'ThumbnailsConfiguration' => true,   # `class ThumbnailsConfiguration`
+
+          # AccountType.kt
+          'AccountType' => false, # `enum class AccountType`
+
+          # SelectPhotoUseCase.kt
+          'SelectPhotoUseCase' => true, # `class SelectPhotoUseCase`
+          'GetMultipleImages' => false, # `private class GetMultipleImages`
+          'GetSingleImage' => false # `private class GetSingleImage`
+        }
+
+        # Test with `CLASS_MODIFIER_EXCEPTIONS` excluded (real behavior)
+        @plugin.check_missing_tests
+        expected_violating_classes = expected_detected_classes.filter_map { |k, v| k if v }
+        expect_class_names_match_report(class_names: expected_violating_classes, error_report: @dangerfile.status_report[:errors])
+      end
+
       it 'does not report that a PR with the tests bypass label is missing tests' do
         added_files = %w[
           Abc.java
@@ -363,7 +420,10 @@ module Danger
     end
 
     def expect_class_names_match_report(class_names:, error_report:)
-      expect(error_report.length).to eq(class_names.length)
+      if error_report.length != class_names.length
+        reported_class_names = error_report.map { |e| e.match(/class `(.*?)`/)[1] }
+        expect(reported_class_names).to eq(class_names)
+      end
       class_names.zip(error_report).each do |cls, error|
         expect(error).to include "Please add tests for class `#{cls}`"
       end

--- a/spec/android_unit_test_checker_spec.rb
+++ b/spec/android_unit_test_checker_spec.rb
@@ -160,8 +160,8 @@ module Danger
       end
 
       context 'when detecting classes and class modifiers' do
-        let(:dayone_source_fixtures_subdir) { %w[src main java com dayoneapp dayone] }
         let(:added_files) do
+          dayone_source_fixtures_subdir = %w[src main java com dayoneapp dayone]
           Dir.glob('**/*.kt', base: fixture_path('android_unit_test_checker', dayone_source_fixtures_subdir))
              .map { |file| File.join(dayone_source_fixtures_subdir, file) }
         end
@@ -388,7 +388,7 @@ module Danger
 
     def generate_add_diff_from_fixtures(paths)
       paths.map do |path|
-        content = fixture(File.join('android_unit_test_checker', path))
+        content = fixture('android_unit_test_checker', path)
         diff_str = generate_add_diff(file_path: path, content: content)
 
         GitDiffStruct.new('new', path, diff_str)
@@ -397,7 +397,7 @@ module Danger
 
     def generate_delete_diff_from_fixtures(paths)
       paths.map do |path|
-        content = fixture(File.join('android_unit_test_checker', path))
+        content = fixture('android_unit_test_checker', path)
         diff_str = generate_delete_diff(file_path: path, content: content)
 
         GitDiffStruct.new('deleted', path, diff_str)

--- a/spec/fixtures/android_unit_test_checker/MixDataPlusNormalClass.kt
+++ b/spec/fixtures/android_unit_test_checker/MixDataPlusNormalClass.kt
@@ -1,0 +1,14 @@
+import javax.inject.Inject
+import javax.inject.Singleton
+
+internal data class DummyDataClassNotNeedingTests(
+    val title: String,
+    val id: String
+)
+
+@Singleton
+internal class DummyClassMissingTest @Inject constructor(
+    private val name: String,
+) : ParentClass {
+    private val loggingTag = 'mylogging'
+}

--- a/spec/fixtures/android_unit_test_checker/src/main/java/com/dayoneapp/dayone/api/ApiResult.kt
+++ b/spec/fixtures/android_unit_test_checker/src/main/java/com/dayoneapp/dayone/api/ApiResult.kt
@@ -1,0 +1,69 @@
+package com.dayoneapp.dayone.api
+
+import com.dayoneapp.dayone.api.ApiResult.Failure
+import com.dayoneapp.dayone.api.ApiResult.FailureType.GENERIC
+import com.dayoneapp.dayone.api.ApiResult.FailureType.SERVER_ERROR
+import com.dayoneapp.dayone.api.ApiResult.FailureType.TIMEOUT
+import com.dayoneapp.dayone.api.ApiResult.FailureType.UNAUTHORIZED
+import com.dayoneapp.syncservice.NetworkErrorType
+import com.google.api.client.http.HttpStatusCodes
+import retrofit2.Response
+import java.io.IOException
+
+sealed class ApiResult<T> {
+    data class Success<T>(
+        val data: T,
+    ) : ApiResult<T>()
+
+    class Empty<T> : ApiResult<T>()
+
+    data class Failure<T>(
+        val type: FailureType,
+        val errorCode: Int? = null,
+        val errorMessage: String? = null,
+    ) : ApiResult<T>()
+
+    enum class FailureType {
+        SERVER_ERROR,
+        UNAUTHORIZED,
+        TIMEOUT,
+        GENERIC,
+        NOT_CONNECTED,
+        ;
+
+        companion object {
+            fun fromNetworkErrorType(networkErrorType: NetworkErrorType): FailureType =
+                when (networkErrorType) {
+                    NetworkErrorType.SERVER_ERROR -> SERVER_ERROR
+                    NetworkErrorType.UNAUTHORIZED -> UNAUTHORIZED
+                    NetworkErrorType.TIMEOUT -> TIMEOUT
+                    NetworkErrorType.GENERIC -> GENERIC
+                    else -> {
+                        GENERIC
+                    }
+                }
+        }
+    }
+}
+
+suspend fun <T> apiCall(apiCall: suspend () -> Response<T>): ApiResult<T> =
+    try {
+        with(apiCall()) {
+            if (this.isSuccessful) {
+                this.body()?.let {
+                    ApiResult.Success(it)
+                } ?: ApiResult.Empty()
+            } else {
+                val type =
+                    when (this.code()) {
+                        HttpStatusCodes.STATUS_CODE_UNAUTHORIZED, HttpStatusCodes.STATUS_CODE_FORBIDDEN -> UNAUTHORIZED
+                        HttpStatusCodes.STATUS_CODE_SERVER_ERROR -> SERVER_ERROR
+                        else -> GENERIC
+                    }
+                Failure(type, this.code(), this.message())
+            }
+        }
+    } catch (e: IOException) {
+        Failure(TIMEOUT)
+    }
+    

--- a/spec/fixtures/android_unit_test_checker/src/main/java/com/dayoneapp/dayone/api/WebRecordApi.kt
+++ b/spec/fixtures/android_unit_test_checker/src/main/java/com/dayoneapp/dayone/api/WebRecordApi.kt
@@ -1,0 +1,49 @@
+package com.dayoneapp.dayone.api
+
+import com.dayoneapp.dayone.domain.sync.WebRecordRemote
+import com.google.gson.annotations.SerializedName
+import retrofit2.Response
+import retrofit2.http.*
+
+@JvmInline
+value class CursorTime(
+    val time: String,
+)
+
+val ZeroCursorTime = CursorTime("0")
+
+data class WebRecordChanges(
+    @SerializedName("changes")
+    val changes: List<WebRecordRemote>,
+    @SerializedName("cursor")
+    val cursor: String,
+)
+
+interface WebRecordApi {
+    @POST("$SYNC/named/{name}")
+    suspend fun createRecord(
+        @Path("name") name: String,
+        @Body record: WebRecordRemote,
+    ): Response<WebRecordRemote>
+
+    @PUT("$SYNC/{syncId}")
+    suspend fun updateRecord(
+        @Path("syncId") syncId: String,
+        @Body record: WebRecordRemote,
+    ): Response<WebRecordRemote>
+
+    @GET("$SYNC/named/{name}")
+    suspend fun fetchRecord(
+        @Path("name") name: String,
+    ): Response<WebRecordRemote>
+
+    @GET("$SYNC/changes/{kind}")
+    suspend fun fetchRecordChanges(
+        @Path("kind") kind: String,
+        @Query("cursor") cursor: CursorTime,
+    ): Response<WebRecordChanges>
+
+    companion object {
+        const val SYNC = "/api/v4/sync"
+    }
+}

--- a/spec/fixtures/android_unit_test_checker/src/main/java/com/dayoneapp/dayone/domain/drive/UiStates.kt
+++ b/spec/fixtures/android_unit_test_checker/src/main/java/com/dayoneapp/dayone/domain/drive/UiStates.kt
@@ -1,0 +1,13 @@
+package com.dayoneapp.dayone.domain.drive
+
+sealed class LoadKeyUiState(
+    val buttonEnabled: Boolean,
+) {
+    object Init : LoadKeyUiState(buttonEnabled = true)
+
+    object Loading : LoadKeyUiState(buttonEnabled = false)
+
+    object KeyLoaded : LoadKeyUiState(buttonEnabled = false)
+
+    object KeyNotFound : LoadKeyUiState(buttonEnabled = true)
+}

--- a/spec/fixtures/android_unit_test_checker/src/main/java/com/dayoneapp/dayone/main/settings/integrations/connect/AppIntegrationModule.kt
+++ b/spec/fixtures/android_unit_test_checker/src/main/java/com/dayoneapp/dayone/main/settings/integrations/connect/AppIntegrationModule.kt
@@ -1,0 +1,29 @@
+package com.dayoneapp.dayone.main.settings.integrations.connect
+
+import com.dayoneapp.dayone.main.settings.integrations.IntegrationAppId
+import com.dayoneapp.dayone.main.settings.integrations.strava.StravaAppIntegrationHandler
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import javax.inject.Qualifier
+import javax.inject.Singleton
+import kotlin.jvm.JvmWildcard
+
+@Qualifier
+@Retention(AnnotationRetention.BINARY)
+annotation class AppIntegrationHandlers
+
+@Module
+@InstallIn(SingletonComponent::class)
+internal object AppIntegrationModule {
+    @Provides
+    @Singleton
+    @AppIntegrationHandlers
+    fun provideAppIntegrationHandlers(
+        stravaAppIntegrationHandler: StravaAppIntegrationHandler,
+    ): Map<IntegrationAppId, @JvmWildcard AppIntegrationHandler> =
+        mapOf(
+            IntegrationAppId.STRAVA to stravaAppIntegrationHandler,
+        )
+}

--- a/spec/fixtures/android_unit_test_checker/src/main/java/com/dayoneapp/dayone/main/streaks/StreaksViewModel.kt
+++ b/spec/fixtures/android_unit_test_checker/src/main/java/com/dayoneapp/dayone/main/streaks/StreaksViewModel.kt
@@ -1,0 +1,377 @@
+package com.dayoneapp.dayone.main.streaks
+
+import android.content.Context
+import android.graphics.Bitmap
+import androidx.annotation.ColorRes
+import androidx.annotation.VisibleForTesting
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.dayoneapp.dayone.di.DatabaseThreadDispatcher
+import com.dayoneapp.dayone.domain.JournalRepository
+import com.dayoneapp.dayone.domain.SelectedJournalsProvider
+import com.dayoneapp.dayone.domain.StreakRepository
+import com.dayoneapp.dayone.domain.UserRepository
+import com.dayoneapp.dayone.domain.analytics.AnalyticsTracker
+import com.dayoneapp.dayone.domain.analytics.InitialContent
+import com.dayoneapp.dayone.domain.entry.EntryRepository
+import com.dayoneapp.dayone.main.editor.EditorLauncher
+import com.dayoneapp.dayone.main.editor.MainActivityLauncher
+import com.dayoneapp.dayone.main.navigation.ActivityEventHandler
+import com.dayoneapp.dayone.main.navigation.Navigator
+import com.dayoneapp.dayone.main.sharedjournals.events.OpenJournalOnTimeline
+import com.dayoneapp.dayone.utils.DOStreakCalculator
+import com.dayoneapp.dayone.utils.TimeProvider
+import com.dayoneapp.dayone.utils.UtilsWrapper
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.launch
+import java.io.File
+import java.time.DayOfWeek
+import java.time.LocalDate
+import java.util.Calendar
+import javax.inject.Inject
+
+@HiltViewModel
+class StreaksViewModel
+    @Inject
+    constructor(
+        @DatabaseThreadDispatcher private val databaseDispatcher: CoroutineDispatcher,
+        private val entryRepository: EntryRepository,
+        private val journalRepository: JournalRepository,
+        private val streakRepository: StreakRepository,
+        private val streaksCalculator: DOStreakCalculator,
+        private val timeProvider: TimeProvider,
+        private val userRepository: UserRepository,
+        private val navigator: Navigator,
+        private val selectedJournalsProvider: SelectedJournalsProvider,
+        private val utilsWrapper: UtilsWrapper,
+        private val analyticsTracker: AnalyticsTracker,
+        private val mainActivityLauncher: MainActivityLauncher,
+        private val editorLauncher: EditorLauncher,
+        private val activityEventHandler: ActivityEventHandler,
+    ) : ViewModel() {
+        val uiState =
+            combine(
+                entryRepository.liveEntryCount().distinctUntilChanged(),
+                entryRepository.liveEntryCountForDate().distinctUntilChanged(),
+                journalRepository
+                    .getAllJournalsLive(false)
+                    .map { journals ->
+                        journals.map { journal -> journal.isHideStreaksEnabled }
+                    }.distinctUntilChanged(),
+            ) { _, _, _ ->
+                val streakDays = streaksCalculator.calculateStreakWithSharedJournals()
+                val journals = getStreakJournals()
+                val streakWeekDays = getStreakWeekDays()
+
+                UiState.Streaks(
+                    streakDays = streakDays,
+                    streakWeekDays = streakWeekDays,
+                    journals = journals,
+                )
+            }.stateIn(viewModelScope, SharingStarted.Lazily, UiState.Loading)
+
+        private val _journalOptionsState = MutableStateFlow<JournalOptionsState?>(null)
+        val journalOptionsState = _journalOptionsState.asStateFlow()
+
+        private val dayOfWeekList: DaysOfWeekList = DaysOfWeekList(timeProvider.getFirstDayOfWeek())
+
+        fun shareStreaks(
+            bitmap: Bitmap,
+            context: Context,
+        ) {
+            viewModelScope.launch(databaseDispatcher) {
+                analyticsTracker.trackButtonTapped("streakView_share")
+                val streaksFile: File = utilsWrapper.saveBitmapToFile(context, bitmap, "streaks_file")
+                utilsWrapper.shareImage(context, streaksFile.absolutePath)
+            }
+        }
+
+        fun close() {
+            viewModelScope.launch {
+                analyticsTracker.trackButtonTapped("streakView_close")
+                navigator.goBack()
+            }
+        }
+
+        fun showJournalOptions(
+            journalId: Int,
+            journalName: String,
+        ) {
+            viewModelScope.launch {
+                analyticsTracker.trackButtonTapped("streakView_journal")
+                _journalOptionsState.value = JournalOptionsState(journalId, journalName)
+            }
+        }
+
+        fun openJournal(journalId: Int) {
+            viewModelScope.launch {
+                _journalOptionsState.value = null
+
+                analyticsTracker.trackButtonTapped("streakView_journalMenu_openJournal")
+
+                activityEventHandler.sendEvent(
+                    OpenJournalOnTimeline(
+                        journalId = journalId,
+                        selectedJournalsProvider = selectedJournalsProvider,
+                        mainActivityLauncher = mainActivityLauncher,
+                    ),
+                )
+            }
+        }
+
+        fun createEntry(journalId: Int) {
+            viewModelScope.launch {
+                _journalOptionsState.value = null
+
+                analyticsTracker.trackButtonTapped("streakView_journalMenu_createEntry")
+
+                val newEntry =
+                    entryRepository.createNewEntry(
+                        journalId = journalId,
+                    )
+                val newEntryInformation =
+                    EditorLauncher.NewEntryInformation(
+                        AnalyticsTracker.NewEntrySource.STREAKS,
+                        InitialContent.BLANK,
+                    )
+                editorLauncher.editNewEntry(
+                    entry = newEntry,
+                    newEntryInformation = newEntryInformation,
+                    navigateTo = navigator::navigateTo,
+                )
+            }
+        }
+
+        fun closeJournalOptions() {
+            _journalOptionsState.value = null
+        }
+
+        private suspend fun getStreakWeekDays(): List<StreakWeekDay> {
+            val week = mutableListOf<StreakWeekDay>()
+            // First day of the week can vary based on the user's locale. Generally, SUNDAY is the default in countries
+            // influenced by the US, MONDAY is standard in most of Europe and Asia, and SATURDAY can be common in some
+            // Middle Eastern countries due to the weekend structure.
+            val firstDayOfWeek = timeProvider.getFirstDayOfWeek()
+            if (firstDayOfWeek == Calendar.SATURDAY) {
+                week.add(getStreakWeekDay(DayOfWeek.SATURDAY))
+            }
+            if (firstDayOfWeek == Calendar.SUNDAY || firstDayOfWeek == Calendar.SATURDAY) {
+                week.add(getStreakWeekDay(DayOfWeek.SUNDAY))
+            }
+            week.add(getStreakWeekDay(DayOfWeek.MONDAY))
+            week.add(getStreakWeekDay(DayOfWeek.TUESDAY))
+            week.add(getStreakWeekDay(DayOfWeek.WEDNESDAY))
+            week.add(getStreakWeekDay(DayOfWeek.THURSDAY))
+            week.add(getStreakWeekDay(DayOfWeek.FRIDAY))
+            if (firstDayOfWeek != Calendar.SATURDAY) {
+                week.add(getStreakWeekDay(DayOfWeek.SATURDAY))
+            }
+            if (firstDayOfWeek != Calendar.SUNDAY && firstDayOfWeek != Calendar.SATURDAY) {
+                week.add(getStreakWeekDay(DayOfWeek.SUNDAY))
+            }
+
+            return week
+        }
+
+        @VisibleForTesting
+        suspend fun getStreakWeekDay(dayOfWeek: DayOfWeek): StreakWeekDay {
+            val currentDate = timeProvider.currentLocalDate()
+            val daysToDayOfWeek =
+                dayOfWeekList.daysToPreviousDay(
+                    currentDay = currentDate.dayOfWeek,
+                    previousDay = dayOfWeek,
+                )
+            // Go to the previous date based on [dateOfWeek] and current date.
+            val currentDateForDayOfWeek = currentDate.minusDays(daysToDayOfWeek.daysToPreviousDay.toLong())
+            // From that date, go back DAYS_MINUS_WEEK * 7 days to cover DAYS_MINUS_WEEK (18) instances of the [dayOfWeek].
+            // For example,if [dayOfWeek] is MONDAY and current date is 2024-10-8 (a TUESDAY), then [daysToDayOfWeek] is 1
+            // and [currentDateForDayOfWeek] is 2024-10-7 and since becomes 2024-6-7 which represents the 18th MONDAY from
+            // the current date.
+            val previousWeeks = if (daysToDayOfWeek.wasInPreviousWeek) DAYS_MINUS_WEEK - 1 else DAYS_MINUS_WEEK
+            val since = currentDateForDayOfWeek.minusDays(previousWeeks * 7)
+            // Generates a sequences of dates that represents the [dayOfWeek] for the previous 18 weeks. For the previous
+            // example, represent dates for each MONDAY from 2024-6-7 to 2024-10-7.
+            val dateRange: Sequence<LocalDate> =
+                generateSequence(since) { date ->
+                    if (date < currentDateForDayOfWeek) date.plusDays(7) else null
+                }
+            // We query all the dates with entries since 2024-6-7 and check if the [dayOfWeek] for each week has an entry.
+            val userId = userRepository.getUser()?.id
+            val datesWithEntries = streakRepository.getDatesThatHaveEntriesSince(since, userId)
+            val days =
+                dateRange
+                    .map { date ->
+                        DayJournaled(datesWithEntries.contains(date))
+                    }.toMutableList()
+                    .also {
+                        if (daysToDayOfWeek.wasInPreviousWeek) {
+                            it.add(DayJournaled(null))
+                        }
+                    }
+
+            return StreakWeekDay(dayOfWeek = dayOfWeek, days = days)
+        }
+
+        @VisibleForTesting
+        suspend fun getStreakJournals(): List<StreakJournal> {
+            val currentDate = timeProvider.currentLocalDate()
+            val since = currentDate.minusDays(DAYS_MINUS_JOURNAL)
+            val dateRange: Sequence<LocalDate> =
+                generateSequence(since) { date ->
+                    if (date < currentDate) date.plusDays(1) else null
+                }
+            return journalRepository
+                .getAllJournals(includeHidden = true)
+                .filter {
+                    !it.isHideFromStreakEnabledNonNull() && !it.isPlaceholderForEncryptedJournalNonNull()
+                }.sortedBy { it.sortOrder ?: 0 }
+                .map { journal ->
+                    val datesWithEntries =
+                        if (journal.isShared == true) {
+                            streakRepository.getDatesThatHaveEntriesSinceForSharedJournal(
+                                journalId = journal.id,
+                                since = since,
+                                userId = userRepository.getUser()?.id ?: "",
+                            )
+                        } else {
+                            streakRepository.getDatesThatHaveEntriesSinceForJournal(journalId = journal.id, since = since)
+                        }
+                    val days =
+                        dateRange
+                            .map { date ->
+                                DayJournaled(datesWithEntries.contains(date))
+                            }.toList()
+                    val entriesToday =
+                        if (journal.isShared == true) {
+                            streakRepository.getNumEntriesForSharedJournalOnDate(
+                                journalId = journal.id,
+                                date = currentDate,
+                                userId = userRepository.getUser()?.id ?: "",
+                            )
+                        } else {
+                            streakRepository.getNumEntriesOnDate(journalId = journal.id, date = currentDate)
+                        }
+
+                    StreakJournal(
+                        journalId = journal.id,
+                        journalName = journal.name ?: "",
+                        entriesToday = entriesToday,
+                        color = journal.journalColor.backgroundColorRes,
+                        days = days,
+                    )
+                }
+        }
+
+        companion object {
+            private const val DAYS_MINUS_JOURNAL = 18L
+            private const val DAYS_MINUS_WEEK = 17L
+        }
+
+        sealed interface UiState {
+            data object Loading : UiState
+
+            data class Streaks(
+                val streakDays: Int,
+                val streakWeekDays: List<StreakWeekDay>,
+                val journals: List<StreakJournal>,
+            ) : UiState
+        }
+
+        class JournalOptionsState(
+            val journalId: Int,
+            val journalName: String,
+        )
+    }
+
+data class StreakWeekDay(
+    val dayOfWeek: DayOfWeek,
+    val days: List<DayJournaled>,
+)
+
+@JvmInline
+value class DayJournaled(
+    val isFilled: Boolean?,
+)
+
+data class StreakJournal(
+    val journalId: Int,
+    val journalName: String,
+    val entriesToday: Int,
+    @ColorRes
+    val color: Int,
+    val days: List<DayJournaled>,
+)
+
+private class DaysOfWeekList(
+    private val firstDayOfWeek: Int,
+) {
+    private val days =
+        buildList {
+            if (firstDayOfWeek == Calendar.SATURDAY) {
+                add(DayOfWeek.SATURDAY)
+            }
+            if (firstDayOfWeek == Calendar.SUNDAY || firstDayOfWeek == Calendar.SATURDAY) {
+                add(DayOfWeek.SUNDAY)
+            }
+            add(DayOfWeek.MONDAY)
+            add(DayOfWeek.TUESDAY)
+            add(DayOfWeek.WEDNESDAY)
+            add(DayOfWeek.THURSDAY)
+            add(DayOfWeek.FRIDAY)
+            if (firstDayOfWeek != Calendar.SATURDAY) {
+                add(DayOfWeek.SATURDAY)
+            }
+            if (firstDayOfWeek != Calendar.SUNDAY && firstDayOfWeek != Calendar.SATURDAY) {
+                add(DayOfWeek.SUNDAY)
+            }
+        }
+
+    /**
+     * Return the number of days between the current day of the week and the previous day of the week.
+     *
+     * Example: If the current day of the week is MONDAY and the previous day of the week is FRIDAY, then it would
+     * return 3 because we have to go through SUNDAY, SATURDAY to FRIDAY.
+     *
+     * @param currentDay The current day of the week.
+     * @param previousDay The previous day of the week.
+     * @return Number of days between the current day of the week and the previous day of the week.
+     */
+    fun daysToPreviousDay(
+        currentDay: DayOfWeek,
+        previousDay: DayOfWeek,
+    ): PreviousDays {
+        if (currentDay == previousDay) {
+            return PreviousDays(0, false)
+        }
+        var indexCurrentDay = days.indexOf(currentDay)
+        var daysToPreviousDay = 0
+        var wasInPreviousWeek = false
+        while (true) {
+            indexCurrentDay -= 1
+            if (indexCurrentDay < 0) {
+                wasInPreviousWeek = true
+                indexCurrentDay = days.size - 1
+            }
+            daysToPreviousDay += 1
+
+            if (days[indexCurrentDay] == previousDay) {
+                break
+            }
+        }
+
+        return PreviousDays(daysToPreviousDay, wasInPreviousWeek)
+    }
+
+    class PreviousDays(
+        val daysToPreviousDay: Int,
+        val wasInPreviousWeek: Boolean,
+    )
+}

--- a/spec/fixtures/android_unit_test_checker/src/main/java/com/dayoneapp/dayone/mediastorage/MediaStorageConfiguration.kt
+++ b/spec/fixtures/android_unit_test_checker/src/main/java/com/dayoneapp/dayone/mediastorage/MediaStorageConfiguration.kt
@@ -1,0 +1,31 @@
+package com.dayoneapp.mediastorage
+
+import android.graphics.Bitmap
+
+@JvmInline
+value class CompressQuality(
+    val value: Int,
+) {
+    init {
+        require(value in 1..100) { }
+    }
+}
+
+class MediaStorageConfiguration(
+    val mediaPath: String,
+    val externalImagesPath: String,
+    val externalVideosPath: String,
+    val externalAudiosPath: String,
+    val externalDocumentsPath: String,
+    val avatarsPath: String,
+    val thumbnailsConfiguration: ThumbnailsConfiguration,
+)
+
+class ThumbnailsConfiguration(
+    val thumbnailsPath: String,
+    val height: Int,
+    val width: Int,
+    val extension: String,
+    val compression: Bitmap.CompressFormat,
+    val quality: CompressQuality,
+)

--- a/spec/fixtures/android_unit_test_checker/src/main/java/com/dayoneapp/dayone/utils/AccountType.kt
+++ b/spec/fixtures/android_unit_test_checker/src/main/java/com/dayoneapp/dayone/utils/AccountType.kt
@@ -1,0 +1,15 @@
+package com.dayoneapp.dayone.utils
+
+enum class AccountType(
+    val key: String,
+) {
+    DAY_ONE("Day One"),
+    GOOGLE("Google"),
+    APPLE("Apple ID"),
+    ;
+
+    companion object {
+        @JvmStatic
+        fun fromString(key: String): AccountType = values().find { it.key == key }!!
+    }
+}

--- a/spec/fixtures/android_unit_test_checker/src/main/java/com/dayoneapp/dayone/utils/usecase/SelectPhotoUseCase.kt
+++ b/spec/fixtures/android_unit_test_checker/src/main/java/com/dayoneapp/dayone/utils/usecase/SelectPhotoUseCase.kt
@@ -1,0 +1,76 @@
+package com.dayoneapp.dayone.utils.usecase
+
+import android.content.Context
+import android.content.Intent
+import androidx.activity.result.ActivityResultLauncher
+import androidx.activity.result.contract.ActivityResultContracts.GetContent
+import androidx.activity.result.contract.ActivityResultContracts.GetMultipleContents
+import androidx.fragment.app.Fragment
+import com.dayoneapp.dayone.utils.UriWrapper
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.asSharedFlow
+import javax.inject.Inject
+
+class SelectPhotoUseCase
+    @Inject
+    constructor() {
+        private lateinit var getContent: ActivityResultLauncher<String>
+        private val _mediaUris = MutableSharedFlow<List<UriWrapper>>(extraBufferCapacity = 5)
+        val mediaUris = _mediaUris.asSharedFlow()
+
+        fun onCreate(
+            fragment: Fragment,
+            singlePhoto: Boolean = false,
+        ) {
+            getContent =
+                if (singlePhoto) {
+                    fragment.registerForActivityResult(GetSingleImage()) { uri ->
+                        uri?.let {
+                            _mediaUris.tryEmit(listOf(UriWrapper(it)))
+                        }
+                    }
+                } else {
+                    fragment.registerForActivityResult(GetMultipleImages()) { uris ->
+                        _mediaUris.tryEmit(uris.map { UriWrapper(it) })
+                    }
+                }
+        }
+
+        fun selectPhotos() {
+            getContent.launch("image/*")
+        }
+
+        private class GetMultipleImages : GetMultipleContents() {
+            // Required to remove a lint error due to this method no longer calling super.createIntent()
+            @Suppress("MissingSuperCall")
+            override fun createIntent(
+                context: Context,
+                input: String,
+            ): Intent =
+                Intent(
+                    Intent.ACTION_PICK,
+                    android.provider.MediaStore.Images.Media.EXTERNAL_CONTENT_URI,
+                ).setType(input)
+                    .putExtra(Intent.EXTRA_ALLOW_MULTIPLE, true)
+                    .apply {
+                        putExtra(Intent.EXTRA_MIME_TYPES, arrayOf("image/jpeg", "image/png", "image/jpg"))
+                    }
+        }
+
+        private class GetSingleImage : GetContent() {
+            // Required to remove a lint error due to this method no longer calling super.createIntent()
+            @Suppress("MissingSuperCall")
+            override fun createIntent(
+                context: Context,
+                input: String,
+            ): Intent =
+                Intent(
+                    Intent.ACTION_PICK,
+                    android.provider.MediaStore.Images.Media.EXTERNAL_CONTENT_URI,
+                ).setType(input)
+                    .apply {
+                        putExtra(Intent.EXTRA_MIME_TYPES, arrayOf("image/jpeg", "image/png", "image/jpg"))
+                    }
+        }
+    }
+    

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -58,8 +58,12 @@ def testing_dangerfile
   Danger::Dangerfile.new(env, testing_ui)
 end
 
+def fixture_path(*components)
+  File.join('spec', 'fixtures', *components)
+end
+
 def fixture(name)
-  File.read("spec/fixtures/#{name}")
+  File.read(fixture_path(name))
 end
 
 # custom matchers

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -58,12 +58,14 @@ def testing_dangerfile
   Danger::Dangerfile.new(env, testing_ui)
 end
 
-def fixture_path(*components)
-  File.join('spec', 'fixtures', *components)
+# Returns the full path of the fixture at the given subpath (relative to `spec/fixtures`)
+def fixture_path(*path_components)
+  File.join('spec', 'fixtures', *path_components)
 end
 
-def fixture(name)
-  File.read(fixture_path(name))
+# Returns the content of the fixture at the given path (relative to `spec/fixtures`)
+def fixture(*path_components)
+  File.read(fixture_path(*path_components))
 end
 
 # custom matchers


### PR DESCRIPTION
Closes https://linear.app/a8c/issue/AINFRA-1273/dangermattic-do-not-require-tests-for-annotation-classes

## What

Adds an exception for `annotation class` to the `android_unit_test_checker`

## Testing

Tested in [this dummy Draft PR in DOAndroid](https://github.com/bloom/DayOne-Android/pull/6539) by running `danger pr "https://github.com/bloom/DayOne-Android/pull/6539"` on my Terminal (after having set the API token env var), especially after that PR added [this file](https://github.com/bloom/DayOne-Android/pull/6539/files#diff-e862de46717f5ff22703e5b793b9d49a617f1cec6ad0321fff67f8a4d81be6dc):

```
Results:

Errors:
- [ ] Please add tests for class `StravaAppIntegrationHandler` (or add `unit-tests-exemption` label to ignore this).

Warnings:
- [ ] This PR is larger than 500 lines of changes. Please consider splitting it into smaller PRs for easier and faster reviews.

Messages:
- [ ] This PR is still a Draft: some checks will be skipped.
```

This validates that:
 - The `annotation class` added in that dummy Draft PR didn't trigger the Danger warning anymore
 - Dangermattic still detects a true positive of a newly-introduced `StravaAppIntegrationHandler` class missing tests (as [I intentionally removed them from that dummy draft PR](https://github.com/bloom/DayOne-Android/pull/6539/commits/959560f3593084065d677ca33a62541a8a35fe0d) to validate exactly that scenario)

🟢  Since I also added a corresponding unit test and those are run on CI, CI being green should also be enough for considering this behaves as expected.