### PR TITLE
Update activesupport to fix security vulnerabilities

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -10,7 +10,7 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (8.1.2)
+    activesupport (8.1.3)
       base64
       bigdecimal
       concurrent-ruby (~> 1.0, >= 1.3.1)
@@ -94,7 +94,7 @@ GEM
       rspec (>= 2.99.0, < 4.0)
     i18n (1.14.8)
       concurrent-ruby (~> 1.0)
-    json (2.19.2)
+    json (2.19.3)
     kramdown (2.5.2)
       rexml (>= 3.4.4)
     kramdown-parser-gfm (1.1.0)
@@ -107,7 +107,8 @@ GEM
     logger (1.7.0)
     lumberjack (1.4.0)
     method_source (1.1.0)
-    minitest (6.0.1)
+    minitest (6.0.2)
+      drb (~> 2.0)
       prism (~> 1.5)
     nap (1.1.0)
     nenv (0.3.0)


### PR DESCRIPTION
## Summary
- Updates `activesupport` gem to fix three security vulnerabilities published on 2026-03-23
- **GHSA-cg4j-q9v8-6v38**: ReDoS vulnerability in `number_to_delimited` (`NumberToDelimitedConverter` used a regex with `gsub!` causing quadratic time complexity)
- **GHSA-89vf-4333-qx8v**: XSS vulnerability in `SafeBuffer#%`
- **GHSA-2j26-frm8-cmj9**: DoS vulnerability in number helpers

## Test plan
- [ ] Verify CI passes
- [ ] Confirm `activesupport` version in `Gemfile.lock` is patched (>= 8.1.2.1 for 8.1.x, >= 8.0.4.1 for 8.0.x, >= 7.2.3.1 for 7.x)

🤖 Generated with [Claude Code](https://claude.com/claude-code)