### PR TITLE
Optimize PR Size Checker and Manifest Checker for large diffs

### DIFF
--- a/lib/dangermattic/plugins/manifest_pr_checker.rb
+++ b/lib/dangermattic/plugins/manifest_pr_checker.rb
@@ -115,13 +115,19 @@ module Danger
     private
 
     def check_manifest_lock_updated(file_name:, lock_file_name:, instruction:, report_type: :warning)
+      all_files = git_utils.all_changed_files
+
       # Find all the modified manifest files
-      manifest_modified_files = git_utils.all_changed_files.select { |f| File.basename(f) == file_name }
+      manifest_modified_files = all_files.select { |f| File.basename(f) == file_name }
+
+      # Build a hash mapping directory -> set of basenames for O(1) lookup
+      files_by_dir = all_files.group_by { |f| File.dirname(f) }
+                              .transform_values { |files| files.to_set { |f| File.basename(f) } }
 
       # For each manifest file, check if the corresponding lockfile (in the same dir) was also modified
       manifest_modified_files.each do |manifest_file|
-        lockfile_modified = git_utils.all_changed_files.any? { |f| File.dirname(f) == File.dirname(manifest_file) && File.basename(f) == lock_file_name }
-        next if lockfile_modified
+        manifest_dir = File.dirname(manifest_file)
+        next if files_by_dir[manifest_dir]&.include?(lock_file_name)
 
         message = format(MESSAGE, manifest_file, lock_file_name, instruction)
         reporter.report(message: message, type: report_type)
@@ -129,11 +135,10 @@ module Danger
     end
 
     def check_manifest_lock_updated_strict(manifest_path:, manifest_lock_path:, instruction:, report_type: :warning)
-      manifest_modified = git_utils.all_changed_files.include?(manifest_path)
-      return unless manifest_modified
+      all_files_set = git_utils.all_changed_files.to_set
 
-      lockfile_modified = git_utils.all_changed_files.include?(manifest_lock_path)
-      return if lockfile_modified
+      return unless all_files_set.include?(manifest_path)
+      return if all_files_set.include?(manifest_lock_path)
 
       message = format(MESSAGE, manifest_path, File.basename(manifest_lock_path), instruction)
       reporter.report(message: message, type: report_type)

--- a/lib/dangermattic/plugins/pr_size_checker.rb
+++ b/lib/dangermattic/plugins/pr_size_checker.rb
@@ -76,13 +76,12 @@ module Danger
     def insertions_size(file_selector: nil)
       return danger.git.insertions unless file_selector
 
-      filtered_files = git_utils.all_changed_files.select(&file_selector)
+      # Only check added and modified files - deleted files have 0 insertions
+      filtered_files = git_utils.added_and_modified_files.select(&file_selector)
 
       filtered_files.sum do |file|
-        # stats for a file in the GitHub API might be nil, making `info_for_file()` crash
-        next 0 if danger.git.diff.stats[:files][file].nil?
-
-        danger.git.info_for_file(file)&.[](:insertions).to_i
+        # Use cached stats directly instead of calling info_for_file for each file
+        danger.git.diff.stats[:files][file]&.[](:insertions).to_i
       end
     end
 
@@ -97,10 +96,8 @@ module Danger
       filtered_files = git_utils.all_changed_files.select(&file_selector)
 
       filtered_files.sum do |file|
-        # stats for a file in the GitHub API might be nil, making `info_for_file()` crash
-        next 0 if danger.git.diff.stats[:files][file].nil?
-
-        danger.git.info_for_file(file)&.[](:deletions).to_i
+        # Use cached stats directly instead of calling info_for_file for each file
+        danger.git.diff.stats[:files][file]&.[](:deletions).to_i
       end
     end
 
@@ -115,10 +112,11 @@ module Danger
       filtered_files = git_utils.all_changed_files.select(&file_selector)
 
       filtered_files.sum do |file|
-        # stats for a file in the GitHub API might be nil, making `info_for_file()` crash
-        next 0 if danger.git.diff.stats[:files][file].nil?
+        # Use cached stats directly instead of calling info_for_file for each file
+        stats = danger.git.diff.stats[:files][file]
+        next 0 unless stats
 
-        danger.git.info_for_file(file)&.[](:deletions).to_i + danger.git.info_for_file(file)&.[](:insertions).to_i
+        stats[:deletions].to_i + stats[:insertions].to_i
       end
     end
   end

