### PR TITLE
chore: split Dependabot github-actions into minor+patch / major groups, add cooldown

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,8 +5,19 @@ updates:
     schedule:
       interval: "weekly"
       day: "monday"
-    open-pull-requests-limit: 5
+    open-pull-requests-limit: 10
     groups:
-      github-actions:
+      actions-minor-patch:
         patterns:
-          - "*"
+          - '*'
+        update-types:
+          - minor
+          - patch
+      actions-major:
+        patterns:
+          - '*'
+        update-types:
+          - major
+    cooldown:
+      default-days: 7
+      semver-major-days: 14


### PR DESCRIPTION
Restructures the Dependabot `github-actions` config:

1. Splits into two groups: `actions-minor-patch` (auto-mergeable) and `actions-major` (review-required).
2. Adds `cooldown` (7 days default, 14 days for majors) to avoid merging day-zero broken bumps.

Drift-free alternative to suppressing major bumps. Same noise reduction (cooldown defers) but majors stay visible.

Tracking: DEVPROD-1072.