### PR TITLE
Add `check_existing_strings_not_modified` to `android_strings_checker`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ _None_
 
 ### New Features
 
-- Added `android_strings_checker.check_existing_strings_not_modified`, which fails when the value of an existing translatable `<string>` is changed in place (rather than added under a new key). This enforces string-key immutability, which keeps in-progress translations valid in a continuous-localization setup.
+- Added `android_strings_checker.check_existing_strings_not_modified`, which fails when the value of an existing translatable `<string>` is changed in place (rather than added under a new key). This enforces string-key immutability, which keeps in-progress translations valid in a continuous-localization setup. [#126]
 
 ### Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ _None_
 
 ### New Features
 
-_None_
+- Added `android_strings_checker.check_existing_strings_not_modified`, which fails when the value of an existing translatable `<string>` is changed in place (rather than added under a new key). This enforces string-key immutability, which keeps in-progress translations valid in a continuous-localization setup.
 
 ### Bug Fixes
 

--- a/lib/dangermattic/plugins/android_strings_checker.rb
+++ b/lib/dangermattic/plugins/android_strings_checker.rb
@@ -7,12 +7,28 @@ module Danger
   #
   #          android_strings_checker.check_strings_do_not_refer_resource
   #
+  # @example Check that existing translatable strings are not modified in place
+  #
+  #          android_strings_checker.check_existing_strings_not_modified
+  #
   # @see Automattic/dangermattic
   # @tags android, localization
   #
   class AndroidStringsChecker < Plugin
     MESSAGE = "This PR adds a translatable entry which references another string resource; this usually causes issues with translations.\n" \
               'Please make sure to set the `translatable="false"` attribute.'
+
+    STRING_MODIFIED_MESSAGE = 'This PR changes the value of an existing translatable string. Existing string keys must stay immutable so that ' \
+                              'in-progress and existing translations remain valid: please add a **new** string key for the new copy instead of ' \
+                              'editing the existing one (old translations stay attached to the old key).'
+
+    # Default file selector: only the app's source (English) strings, living at `…/res/values/strings.xml`.
+    # This deliberately excludes localized `values-<locale>/strings.xml` files (whose values legitimately change
+    # when translations are pulled in) and any generated/frozen copies that live outside a `res` directory.
+    DEFAULT_SOURCE_STRINGS_SELECTOR = ->(path) { path.match?(%r{(^|/)res/values/strings\.xml$}) }
+
+    # Matches a single-line `<string name="…">value</string>` entry, capturing its name and value.
+    STRING_LINE_REGEX = %r{<string\b[^>]*\sname="(?<name>[^"]+)"[^>]*>(?<value>.*)</string>}
 
     # Check if translatable strings reference another string resource in 'strings.xml' files in a pull request.
     #
@@ -26,6 +42,66 @@ module Danger
         message: MESSAGE,
         report_type: report_type
       )
+    end
+
+    # Check that the value of an existing translatable string is not modified in place.
+    #
+    # In a continuous-localization setup, source strings flow to the translation system constantly, so changing
+    # the English value of an existing key silently invalidates the translations already done for that key. The
+    # safe convention is to leave existing keys untouched and introduce a new key for any new copy. This check
+    # enforces that convention by failing when a `<string>` entry present in the base is modified (rather than
+    # added under a new key). Adding new keys, removing keys, and renaming keys are all allowed.
+    #
+    # @param report_type [Symbol] (optional) Type of report (:error, :warning, :message). Default is :error.
+    # @param file_selector [Proc] (optional) Selects which files to check. Defaults to the app's source
+    #   `…/res/values/strings.xml` files, excluding localized and generated copies.
+    #
+    # @return [void]
+    def check_existing_strings_not_modified(report_type: :error, file_selector: DEFAULT_SOURCE_STRINGS_SELECTOR)
+      files = git_utils.added_and_modified_files.select(&file_selector)
+
+      files.each do |file|
+        diff = danger.git.diff_for_file(file)
+        next if diff.nil?
+
+        removed = translatable_strings_by_name(git_utils.removed_lines(diff_patch: diff.patch))
+        added = translatable_strings_by_name(git_utils.added_lines(diff_patch: diff.patch))
+
+        modified_keys = removed.keys & added.keys
+        modified_keys.each do |name|
+          next if removed[name].value == added[name].value
+
+          final_message = <<~MESSAGE
+            #{STRING_MODIFIED_MESSAGE}
+            File `#{file}`, string `#{name}`:
+            ```diff
+            -#{removed[name].line.chomp}
+            +#{added[name].line.chomp}
+            ```
+          MESSAGE
+
+          reporter.report(message: final_message, type: report_type)
+        end
+      end
+    end
+
+    ParsedString = Struct.new(:value, :line)
+
+    private
+
+    # Parses `<string>` entries out of a set of diff content lines, keyed by their `name` attribute.
+    # `translatable="false"` entries are ignored, as they are never sent for translation.
+    #
+    # @param lines [String] Newline-separated content lines (with the diff `+`/`-` markers already stripped).
+    #
+    # @return [Hash{String => ParsedString}] A mapping of string name to its parsed value and originating line.
+    def translatable_strings_by_name(lines)
+      lines.each_line.with_object({}) do |line, result|
+        next if line.include?('translatable="false"')
+
+        match = STRING_LINE_REGEX.match(line)
+        result[match[:name]] = ParsedString.new(match[:value], line) unless match.nil?
+      end
     end
   end
 end

