### PR TITLE
Deprecate issue label success comments

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -23,7 +23,7 @@ This workflow is an independent check (not using Danger) to verify if the labels
 - Permissions: `issues: write`
 - Main step: "🏷️ Check Issue Labels"
   - Checks if issue labels match the specified regex patterns
-  - Upserts a managed comment on the issue when labels are missing
+  - Upserts a managed comment authored by the configured token when labels are missing
   - Removes that managed comment when labels become valid
 
 ## Retry Buildkite Step on Pull Request Events

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -24,7 +24,7 @@ This workflow is an independent check (not using Danger) to verify if the labels
 - Permissions: `issues: write`
 - Main step: "🏷️ Check Issue Labels"
   - Checks if issue labels match the specified regex patterns
-  - Upserts a managed comment authored by the configured token when labels are missing
+  - Updates a managed comment authored by the configured token when labels are missing
   - Removes that managed comment when labels become valid
 
 ## Retry Buildkite Step on Pull Request Events

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -13,7 +13,7 @@ This workflow is an independent check (not using Danger) to verify if the labels
 ### Inputs:
 - `label-format-list`: JSON list of regex formats expected for the labels (default: `[".*"]`)
 - `label-error-message`: Error message when labels don't match
-- `label-success-message`: Success message when labels match
+- `label-success-message`: Deprecated and ignored. Kept only for backward compatibility with existing callers.
 - `cancel-running-jobs`: Cancel in-progress jobs when new ones are created (default: `true`)
 
 ### Secrets:
@@ -23,7 +23,8 @@ This workflow is an independent check (not using Danger) to verify if the labels
 - Permissions: `issues: write`
 - Main step: "🏷️ Check Issue Labels"
   - Checks if issue labels match the specified regex patterns
-  - Posts a comment on the issue with success or error message
+  - Upserts a managed comment on the issue when labels are missing
+  - Removes that managed comment when labels become valid
 
 ## Retry Buildkite Step on Pull Request Events
 

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -13,11 +13,12 @@ This workflow is an independent check (not using Danger) to verify if the labels
 ### Inputs:
 - `label-format-list`: JSON list of regex formats expected for the labels (default: `[".*"]`)
 - `label-error-message`: Error message when labels don't match
-- `label-success-message`: Deprecated and ignored. Kept only for backward compatibility with existing callers.
+- `label-success-message`: Deprecated and ignored. Kept only for backward compatibility with existing callers, and scheduled for removal in the next major release.
 - `cancel-running-jobs`: Cancel in-progress jobs when new ones are created (default: `true`)
 
 ### Secrets:
 - `github-token`: Required GitHub token
+  - The token must resolve through `gh api user` to the same login that appears on issue comments, because the workflow only manages comments authored by that login.
 
 ### Job: `check-issue-labels`
 - Permissions: `issues: write`

--- a/.github/workflows/reusable-check-labels-on-issues.yml
+++ b/.github/workflows/reusable-check-labels-on-issues.yml
@@ -54,6 +54,7 @@ jobs:
           set -euo pipefail
 
           comment_marker='<!-- generated_by_dangermattic -->'
+          authenticated_login=''
           managed_comment_id=''
           declare -a managed_comment_ids=()
 
@@ -72,10 +73,19 @@ jobs:
             printf '%s\n%s' "$message" "$comment_marker"
           }
 
+          load_authenticated_login() {
+            authenticated_login="$(gh api user --jq '.login')"
+
+            if [ -z "$authenticated_login" ] || [ "$authenticated_login" = 'null' ]; then
+              echo '❌ Unable to determine the authenticated GitHub login for managed comment filtering.'
+              exit 1
+            fi
+          }
+
           load_managed_comment_ids() {
             readarray -t managed_comment_ids < <(
               gh api "repos/$GH_REPO/issues/$ISSUE_NUMBER/comments" --paginate |
-                jq -r --arg marker "$comment_marker" '.[] | select(.body | contains($marker)) | .id'
+                jq -r --arg author "$authenticated_login" --arg marker "$comment_marker" '.[] | select(.user.login == $author) | select((.body // "") | contains($marker)) | .id'
             )
 
             if [ "${#managed_comment_ids[@]}" -gt 0 ]; then
@@ -106,10 +116,10 @@ jobs:
 
             if [ -n "$managed_comment_id" ]; then
               echo "✍️ Updating managed comment $managed_comment_id on issue $ISSUE_NUMBER"
-              gh api --method PATCH "repos/$GH_REPO/issues/comments/$managed_comment_id" -f body="$comment_body" > /dev/null
+              gh api --method PATCH "repos/$GH_REPO/issues/comments/$managed_comment_id" --raw-field "body=$comment_body" > /dev/null
             else
               echo "✍️ Creating managed comment on issue $ISSUE_NUMBER"
-              gh api --method POST "repos/$GH_REPO/issues/$ISSUE_NUMBER/comments" -f body="$comment_body" > /dev/null
+              gh api --method POST "repos/$GH_REPO/issues/$ISSUE_NUMBER/comments" --raw-field "body=$comment_body" > /dev/null
             fi
           }
 
