### PR TITLE
chore: pin third-party GitHub Actions to SHAs + enable Dependabot github-actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 5
+    groups:
+      github-actions:
+        patterns:
+          - "*"

--- a/.github/workflows/reusable-run-danger.yml
+++ b/.github/workflows/reusable-run-danger.yml
@@ -30,7 +30,7 @@ jobs:
         with:
           fetch-depth: 100
       - name: 💎 Ruby Setup
-        uses: ruby/setup-ruby@v1
+        uses: ruby/setup-ruby@afeafc3d1ab54a631816aba4c914a0081c12ff2f # v1.310.0
         with:
           bundler-cache: true
       - name: ☢️ Danger PR Check


### PR DESCRIPTION
Two changes in one PR:

1. Pin `ruby/setup-ruby@v1` to a commit SHA (tag preserved as trailing comment) to harden against supply-chain risk on mutable tags.
2. Enable Dependabot for the `github-actions` ecosystem so pinned SHAs get automatic refresh PRs (weekly, grouped).

Tracking: DEVPROD-1072.