### PR TITLE
Add stub AGENTS.md with CLAUDE.md pointer

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,8 @@
+# AGENTS.md
+
+This file provides guidance to AI agents when working with code in this repository.
+
+## Overview
+
+Dangermattic is a shared collection of Danger plugins used across Automattic's mobile repositories.
+It provides reusable Danger rules for PR checks, code review automation, and CI enforcement.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md


### PR DESCRIPTION
## Summary

- Add stub `AGENTS.md` with project overview as the source of truth for agent instructions
- Add `CLAUDE.md` containing only `@AGENTS.md` pointer

See also:
- bloom/DayOne-Apple#28097
- wordpress-mobile/WordPress-iOS#25252
- wordpress-mobile/GutenbergKit#321
- wordpress-mobile/release-toolkit#691

---

This PR was created autonomously by Claude Code (Opus 4.6) on behalf of @mokagio with approval.