@@ -147,6 +157,7 @@ jobs:
             fi
           done
 
+          load_authenticated_login
           load_managed_comment_ids
           delete_extra_managed_comments
 

--- a/.github/workflows/reusable-check-labels-on-issues.yml
+++ b/.github/workflows/reusable-check-labels-on-issues.yml
@@ -50,7 +50,8 @@ jobs:
           DEPRECATED_SUCCESS_MESSAGE: ${{ inputs.label-success-message }}
           ISSUE_ERROR_MESSAGE: ${{ inputs.label-error-message }}
         run: |
-          #!/bin/bash
+          #!/usr/bin/env bash
+          
           set -euo pipefail
 
           comment_marker='<!-- generated_by_dangermattic -->'

--- a/.github/workflows/reusable-check-labels-on-issues.yml
+++ b/.github/workflows/reusable-check-labels-on-issues.yml
@@ -17,8 +17,8 @@ on:
         type: string
         required: false
       label-success-message:
-        description: Message to be posted when the labels set fulfill the entire list of expected formats.
-        default: ✅ Yay, issue looks great!
+        description: Deprecated and ignored. Kept only for backward compatibility with existing callers.
+        default: ''
         type: string
         required: false
       cancel-running-jobs:
@@ -42,19 +42,88 @@ jobs:
     steps:
       - name: 🏷️ Check Issue Labels
         env:
-          GITHUB_TOKEN: ${{ secrets.github-token }}
+          GH_TOKEN: ${{ secrets.github-token }}
           GH_REPO: ${{ github.repository }}
           ISSUE_NUMBER: ${{ github.event.issue.number }}
           ISSUE_LABELS: ${{ toJSON(github.event.issue.labels.*.name) }}
           LABEL_REGEX_LIST: ${{ inputs.label-format-list }}
-          ISSUE_SUCCESS_COMMENT: >
-            ${{ inputs.label-success-message }}
-            <!-- generated_by_dangermattic -->
-          ISSUE_ERROR_COMMENT: >
-            ${{ inputs.label-error-message }}
-            <!-- generated_by_dangermattic -->
+          DEPRECATED_SUCCESS_MESSAGE: ${{ inputs.label-success-message }}
+          ISSUE_ERROR_MESSAGE: ${{ inputs.label-error-message }}
         run: |
           #!/bin/bash