--- a/spec/android_strings_checker_spec.rb
+++ b/spec/android_strings_checker_spec.rb
@@ -180,6 +180,224 @@ module Danger
           expect(@dangerfile).to not_report
         end
       end
+
+      context 'when checking that existing strings are not modified' do
+        let(:source_strings_xml) { 'WordPress/src/main/res/values/strings.xml' }
+
+        def stub_diff(path, patch)
+          allow(@plugin.git).to receive(:modified_files).and_return([path])
+          diff = GitDiffStruct.new('modified', path, patch)
+          allow(@plugin.git).to receive(:diff_for_file).with(path).and_return(diff)
+        end
+
+        it 'reports an error when the value of an existing string is modified in place' do
+          stub_diff(source_strings_xml, <<~STRINGS)
+            diff --git a/#{source_strings_xml} b/#{source_strings_xml}
+            index 5794d472..772e2b99 100644
+            --- a/#{source_strings_xml}
+            +++ b/#{source_strings_xml}
+            @@ -1,3 +1,3 @@
+             <resources xmlns:tools="http://schemas.android.com/tools">
+            -  <string name="greeting">Hello</string>
+            +  <string name="greeting">Hi there</string>
+             </resources>
+          STRINGS
+
+          @plugin.check_existing_strings_not_modified
+
+          expected_error = <<~ERROR
+            #{AndroidStringsChecker::STRING_MODIFIED_MESSAGE}
+            File `#{source_strings_xml}`, string `greeting`:
+            ```diff
+            -  <string name="greeting">Hello</string>
+            +  <string name="greeting">Hi there</string>
+            ```
+          ERROR
+
+          expect(@dangerfile).to report_errors([expected_error])
+        end
+
+        it 'does nothing when a brand new string key is added' do
+          stub_diff(source_strings_xml, <<~STRINGS)
+            diff --git a/#{source_strings_xml} b/#{source_strings_xml}
+            index 5794d472..772e2b99 100644
+            --- a/#{source_strings_xml}
+            +++ b/#{source_strings_xml}
+            @@ -1,2 +1,3 @@
+             <resources xmlns:tools="http://schemas.android.com/tools">
+            +  <string name="greeting">Hello</string>
+             </resources>
+          STRINGS
+
+          @plugin.check_existing_strings_not_modified
+
+          expect(@dangerfile).to not_report
+        end
+
+        it 'does nothing when an existing string key is removed' do
+          stub_diff(source_strings_xml, <<~STRINGS)
+            diff --git a/#{source_strings_xml} b/#{source_strings_xml}
+            index 5794d472..772e2b99 100644
+            --- a/#{source_strings_xml}
+            +++ b/#{source_strings_xml}
+            @@ -1,3 +1,2 @@
+             <resources xmlns:tools="http://schemas.android.com/tools">
+            -  <string name="greeting">Hello</string>
+             </resources>
+          STRINGS
+
+          @plugin.check_existing_strings_not_modified
+
+          expect(@dangerfile).to not_report
+        end
+
+        it 'does nothing when a string is only reordered (value unchanged)' do
+          stub_diff(source_strings_xml, <<~STRINGS)
+            diff --git a/#{source_strings_xml} b/#{source_strings_xml}
+            index 5794d472..772e2b99 100644
+            --- a/#{source_strings_xml}
+            +++ b/#{source_strings_xml}
+            @@ -1,4 +1,4 @@
+             <resources xmlns:tools="http://schemas.android.com/tools">
+            -  <string name="greeting">Hello</string>
+               <string name="other">Other</string>
+            +  <string name="greeting">Hello</string>
+             </resources>
+          STRINGS
+
+          @plugin.check_existing_strings_not_modified
+
+          expect(@dangerfile).to not_report
+        end
+
+        it 'does nothing when a key is renamed (old key removed, new key added)' do
+          stub_diff(source_strings_xml, <<~STRINGS)
+            diff --git a/#{source_strings_xml} b/#{source_strings_xml}
+            index 5794d472..772e2b99 100644
+            --- a/#{source_strings_xml}
+            +++ b/#{source_strings_xml}
+            @@ -1,3 +1,3 @@
+             <resources xmlns:tools="http://schemas.android.com/tools">
+            -  <string name="greeting">Hello</string>
+            +  <string name="greeting_v2">Hello</string>
+             </resources>
+          STRINGS
+
+          @plugin.check_existing_strings_not_modified
+
+          expect(@dangerfile).to not_report
+        end
+
+        it 'ignores modifications to non-translatable strings' do
+          stub_diff(source_strings_xml, <<~STRINGS)
+            diff --git a/#{source_strings_xml} b/#{source_strings_xml}
+            index 5794d472..772e2b99 100644
+            --- a/#{source_strings_xml}
+            +++ b/#{source_strings_xml}
+            @@ -1,3 +1,3 @@
+             <resources xmlns:tools="http://schemas.android.com/tools">
+            -  <string name="app_name" translatable="false">WordPress</string>
+            +  <string name="app_name" translatable="false">WordPress.com</string>
+             </resources>
+          STRINGS
+
+          @plugin.check_existing_strings_not_modified
+
+          expect(@dangerfile).to not_report
+        end
+
+        it 'ignores localized strings.xml files by default' do
+          localized_path = 'WordPress/src/main/res/values-fr/strings.xml'
+          stub_diff(localized_path, <<~STRINGS)
+            diff --git a/#{localized_path} b/#{localized_path}
+            index 5794d472..772e2b99 100644
+            --- a/#{localized_path}
+            +++ b/#{localized_path}
+            @@ -1,3 +1,3 @@
+             <resources xmlns:tools="http://schemas.android.com/tools">
+            -  <string name="greeting">Bonjour</string>
+            +  <string name="greeting">Salut</string>
+             </resources>
+          STRINGS
+
+          @plugin.check_existing_strings_not_modified
+
+          expect(@dangerfile).to not_report
+        end
+
+        it 'reports an error for each modified string across multiple source files' do
+          wp_path = 'WordPress/src/main/res/values/strings.xml'
+          jp_path = 'WordPress/src/jetpack/res/values/strings.xml'
+          allow(@plugin.git).to receive(:modified_files).and_return([wp_path, jp_path])
+
+          wp_diff = GitDiffStruct.new('modified', wp_path, <<~STRINGS)
+            diff --git a/#{wp_path} b/#{wp_path}
+            index 5794d472..772e2b99 100644
+            --- a/#{wp_path}
+            +++ b/#{wp_path}
+            @@ -1,3 +1,3 @@
+             <resources xmlns:tools="http://schemas.android.com/tools">
+            -  <string name="greeting">Hello</string>
+            +  <string name="greeting">Hi</string>
+             </resources>
+          STRINGS
+          allow(@plugin.git).to receive(:diff_for_file).with(wp_path).and_return(wp_diff)
+
+          jp_diff = GitDiffStruct.new('modified', jp_path, <<~STRINGS)
+            diff --git a/#{jp_path} b/#{jp_path}
+            index 5794d472..772e2b99 100644
+            --- a/#{jp_path}
+            +++ b/#{jp_path}
+            @@ -1,3 +1,3 @@
+             <resources xmlns:tools="http://schemas.android.com/tools">
+            -  <string name="farewell">Bye</string>
+            +  <string name="farewell">Goodbye</string>
+             </resources>
+          STRINGS
+          allow(@plugin.git).to receive(:diff_for_file).with(jp_path).and_return(jp_diff)
+
+          @plugin.check_existing_strings_not_modified
+
+          wp_error = <<~ERROR
+            #{AndroidStringsChecker::STRING_MODIFIED_MESSAGE}
+            File `#{wp_path}`, string `greeting`:
+            ```diff
+            -  <string name="greeting">Hello</string>
+            +  <string name="greeting">Hi</string>
+            ```
+          ERROR
+
+          jp_error = <<~ERROR
+            #{AndroidStringsChecker::STRING_MODIFIED_MESSAGE}
+            File `#{jp_path}`, string `farewell`:
+            ```diff
+            -  <string name="farewell">Bye</string>
+            +  <string name="farewell">Goodbye</string>
+            ```
+          ERROR
+
+          expect(@dangerfile.status_report[:errors]).to contain_exactly(wp_error, jp_error)
+        end
+
+        it 'can be configured to report a warning instead of an error' do
+          stub_diff(source_strings_xml, <<~STRINGS)
+            diff --git a/#{source_strings_xml} b/#{source_strings_xml}
+            index 5794d472..772e2b99 100644
+            --- a/#{source_strings_xml}
+            +++ b/#{source_strings_xml}
+            @@ -1,3 +1,3 @@
+             <resources xmlns:tools="http://schemas.android.com/tools">
+            -  <string name="greeting">Hello</string>
+            +  <string name="greeting">Hi there</string>
+             </resources>
+          STRINGS
+
+          @plugin.check_existing_strings_not_modified(report_type: :warning)
+
+          expect(@dangerfile.status_report[:warnings].count).to eq(1)
+          expect(@dangerfile.status_report[:errors]).to be_empty
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
New check that fails when an **existing** translatable `<string>`'s value is changed in place instead of added under a new key. This enforces the "new copy → new key" convention so in-progress translations stay valid as we move to continuous localization.

- Diff-based: a key in both the removed and added lines with a different value is a violation. Add / remove / rename / reorder are allowed; `translatable="false"` is ignored.
- Default selector targets source `…/res/values/strings.xml` only (skips localized `values-<locale>/` and generated copies). `report_type:` defaults to `:error`.

---

I tried to test this PR in https://github.com/wordpress-mobile/WordPress-Android/pull/22986, but it doesn't look like I can point to this branch, so I think it needs to be reviewed and landed first. Let me know if there is a testing process that I'm missing.