--- a/spec/pr_size_checker_spec.rb
+++ b/spec/pr_size_checker_spec.rb
@@ -146,19 +146,20 @@ module Danger
             allow(@plugin.git).to receive_messages(added_files: [added_config, added_file], modified_files: [modified_file1, modified_file2, added_test_file, modified_strings], deleted_files: [deleted_file1, deleted_test_file, deleted_strings, deleted_file2])
 
             allow(@plugin.git).to receive(:diff).and_return(instance_double(Git::Diff))
-            expected_files = { added_test_file => {}, added_config => {}, added_file => {}, modified_file1 => {}, modified_file2 => {}, modified_strings => {}, deleted_file1 => {}, deleted_file2 => {}, deleted_test_file => {}, deleted_strings => {} }
+            # Populate stats hash directly with insertions/deletions data for the optimized code path
+            expected_files = {
+              added_test_file => { insertions: 201 },
+              added_config => { insertions: 311 },
+              added_file => { insertions: 13 },
+              modified_file1 => { insertions: 127, deletions: 159 },
+              modified_file2 => { insertions: 43, deletions: 37 },
+              modified_strings => { insertions: 432, deletions: 297 },
+              deleted_file1 => { deletions: 246 },
+              deleted_file2 => { deletions: 493 },
+              deleted_test_file => { deletions: 222 },
+              deleted_strings => { deletions: 593 }
+            }
             allow(@plugin.git.diff).to receive(:stats).and_return({ files: expected_files })
-
-            allow(@plugin.git).to receive(:info_for_file).with(added_test_file).and_return({ insertions: 201 })
-            allow(@plugin.git).to receive(:info_for_file).with(added_config).and_return({ insertions: 311 })
-            allow(@plugin.git).to receive(:info_for_file).with(added_file).and_return({ insertions: 13 })
-            allow(@plugin.git).to receive(:info_for_file).with(modified_file1).and_return({ insertions: 127, deletions: 159 })
-            allow(@plugin.git).to receive(:info_for_file).with(modified_file2).and_return({ insertions: 43, deletions: 37 })
-            allow(@plugin.git).to receive(:info_for_file).with(modified_strings).and_return({ insertions: 432, deletions: 297 })
-            allow(@plugin.git).to receive(:info_for_file).with(deleted_file1).and_return({ deletions: 246 })
-            allow(@plugin.git).to receive(:info_for_file).with(deleted_file2).and_return({ deletions: 493 })
-            allow(@plugin.git).to receive(:info_for_file).with(deleted_test_file).and_return({ deletions: 222 })
-            allow(@plugin.git).to receive(:info_for_file).with(deleted_strings).and_return({ deletions: 593 })
           end
         end
 


### PR DESCRIPTION
Mitigates AINFRA-1384

We've noticed the Danger PR check job could take 40min+ when running on a [really large PR](https://github.tumblr.net/Tumblr/ios/pull/29762).

I've then created a branch off this large PR and added some code in the `Dangerfile` to time each operation. It turned out that the most [expensive ones](https://buildkite.com/automattic/tumblr-ios/builds/34941#0199be91-6f28-4976-a76e-c6e3a678ef48/158-170) seemed to be the `pr_size_checker.check_diff_size` and `manifest_pr_checker.check_all_manifest_lock_updated`.

Upon reviewing the plugins, I've found out:

- For `pr_size_checker`:
  - We called `danger.git.info_for_file(file)` for each file
  - This method likely parses the entire diff patch for that file each time
  - We actually called info_for_file() twice per file (deletions + insertions)

```ruby
# BEFORE: Expensive diff parsing per file
danger.git.info_for_file(file)&.[](:insertions).to_i

# AFTER: Direct access to cached stats
danger.git.diff.stats[:files][file]&.[](:insertions).to_i
```

- For `manifest_pr_checker`:
  - We had repeated array creation: `git_utils.all_changed_files` concatenates 3 arrays each call
  - We had nested O(n×m) loops with Linear array scans (`.include?()`, `.any?()`)

--- 

After the changes, the PR check [finished](https://buildkite.com/automattic/tumblr-ios/builds/34965#0199c4d3-4f99-44e5-9af4-d10824165806/520-533) in ~3min.