### PR TITLE
Update yard to 0.9.43 (GHSA-3jfp-46x4-xgfj)

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -190,7 +190,7 @@ GEM
       unicode-emoji (~> 4.1)
     unicode-emoji (4.2.0)
     uri (1.1.1)
-    yard (0.9.37)
+    yard (0.9.43)
 
 PLATFORMS
   arm64-darwin-22


### PR DESCRIPTION
## Summary
- Bump `yard` from 0.9.37 to 0.9.43 in `Gemfile.lock` to address [GHSA-3jfp-46x4-xgfj](https://github.com/advisories/GHSA-3jfp-46x4-xgfj), a path traversal vulnerability in `yard server` (< 0.9.42).
- Resolves https://github.com/Automattic/dangermattic/security/dependabot/19.

## Test plan
- [ ] CI passes on the updated `Gemfile.lock`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)