### PR TITLE
Release `1.2.4`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,12 @@ _None_
 
 ### Internal Changes
 
+_None_
+
+## 1.2.4
+
+### Internal Changes
+
 - `pr_size_checker` and `manifest_pr_checker`: optimize performance for large PRs [#103]
 
 ## 1.2.3

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    danger-dangermattic (1.2.3)
+    danger-dangermattic (1.2.4)
       danger (~> 9.4)
       danger-plugin-api (~> 1.0)
       danger-rubocop (~> 0.13)

--- a/lib/dangermattic/gem_version.rb
+++ b/lib/dangermattic/gem_version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Dangermattic
-  VERSION = '1.2.3'
+  VERSION = '1.2.4'
 end


### PR DESCRIPTION
Releasing new version `1.2.4`.

# What's Next

PR Author: Be sure to create and publish a GitHub Release pointing to `trunk` once this PR gets merged,
copy/pasting the following text as the GitHub Release's description:

```
### Internal Changes

- `pr_size_checker` and `manifest_pr_checker`: optimize performance for large PRs [#103]


```
