### PR TITLE
Add reusable Dependabot auto-merge workflow

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -83,4 +83,72 @@ This workflow runs Danger directly on GitHub Actions.
      - Executes Danger in read-only mode for forks and Dependabot PRs
      - Runs Danger with full functionality for PRs where the configured token has access to the repo
 
-These reusable workflows can be incorporated into other workflows in your repository to perform specific tasks related to issue labeling, Buildkite job management, and pull request checks using Danger.
+## Auto-Merge Dependabot Pull Requests
+
+**File:** `workflows/reusable-dependabot-auto-merge.yml`
+
+This workflow approves and enables auto-merge on Dependabot pull requests.
+By default it only does so for patch updates; everything else is left for a human to review.
+
+Auto-merge is enabled rather than merging directly, so the pull request still has to pass the repository's required checks before it lands.
+
+### Inputs:
+- `merge-method`: The merge method to use, one of `merge`, `squash` or `rebase` (default: `merge`)
+- `minor-update-allowlist`: JSON array of dependency names that may also be auto-merged on minor updates (default: `[]`)
+- `denylist`: JSON array of dependency names that are never auto-merged, whatever the update type (default: `[]`)
+- `assign-closest-milestone`: Assign the closest open milestone with a future due date before merging (default: `false`)
+  - Useful where Danger requires a milestone, since the pull request would otherwise never satisfy its required checks.
+
+Example:
+
+```yaml
+with:
+  minor-update-allowlist: |
+    [
+      "release-toolkit"
+    ]
+  denylist: |
+    [
+      "some-fragile-dependency"
+    ]
+```
+
+For grouped updates, a denylisted dependency anywhere in the group blocks the pull request, and a minor update is only auto-merged when every dependency in the group is on the allowlist.
+Names are matched exactly, so `okhttp` on the denylist does not block `okhttp-urlconnection`.
+
+### Secrets:
+- `github-token`: Optional GitHub token, defaulting to `GITHUB_TOKEN`
+  - Dependabot-triggered runs cannot read Actions secrets, so a token passed here must be stored as a [Dependabot secret](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/configuring-access-to-private-registries-for-dependabot).
+
+### Job: `dependabot-auto-merge`
+- Permissions: `contents: write`, `pull-requests: write`
+  - A reusable workflow cannot hold more permissions than its caller, so the calling workflow must grant these too.
+- Runs only for Dependabot pull requests opened from a branch on the repository itself, never from a fork.
+- Steps:
+  1. Fetch Dependabot metadata
+  2. Decide whether to auto-merge, from the update type and the allow/deny lists
+  3. Assign the closest milestone, when enabled
+  4. Approve the pull request
+  5. Enable auto-merge
+
+The calling workflow must use the `pull_request` event and grant the permissions above:
+
+```yaml
+name: 🤖 Auto-merge Dependabot Updates
+
+on:
+  pull_request:
+    types: [opened, reopened]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  dependabot-auto-merge:
+    uses: Automattic/dangermattic/.github/workflows/reusable-dependabot-auto-merge.yml@v1.5.0
+```
+
+The repository must have "Allow auto-merge" enabled, and the organisation must allow GitHub Actions to approve pull requests, otherwise the workflow fails when approving or enabling auto-merge.
+
+These reusable workflows can be incorporated into other workflows in your repository to perform specific tasks related to issue labeling, Buildkite job management, Dependabot updates, and pull request checks using Danger.

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -125,7 +125,7 @@ Names are matched exactly, so `okhttp` on the denylist does not block `okhttp-ur
 - Steps:
   1. Fetch Dependabot metadata
   2. Decide whether to auto-merge, from the update type and the allow/deny lists
-  3. Approve the pull request
+  3. Approve the pull request, leaving a review comment saying why it was auto-approved
   4. Enable auto-merge
 
 The calling workflow must use the `pull_request` event and grant the permissions above:

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -96,8 +96,6 @@ Auto-merge is enabled rather than merging directly, so the pull request still ha
 - `merge-method`: The merge method to use, one of `merge`, `squash` or `rebase` (default: `merge`)
 - `minor-update-allowlist`: JSON array of dependency names that may also be auto-merged on minor updates (default: `[]`)
 - `denylist`: JSON array of dependency names that are never auto-merged, whatever the update type (default: `[]`)
-- `assign-closest-milestone`: Assign the closest open milestone with a future due date before merging (default: `false`)
-  - Useful where Danger requires a milestone, since the pull request would otherwise never satisfy its required checks.
 
 Example:
 
@@ -127,9 +125,8 @@ Names are matched exactly, so `okhttp` on the denylist does not block `okhttp-ur
 - Steps:
   1. Fetch Dependabot metadata
   2. Decide whether to auto-merge, from the update type and the allow/deny lists
