### PR TITLE
pr_size_checker: add line_selector to exclude lines from diff size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ _None_
 
 ### New Features
 
-_None_
+- `pr_size_checker`: add optional `line_selector` to `check_diff_size` (and `insertions_size` / `deletions_size` / `diff_size`) to exclude specific changed lines (e.g. comments and blank lines) from the diff-size metric. [#133]
 
 ### Bug Fixes
 

--- a/lib/dangermattic/plugins/pr_size_checker.rb
+++ b/lib/dangermattic/plugins/pr_size_checker.rb
@@ -48,9 +48,9 @@ module Danger
     # @param max_size [Integer] The maximum allowed size for the diff.
     # @param file_selector [Proc] Optional closure to filter the files in the diff to be used for size calculation.
     # @param line_selector [Proc] Optional closure to filter the individual changed lines counted towards the size.
-    #   It receives the content of an added/removed line (without the leading `+`/`-` diff marker) and should return
-    #   `true` for lines that should be counted. When provided, the size is computed by iterating the diff patches
-    #   instead of the cached numstats, which is slower but allows excluding lines such as comments or blank lines.
+    #   It receives the content of an added/removed line (without the leading `+`/`-` diff marker or trailing newline)
+    #   and should return `true` for lines that should be counted. When provided, the size is computed by iterating the
+    #   diff patches instead of the cached numstats, which is slower but allows excluding lines such as comments or blanks.
     # @param type [:insertions, :deletions, :all] The type of diff size to check. (default: :all)
     # @param message [String] The message to display if the diff size exceeds the maximum. (default: DEFAULT_DIFF_SIZE_MESSAGE)
     # @param report_type [Symbol] (optional) The type of report for the message. Types: :error, :warning (default), :message.
@@ -64,6 +64,8 @@ module Danger
                deletions_size(file_selector: file_selector, line_selector: line_selector)
              when :all
                diff_size(file_selector: file_selector, line_selector: line_selector)
+             else
+               raise ArgumentError, "Unknown diff size type: #{type.inspect}. Use :insertions, :deletions, or :all."
              end
 
       reporter.report(message: message, type: report_type) if size > max_size
@@ -162,11 +164,12 @@ module Danger
       files = files.select(&file_selector) if file_selector
 
       files.sum do |file|
-        diff = danger.git.diff_for_file(file)
-        next 0 unless diff
+        # `patch` can be nil (e.g. binary files), in which case there are no textual lines to count.
+        patch = danger.git.diff_for_file(file)&.patch
+        next 0 unless patch
 
-        diff.patch.each_line.count do |line|
-          change_types.include?(git_utils.change_type(diff_line: line)) && line_selector.call(line[1..] || '')
+        patch.each_line.count do |line|
+          change_types.include?(git_utils.change_type(diff_line: line)) && line_selector.call((line[1..] || '').chomp)
         end
       end
     end

--- a/lib/dangermattic/plugins/pr_size_checker.rb
+++ b/lib/dangermattic/plugins/pr_size_checker.rb
@@ -168,10 +168,23 @@ module Danger
         patch = danger.git.diff_for_file(file)&.patch
         next 0 unless patch
 
-        patch.each_line.count do |line|
-          change_types.include?(git_utils.change_type(diff_line: line)) && line_selector.call((line[1..] || '').chomp)
+        patch.each_line.count do |diff_line|
+          next false unless change_types.include?(git_utils.change_type(diff_line: diff_line))
+
+          line_selector.call(strip_diff_marker(diff_line))
         end
       end
+    end
+
+    # Strip the leading `+`/`-` diff marker and the trailing newline from a diff patch line,
+    # so that `line_selector` only sees the actual line content.
+    #
+    # @param diff_line [String] A line from a diff patch, e.g. `"+    // a comment\n"`.
+    #
+    # @return [String] The line content, e.g. `"    // a comment"`.
+    def strip_diff_marker(diff_line)
+      without_marker = diff_line[1..].to_s
+      without_marker.chomp
     end
   end
 end

--- a/lib/dangermattic/plugins/pr_size_checker.rb
+++ b/lib/dangermattic/plugins/pr_size_checker.rb
@@ -18,6 +18,14 @@ module Danger
   #          # Check the size of insertions in the files selected by the file_selector
   #          pr_size_checker.check_diff_size(file_selector: ->(file) { file.include?('/java/test/') }, type: :insertions)
   #
+  # @example Running a PR diff size check that excludes comment and blank lines from the count
+  #
+  #          # Only count changed lines that are neither blank nor comments (e.g. Kotlin/Java/Swift)
+  #          pr_size_checker.check_diff_size(
+  #            max_size: 300,
+  #            line_selector: ->(line) { stripped = line.strip; !(stripped.empty? || stripped.start_with?('//', '/*', '*', '*/')) }
+  #          )
+  #
   # @example Running a PR description length check
   #
   #          # Check the PR Body using the default parameters, reporting a warning if the PR is smaller than 10 characters
@@ -39,20 +47,26 @@ module Danger
     #
     # @param max_size [Integer] The maximum allowed size for the diff.
     # @param file_selector [Proc] Optional closure to filter the files in the diff to be used for size calculation.
+    # @param line_selector [Proc] Optional closure to filter the individual changed lines counted towards the size.
+    #   It receives the content of an added/removed line (without the leading `+`/`-` diff marker) and should return
+    #   `true` for lines that should be counted. When provided, the size is computed by iterating the diff patches
+    #   instead of the cached numstats, which is slower but allows excluding lines such as comments or blank lines.
     # @param type [:insertions, :deletions, :all] The type of diff size to check. (default: :all)
     # @param message [String] The message to display if the diff size exceeds the maximum. (default: DEFAULT_DIFF_SIZE_MESSAGE)
     # @param report_type [Symbol] (optional) The type of report for the message. Types: :error, :warning (default), :message.
     #
     # @return [void]
-    def check_diff_size(max_size:, file_selector: nil, type: :all, message: format(DEFAULT_DIFF_SIZE_MESSAGE_FORMAT, max_size), report_type: :warning)
-      case type
-      when :insertions
-        reporter.report(message: message, type: report_type) if insertions_size(file_selector: file_selector) > max_size
-      when :deletions
-        reporter.report(message: message, type: report_type) if deletions_size(file_selector: file_selector) > max_size
-      when :all
-        reporter.report(message: message, type: report_type) if diff_size(file_selector: file_selector) > max_size
-      end
+    def check_diff_size(max_size:, file_selector: nil, line_selector: nil, type: :all, message: format(DEFAULT_DIFF_SIZE_MESSAGE_FORMAT, max_size), report_type: :warning)
+      size = case type
+             when :insertions
+               insertions_size(file_selector: file_selector, line_selector: line_selector)
+             when :deletions
+               deletions_size(file_selector: file_selector, line_selector: line_selector)
+             when :all
+               diff_size(file_selector: file_selector, line_selector: line_selector)
+             end
+
+      reporter.report(message: message, type: report_type) if size > max_size
     end
 
     # Check the size of the Pull Request description (PR body) against a specified minimum size.
@@ -71,9 +85,12 @@ module Danger
     # Calculate the total size of insertions in modified files that match the file selector.
     #
     # @param file_selector [Proc] Select the files to be used for the insertions calculation.
+    # @param line_selector [Proc] Optional closure to select which added lines are counted (see #check_diff_size).
     #
     # @return [Integer] The total size of insertions in the selected modified files.
-    def insertions_size(file_selector: nil)
+    def insertions_size(file_selector: nil, line_selector: nil)
+      return filtered_diff_size(file_selector: file_selector, line_selector: line_selector, change_types: [:added]) if line_selector
+
       return danger.git.insertions unless file_selector
 
       # Only check added and modified files - deleted files have 0 insertions
@@ -88,9 +105,12 @@ module Danger
     # Calculate the total size of deletions in modified files that match the file selector.
     #
     # @param file_selector [Proc] Select the files to be used for the deletions calculation.
+    # @param line_selector [Proc] Optional closure to select which removed lines are counted (see #check_diff_size).
     #
     # @return [Integer] The total size of deletions in the selected modified files.
-    def deletions_size(file_selector: nil)
+    def deletions_size(file_selector: nil, line_selector: nil)
+      return filtered_diff_size(file_selector: file_selector, line_selector: line_selector, change_types: [:removed]) if line_selector
+
       return danger.git.deletions unless file_selector
 
       filtered_files = git_utils.all_changed_files.select(&file_selector)
@@ -104,9 +124,12 @@ module Danger
     # Calculate the total size of changes (insertions and deletions) in modified files that match the file selector.
     #
     # @param file_selector [Proc] Select the files to be used for the total insertions and deletions calculation.
+    # @param line_selector [Proc] Optional closure to select which added/removed lines are counted (see #check_diff_size).
     #
     # @return [Integer] The total size of changes in the selected modified files.
-    def diff_size(file_selector: nil)
+    def diff_size(file_selector: nil, line_selector: nil)
+      return filtered_diff_size(file_selector: file_selector, line_selector: line_selector, change_types: %i[added removed]) if line_selector
+
       return danger.git.lines_of_code unless file_selector
 
       filtered_files = git_utils.all_changed_files.select(&file_selector)
@@ -117,6 +140,34 @@ module Danger
         next 0 unless stats
 
         stats[:deletions].to_i + stats[:insertions].to_i
+      end
+    end
+
+    private
+
+    # Count the changed lines across the selected files by iterating the diff patches, keeping only the lines
+    # whose change type is included in `change_types` and for which `line_selector` returns true.
+    #
+    # This is slower than the cached-numstats path used when no `line_selector` is given, since it needs the
+    # actual patch content to evaluate each line, but it is the only way to exclude specific lines (e.g. comments).
+    #
+    # @param file_selector [Proc, nil] Optional closure to select the files to inspect.
+    # @param line_selector [Proc] Closure receiving a changed line's content (without the `+`/`-` marker),
+    #   returning true when the line should be counted.
+    # @param change_types [Array<Symbol>] The diff change types to count (any of :added, :removed).
+    #
+    # @return [Integer] The total number of counted changed lines.
+    def filtered_diff_size(file_selector:, line_selector:, change_types:)
+      files = git_utils.all_changed_files
+      files = files.select(&file_selector) if file_selector
+
+      files.sum do |file|
+        diff = danger.git.diff_for_file(file)
+        next 0 unless diff
+
+        diff.patch.each_line.count do |line|
+          change_types.include?(git_utils.change_type(diff_line: line)) && line_selector.call(line[1..] || '')
+        end
       end
     end
   end

--- a/spec/pr_size_checker_spec.rb
+++ b/spec/pr_size_checker_spec.rb
@@ -177,6 +177,118 @@ module Danger
           it_behaves_like 'using the default diff size counter, without a file selector', :deletions
           it_behaves_like 'using a file selector to filter and count the changes in a diff', :deletions, [221, 380, 1157]
         end
+
+        context 'when using a line_selector to exclude comment and blank lines' do
+          # Counts a changed line only if, once trimmed, it is neither empty nor the start of a comment.
+          let(:code_line_selector) do
+            lambda do |line|
+              stripped = line.strip
+              !(stripped.empty? || stripped.start_with?('//', '/*', '*', '*/'))
+            end
+          end
+
+          # 4 added code lines (fun/val/return/}) + 1 removed code line, plus comment and blank lines that must be ignored.
+          let(:kotlin_patch) do
+            <<~PATCH
+              diff --git a/Foo.kt b/Foo.kt
+              index 1234567..89abcde 100644
+              --- a/Foo.kt
+              +++ b/Foo.kt
+              @@ -1,2 +1,10 @@
+               package com.example
+              +
+              +// a single line comment
+              +/* a block comment */
+              +/** kdoc opening */
+              + * kdoc continuation line
+              +fun foo(): Int {
+              +    val x = 1
+              +    return x
+              +}
+              -val removedCode = 0
+              -// removed comment
+            PATCH
+          end
+
+          before do
+            stub_const('GitDiffStruct', Struct.new(:type, :path, :patch))
+            allow(@plugin.git).to receive_messages(added_files: ['Foo.kt'], modified_files: [], deleted_files: [])
+            allow(@plugin.git).to receive(:diff_for_file).with('Foo.kt').and_return(GitDiffStruct.new('added', 'Foo.kt', kotlin_patch))
+          end
+
+          it 'reports a warning when the non-comment, non-blank changes exceed the max (type :all counts 5)' do
+            @plugin.check_diff_size(max_size: 4, type: :all, line_selector: code_line_selector)
+
+            expect(@dangerfile).to report_warnings([format(described_class::DEFAULT_DIFF_SIZE_MESSAGE_FORMAT, 4)])
+          end
+
+          it 'does nothing when the non-comment, non-blank changes are within the max (type :all counts 5)' do
+            @plugin.check_diff_size(max_size: 5, type: :all, line_selector: code_line_selector)
+
+            expect(@dangerfile).to not_report
+          end
+
+          it 'counts only added code lines for :insertions (counts 4)' do
+            @plugin.check_diff_size(max_size: 3, type: :insertions, line_selector: code_line_selector)
+
+            expect(@dangerfile).to report_warnings([format(described_class::DEFAULT_DIFF_SIZE_MESSAGE_FORMAT, 3)])
+          end
+
+          it 'does nothing for :insertions when the added code lines are within the max (counts 4)' do
+            @plugin.check_diff_size(max_size: 4, type: :insertions, line_selector: code_line_selector)
+
+            expect(@dangerfile).to not_report
+          end
+
+          it 'counts only removed code lines for :deletions (counts 1)' do
+            @plugin.check_diff_size(max_size: 0, type: :deletions, line_selector: code_line_selector)
+
+            expect(@dangerfile).to report_warnings([format(described_class::DEFAULT_DIFF_SIZE_MESSAGE_FORMAT, 0)])
+          end
+
+          it 'does nothing for :deletions when the removed code lines are within the max (counts 1)' do
+            @plugin.check_diff_size(max_size: 1, type: :deletions, line_selector: code_line_selector)
+
+            expect(@dangerfile).to not_report
+          end
+
+          it 'exposes the filtered counts through the size helpers' do
+            expect(@plugin.diff_size(line_selector: code_line_selector)).to eq(5)
+            expect(@plugin.insertions_size(line_selector: code_line_selector)).to eq(4)
+          end
+
+          context 'when combined with a file_selector' do
+            before do
+              excluded_test_file = 'src/test/java/FooTest.kt'
+              allow(@plugin.git).to receive_messages(added_files: ['Foo.kt', excluded_test_file], modified_files: [], deleted_files: [])
+              allow(@plugin.git).to receive(:diff_for_file).with(excluded_test_file).and_return(GitDiffStruct.new('added', excluded_test_file, kotlin_patch))
+            end
+
+            it 'ignores lines in files rejected by the file_selector (still counts 5)' do
+              @plugin.check_diff_size(
+                max_size: 4,
+                type: :all,
+                file_selector: ->(path) { !path.include?('/src/test') },
+                line_selector: code_line_selector
+              )
+
+              expect(@dangerfile).to report_warnings([format(described_class::DEFAULT_DIFF_SIZE_MESSAGE_FORMAT, 4)])
+            end
+          end
+
+          context 'without a line_selector (default numstats path)' do
+            before do
+              allow(@plugin.git).to receive(:diff).and_return(instance_double(Git::Diff))
+              allow(@plugin.git.diff).to receive(:stats).and_return({ files: { 'Foo.kt' => { insertions: 9, deletions: 2 } } })
+            end
+
+            it 'counts every changed line including comments and blanks (counts 11)' do
+              @plugin.check_diff_size(max_size: 10, type: :all, file_selector: ->(_path) { true })
+
+              expect(@dangerfile).to report_warnings([format(described_class::DEFAULT_DIFF_SIZE_MESSAGE_FORMAT, 10)])
+            end
+          end
+        end
       end
 
       context 'when checking a PR body size' do

--- a/spec/pr_size_checker_spec.rb
+++ b/spec/pr_size_checker_spec.rb
@@ -264,15 +264,13 @@ module Danger
               allow(@plugin.git).to receive(:diff_for_file).with(excluded_test_file).and_return(GitDiffStruct.new('added', excluded_test_file, kotlin_patch))
             end
 
-            it 'ignores lines in files rejected by the file_selector (still counts 5)' do
-              @plugin.check_diff_size(
-                max_size: 4,
-                type: :all,
-                file_selector: ->(path) { !path.include?('/src/test') },
-                line_selector: code_line_selector
-              )
+            it 'only counts lines in files accepted by the file_selector' do
+              # Both files carry the same patch (5 code lines each); excluding the test file must keep the count at 5, not 10.
+              file_selector = ->(path) { !path.include?('src/test') }
 
-              expect(@dangerfile).to report_warnings([format(described_class::DEFAULT_DIFF_SIZE_MESSAGE_FORMAT, 4)])
+              expect(
+                @plugin.diff_size(file_selector: file_selector, line_selector: code_line_selector)
+              ).to eq(5)
             end
           end
 
@@ -288,6 +286,10 @@ module Danger
               expect(@dangerfile).to report_warnings([format(described_class::DEFAULT_DIFF_SIZE_MESSAGE_FORMAT, 10)])
             end
           end
+        end
+
+        it 'raises an ArgumentError when given an unknown diff size type' do
+          expect { @plugin.check_diff_size(max_size: 100, type: :unknown) }.to raise_error(ArgumentError)
         end
       end
 


### PR DESCRIPTION
### Context

The `pr_size_checker` diff-size warning ("This PR is larger than N lines of changes…") counts every added/removed line from the cached git numstats. Its only filter, `file_selector`, includes/excludes *whole files* by path — there's no way to skip individual lines. As a result, code comments (notably AI-generated ones) and blank lines inflate the count and make the warning less representative of real production-code changes.

### What this does

Adds an optional, language-agnostic `line_selector:` closure to `check_diff_size` (and the `insertions_size` / `deletions_size` / `diff_size` helpers).

- `line_selector` receives each added/removed line's content (with the leading `+`/`-` marker stripped) and returns `true` for lines that should be counted.
- Consumers decide their own policy — e.g. skip comments and blank lines. dangermattic stays un-opinionated (no per-language comment heuristic baked in), so Kotlin/Java, Swift, etc. can each plug in their own filter.

```ruby
pr_size_checker.check_diff_size(
  max_size: 300,
  line_selector: ->(line) {
    stripped = line.strip
    !(stripped.empty? || stripped.start_with?('//', '/*', '*', '*/'))
  }
)
```

### Implementation notes

- When `line_selector` is omitted (the default), behaviour is **unchanged** — the existing cached-numstats fast path (incl. the large-PR optimization from 1.2.4) is preserved.
- When provided, a new private `filtered_diff_size` iterates each file's patch via `danger.git.diff_for_file(file).patch`, classifying lines with the existing `git_utils.change_type`, counting only the relevant change type(s). This is slower, hence gated behind the opt-in.

### Testing

- 8 new specs covering `:all` / `:insertions` / `:deletions` with comments + blank lines excluded, warn/no-warn boundaries, the size helpers, and combination with a `file_selector`, plus a contrast test proving the default path still counts every line.
- `bundle exec rake` → 313 examples, 0 failures; RuboCop clean; `danger plugins lint` passes.

### Motivation

Requested for the WooCommerce Android Dangerfile ([WOOMOB-3401](https://linear.app/a8c/issue/WOOMOB-3401)); the primitive is generic and usable by any consuming repo. Android will adopt it in a follow-up once a version containing this ships.