+          set -euo pipefail
+
+          comment_marker='<!-- generated_by_dangermattic -->'
+          managed_comment_id=''
+          declare -a managed_comment_ids=()
+
+          if ! echo "$LABEL_REGEX_LIST" | jq -e 'type == "array"' > /dev/null; then
+            echo "❌ LABEL_REGEX_LIST must be a JSON array."
+            exit 1
+          fi
+
+          if [ -n "$DEPRECATED_SUCCESS_MESSAGE" ]; then
+            echo "⚠️ label-success-message is deprecated and ignored. Success now removes the managed workflow comment."
+          fi
+
+          build_comment_body() {
+            local message="$1"
+
+            printf '%s\n%s' "$message" "$comment_marker"
+          }
+
+          load_managed_comment_ids() {
+            readarray -t managed_comment_ids < <(
+              gh api "repos/$GH_REPO/issues/$ISSUE_NUMBER/comments" --paginate |
+                jq -r --arg marker "$comment_marker" '.[] | select(.body | contains($marker)) | .id'
+            )
+
+            if [ "${#managed_comment_ids[@]}" -gt 0 ]; then
+              managed_comment_id="${managed_comment_ids[$((${#managed_comment_ids[@]} - 1))]}"
+            else
+              managed_comment_id=''
+            fi
+          }
+
+          delete_extra_managed_comments() {
+            local duplicate_count=0
+
+            duplicate_count=$((${#managed_comment_ids[@]} - 1))
+            if [ "$duplicate_count" -le 0 ]; then
+              return
+            fi
+
+            for comment_id in "${managed_comment_ids[@]:0:$duplicate_count}"; do
+              echo "🧹 Deleting duplicate managed comment $comment_id"
+              gh api --method DELETE "repos/$GH_REPO/issues/comments/$comment_id" > /dev/null
+            done
+
+            managed_comment_ids=("$managed_comment_id")
+          }
+
+          upsert_managed_comment() {
+            local comment_body="$1"
+
+            if [ -n "$managed_comment_id" ]; then
+              echo "✍️ Updating managed comment $managed_comment_id on issue $ISSUE_NUMBER"
+              gh api --method PATCH "repos/$GH_REPO/issues/comments/$managed_comment_id" -f body="$comment_body" > /dev/null
+            else
+              echo "✍️ Creating managed comment on issue $ISSUE_NUMBER"
+              gh api --method POST "repos/$GH_REPO/issues/$ISSUE_NUMBER/comments" -f body="$comment_body" > /dev/null
+            fi
+          }
+
+          delete_managed_comments() {
+            if [ "${#managed_comment_ids[@]}" -eq 0 ]; then
+              echo "🧼 No managed comment found to delete."
+              return
+            fi
+
+            for comment_id in "${managed_comment_ids[@]}"; do
+              echo "🧼 Deleting managed comment $comment_id"
+              gh api --method DELETE "repos/$GH_REPO/issues/comments/$comment_id" > /dev/null
+            done
+          }
 
           readarray -t labels < <(echo "$ISSUE_LABELS" | jq -r '.[]')
           readarray -t label_regex_list < <(echo "$LABEL_REGEX_LIST" | jq -r '.[]')
@@ -78,22 +147,13 @@ jobs:
             fi
           done
 
-          ISSUE_COMMENT=''
+          load_managed_comment_ids
+          delete_extra_managed_comments
+
           if [ "$all_patterns_matched" = true ]; then
             echo "✅ All regex patterns have at least one match."
-            ISSUE_COMMENT="$ISSUE_SUCCESS_COMMENT"
+            delete_managed_comments
           else
             echo "❌ Not all regex patterns have at least one match."
-            ISSUE_COMMENT="$ISSUE_ERROR_COMMENT"
-          fi
-
-          set +e
-          echo "✍️ Attempting to edit existing comment on issue $ISSUE_NUMBER, if it exists:"
-          gh issue comment $ISSUE_NUMBER --body "$ISSUE_COMMENT" --edit-last
-          comment_update_status=$?
-          set -e
-
-          if [ $comment_update_status -ne 0 ]; then
-            echo "✍️ Adding new comment on issue $ISSUE_NUMBER:"
-            gh issue comment $ISSUE_NUMBER --body "$ISSUE_COMMENT"
+            upsert_managed_comment "$(build_comment_body "$ISSUE_ERROR_MESSAGE")"
           fi

--- a/.github/workflows/reusable-check-labels-on-issues.yml
+++ b/.github/workflows/reusable-check-labels-on-issues.yml
@@ -17,7 +17,7 @@ on:
         type: string
         required: false
       label-success-message:
-        description: Deprecated and ignored. Kept only for backward compatibility with existing callers.
+        description: Deprecated and ignored. Kept only for backward compatibility with existing callers, and scheduled for removal in the next major release.
         default: ''
         type: string
         required: false
@@ -107,8 +107,6 @@ jobs:
               echo "🧹 Deleting duplicate managed comment $comment_id"
               gh api --method DELETE "repos/$GH_REPO/issues/comments/$comment_id" > /dev/null
             done
-
-            managed_comment_ids=("$managed_comment_id")
           }
 
           upsert_managed_comment() {


### PR DESCRIPTION
## Summary
- Replace the reusable issue-label workflow comment handling with marker-based `gh api` comment management
- Deprecate and ignore `label-success-message`, and always remove the managed comment once labels are valid
- Update the reusable workflow documentation to reflect the new behavior

## Testing
- Live `gh api` verification against a Automattic/simplenote-ios issue for create, update, list, and delete comment operations