-  3. Assign the closest milestone, when enabled
-  4. Approve the pull request
-  5. Enable auto-merge
+  3. Approve the pull request
+  4. Enable auto-merge
 
 The calling workflow must use the `pull_request` event and grant the permissions above:
 

--- a/.github/workflows/reusable-dependabot-auto-merge.yml
+++ b/.github/workflows/reusable-dependabot-auto-merge.yml
@@ -1,0 +1,164 @@
+# yaml-language-server: $schema=https://json.schemastore.org/github-workflow.json
+
+on:
+  workflow_call:
+    inputs:
+      merge-method:
+        description: The merge method to use. One of `merge`, `squash` or `rebase`.
+        default: merge
+        type: string
+        required: false
+      minor-update-allowlist:
+        description: Dependencies that may also be auto-merged on minor updates; must be a JSON array of strings.
+        default: |
+          []
+        type: string
+        required: false
+      denylist:
+        description: Dependencies that must never be auto-merged, whatever the update type; must be a JSON array of strings.
+        default: |
+          []
+        type: string
+        required: false
+      assign-closest-milestone:
+        description: Assign the closest open milestone with a future due date to the pull request before merging.
+        default: false
+        type: boolean
+        required: false
+    secrets:
+      github-token:
+        required: false
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+
+jobs:
+  dependabot-auto-merge:
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.user.login == 'dependabot[bot]' && github.event.pull_request.head.repo.full_name == github.repository
+    permissions:
+      contents: write
+      pull-requests: write
+    env:
+      GH_TOKEN: ${{ secrets.github-token || secrets.GITHUB_TOKEN }}
+      GH_REPO: ${{ github.repository }}
+      PR_NUMBER: ${{ github.event.pull_request.number }}
+    steps:
+      - name: 🤖 Fetch Dependabot Metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@25dd0e34f4fe68f24cc83900b1fe3fe149efef98 # v3.1.0
+        with:
+          github-token: ${{ secrets.github-token || secrets.GITHUB_TOKEN }}
+
+      - name: 🚦 Decide Whether to Auto-Merge
+        id: decision
+        env:
+          UPDATE_TYPE: ${{ steps.metadata.outputs.update-type }}
+          DEPENDENCY_NAMES: ${{ steps.metadata.outputs.dependency-names }}
+          MINOR_ALLOWLIST: ${{ inputs.minor-update-allowlist }}
+          DENYLIST: ${{ inputs.denylist }}
+          MERGE_METHOD: ${{ inputs.merge-method }}
+        run: |
+          #!/usr/bin/env bash
+
+          set -euo pipefail
+
+          deny() {
+            echo "🛑 Not auto-merging: $1"
+            echo 'should-merge=false' >> "$GITHUB_OUTPUT"
+            exit 0
+          }
+
+          allow() {
+            echo "✅ Auto-merging: $1"
+            echo 'should-merge=true' >> "$GITHUB_OUTPUT"
+            exit 0
+          }
+
+          validate_json_array() {
+            local value="$1" name="$2"
+
+            if ! printf '%s\n' "$value" | jq -e 'type == "array" and all(.[]; type == "string")' > /dev/null; then
+              echo "❌ $name must be a JSON array of strings. Example: [\"release-toolkit\"]"
+              exit 1
+            fi
+          }
+
+          in_list() {
+            printf '%s\n' "$2" | jq -e --arg name "$1" 'index($name) != null' > /dev/null
+          }
+
+          case "$MERGE_METHOD" in
+            merge | squash | rebase) ;;
+            *)
+              echo "❌ merge-method must be one of 'merge', 'squash' or 'rebase'. Got '$MERGE_METHOD'."
+              exit 1
+              ;;
+          esac
+
+          validate_json_array "$MINOR_ALLOWLIST" minor-update-allowlist
+          validate_json_array "$DENYLIST" denylist
+
+          readarray -t dependencies < <(printf '%s' "$DEPENDENCY_NAMES" | tr ',' '\n' | sed 's/^[[:space:]]*//;s/[[:space:]]*$//' | grep -v '^$' || true)
+
+          if [ "${#dependencies[@]}" -eq 0 ]; then
+            deny 'Dependabot reported no updated dependencies.'
+          fi
+
+          echo "📦 Updated dependencies: ${dependencies[*]}"
+          echo "🔖 Update type: $UPDATE_TYPE"
+
+          # A denylisted dependency anywhere in a grouped update blocks the whole pull request.
+          for dependency in "${dependencies[@]}"; do
+            if in_list "$dependency" "$DENYLIST"; then
+              deny "'$dependency' is on the denylist."
+            fi
+          done
+
+          # For grouped updates, Dependabot reports the highest bump across the group,
+          # so a `semver-patch` here means every dependency in the group is a patch.
+          if [ "$UPDATE_TYPE" = 'version-update:semver-patch' ]; then
+            allow 'all updates are patch level.'
+          fi
+
+          if [ "$UPDATE_TYPE" != 'version-update:semver-minor' ]; then
+            deny "update type '$UPDATE_TYPE' is never auto-merged."
+          fi
+
+          for dependency in "${dependencies[@]}"; do
+            if ! in_list "$dependency" "$MINOR_ALLOWLIST"; then
+              deny "minor update to '$dependency', which is not on the minor update allowlist."
+            fi
+          done
+
+          allow 'every dependency in this minor update is on the allowlist.'
+
+      - name: 🗓️ Assign Closest Milestone
+        if: inputs.assign-closest-milestone && steps.decision.outputs.should-merge == 'true'
+        run: |
+          #!/usr/bin/env bash
+
+          set -euo pipefail
+
+          milestone="$(
+            gh api "repos/$GH_REPO/milestones" --paginate |
+              jq -r '[.[] | select(.state == "open" and .due_on != null and (.due_on | fromdateiso8601) >= now)] | sort_by(.due_on) | .[0].title // empty'
+          )"
+
+          if [ -z "$milestone" ]; then
+            echo '⚠️ No open milestone with a future due date. Leaving the pull request unmilestoned.'
+            exit 0
+          fi
+
+          echo "🗓️ Assigning milestone '$milestone'"
+          gh pr edit "$PR_NUMBER" --milestone "$milestone"
+
+      - name: 👍 Approve the Pull Request
+        if: steps.decision.outputs.should-merge == 'true'
+        run: gh pr review --approve "$PR_NUMBER"
+
+      - name: 🚀 Enable Auto-Merge
+        if: steps.decision.outputs.should-merge == 'true'
+        env:
+          MERGE_METHOD: ${{ inputs.merge-method }}
+        run: gh pr merge --auto "--$MERGE_METHOD" "$PR_NUMBER"

