### PR TITLE
Add bundler block to Dependabot config and route Ruby reviews

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,13 @@
+# Ruby dependency surface
+Gemfile*              @Automattic/apps-infra-tooling
+*.gemspec             @Automattic/apps-infra-tooling
+.bundle/              @Automattic/apps-infra-tooling
+.rubocop*.yml         @Automattic/apps-infra-tooling
+
+# CI and automation
+.buildkite/           @Automattic/apps-infra-tooling
+.github/workflows/    @Automattic/apps-infra-tooling
+.github/dependabot.yml @Automattic/apps-infra-tooling
+
+# Toolchain and environment pins
+.ruby-version         @Automattic/apps-infra-tooling

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -21,3 +21,12 @@ updates:
     cooldown:
       default-days: 7
       semver-major-days: 14
+
+  - package-ecosystem: bundler
+    directory: /
+    schedule:
+      interval: daily
+    groups:
+      ruby-minor-and-patch:
+        update-types: [minor, patch]
+    open-pull-requests-limit: 5


### PR DESCRIPTION
Updates Dependabot to check Ruby dependencies daily so we can more easily address security updates. See [AINFRA-2437](https://linear.app/a8c/issue/AINFRA-2437).

Also routes review of the Apps Infra surface to @Automattic/apps-infra-tooling via CODEOWNERS. GitHub retired the dependabot.yml `reviewers` key, and CODEOWNERS is its designated replacement.

---

Posted by Codex (GPT-5) on behalf of @mokagio with approval.
