### PR TITLE
Release 1.4.0 into trunk

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ _None_
 
 ### New Features
 
-- `pr_size_checker`: add optional `line_selector` to `check_diff_size` (and `insertions_size` / `deletions_size` / `diff_size`) to exclude specific changed lines (e.g. comments and blank lines) from the diff-size metric. [#133]
+_None_
 
 ### Bug Fixes
 
@@ -19,6 +19,12 @@ _None_
 ### Internal Changes
 
 _None_
+
+## 1.4.0
+
+### New Features
+
+- `pr_size_checker`: add optional `line_selector` to `check_diff_size` (and `insertions_size` / `deletions_size` / `diff_size`) to exclude specific changed lines (e.g. comments and blank lines) from the diff-size metric. [#133]
 
 ## 1.3.0
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    danger-dangermattic (1.3.0)
+    danger-dangermattic (1.4.0)
       danger (~> 9.5, >= 9.5.3)
       danger-plugin-api (~> 1.0)
       danger-rubocop (~> 0.13)

--- a/lib/dangermattic/gem_version.rb
+++ b/lib/dangermattic/gem_version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Dangermattic
-  VERSION = '1.3.0'
+  VERSION = '1.4.0'
 end


### PR DESCRIPTION
Releasing new version 1.4.0.

# What's Next

PR Author: Be sure to create and publish a GitHub Release pointing to `trunk` once this PR gets merged,
copy/pasting the following text as the GitHub Release's description:
```
### New Features

- `pr_size_checker`: add optional `line_selector` to `check_diff_size` (and `insertions_size` / `deletions_size` / `diff_size`) to exclude specific changed lines (e.g. comments and blank lines) from the diff-size metric. [#133]


```