--- a/.github/workflows/reusable-dependabot-auto-merge.yml
+++ b/.github/workflows/reusable-dependabot-auto-merge.yml
@@ -67,6 +67,7 @@ jobs:
           allow() {
             echo "✅ Auto-merging: $1"
             echo 'should-merge=true' >> "$GITHUB_OUTPUT"
+            echo "reason=$1" >> "$GITHUB_OUTPUT"
             exit 0
           }
 
@@ -130,7 +131,9 @@ jobs:
 
       - name: 👍 Approve the Pull Request
         if: steps.decision.outputs.should-merge == 'true'
-        run: gh pr review --approve "$PR_NUMBER"
+        env:
+          REASON: ${{ steps.decision.outputs.reason }}
+        run: gh pr review --approve --body "🤖 Auto-approved by Dangermattic's Dependabot auto-merge workflow, because $REASON" "$PR_NUMBER"
 
       - name: 🚀 Enable Auto-Merge
         if: steps.decision.outputs.should-merge == 'true'

--- a/.github/workflows/reusable-dependabot-auto-merge.yml
+++ b/.github/workflows/reusable-dependabot-auto-merge.yml
@@ -20,11 +20,6 @@ on:
           []
         type: string
         required: false
-      assign-closest-milestone:
-        description: Assign the closest open milestone with a future due date to the pull request before merging.
-        default: false
-        type: boolean
-        required: false
     secrets:
       github-token:
         required: false
@@ -132,26 +127,6 @@ jobs:
           done
 
           allow 'every dependency in this minor update is on the allowlist.'
-
-      - name: 🗓️ Assign Closest Milestone
-        if: inputs.assign-closest-milestone && steps.decision.outputs.should-merge == 'true'
-        run: |
-          #!/usr/bin/env bash
-
-          set -euo pipefail
-
-          milestone="$(
-            gh api "repos/$GH_REPO/milestones" --paginate |
-              jq -r '[.[] | select(.state == "open" and .due_on != null and (.due_on | fromdateiso8601) >= now)] | sort_by(.due_on) | .[0].title // empty'
-          )"
-
-          if [ -z "$milestone" ]; then
-            echo '⚠️ No open milestone with a future due date. Leaving the pull request unmilestoned.'
-            exit 0
-          fi
-
-          echo "🗓️ Assigning milestone '$milestone'"
-          gh pr edit "$PR_NUMBER" --milestone "$milestone"
 
       - name: 👍 Approve the Pull Request
         if: steps.decision.outputs.should-merge == 'true'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ _None_
 
 ### New Features
 
-_None_
+- Added the `reusable-dependabot-auto-merge` workflow, which approves and enables auto-merge on Dependabot pull requests. Patch updates are auto-merged by default, with optional support for a denylist and for minor updates from an allowlist. [#135]
 
 ### Bug Fixes
 


### PR DESCRIPTION
Woo Android, Day One Android and Studio each grew their own copy of the same workflow: fetch Dependabot's metadata, gate on `update-type`, approve, enable auto-merge. This lifts that into a reusable workflow so the mobile repos with no auto-merge today get it by adding a caller, and the three that have one can drop their local copies.

Patch updates auto-merge; everything else still waits for a human.

Part of [AINFRA-2617](https://linear.app/a8c/issue/AINFRA-2617). Adoption is tracked per-repo under the [project](https://linear.app/a8c/project/implement-auto-merge-for-dependabot-prs-via-reusable-gha-workflow-526a1c6e74f3/overview).

### Intentional tradeoffs

**The `denylist` and `minor-update-allowlist` inputs ship now, though only patch auto-merge is needed.** Both default to `[]`, so a repo configuring nothing gets patch-only behaviour. They're here because the expensive part is computing the decision in one step instead of repeating `if: steps.metadata.outputs.update-type == …` on every step — once that exists, each list is a `jq` lookup. Adding them later would mean doing that restructure twice.

**No checkout step.** Neither `dependabot/fetch-metadata` nor `gh` needs a working tree. The three prior implementations all paid for one.

**`pull_request`, not `pull_request_target`** (Studio uses the latter). Since nothing is checked out the extra privilege buys nothing, and `pull_request` is the documented path. Consequence: Dependabot runs can't read Actions secrets, so an override token must be stored as a *Dependabot* secret. Documented in the README.

**Milestone assignment is deliberately absent**, though Woo Android's implementation has it. It's only needed where a `Dangerfile` reports a missing milestone as an `:error` (Woo iOS and Android), not where it takes the plugin's default `:warning` (WordPress iOS, Pocket Casts iOS). Woo can unblock by having Dependabot apply the `milestone-not-required` label their `Dangerfile` already honours. Assigning milestones for release tracking is a separate concern, explored in #136.

### Gotchas for adopters

- The **caller** must grant `contents: write` and `pull-requests: write` — a reusable workflow can't hold more permission than its caller.
- The repo needs **"Allow auto-merge"** on, and the org must **allow Actions to approve PRs**, or the workflow fails at the approve step. Verified enabled for the four prototype repos.

### How to test

`bundle exec rake` covers the repo's own checks, but not this workflow. I verified the decision logic out-of-band against a 16-case matrix (patch/minor/major, grouped updates, deny beats allow, exact-not-prefix name matching, malformed inputs, a `merge-method` injection attempt); `shellcheck` is clean.

That verification isn't committed here, so it protects nothing. **#137 stacks on this branch and adds it as RSpec**, driving the decision script straight out of the workflow YAML so a renamed input breaks the build. Review order: this PR, then #137.

Real end-to-end validation happens in the prototype repos (dangermattic itself, AutoProxxy, hostmgr, apps-infra-toolbox), which point at this branch before a tag is cut.

🤖 Generated with [Claude Code](https://claude.com/claude-code)