### PR TITLE
Explore auto-assigning the closest milestone

### DIFF
--- a/.github/workflows/reusable-assign-closest-milestone.yml
+++ b/.github/workflows/reusable-assign-closest-milestone.yml
@@ -1,0 +1,62 @@
+# yaml-language-server: $schema=https://json.schemastore.org/github-workflow.json
+
+# EXPLORATORY. See the pull request that introduced this file for the open questions.
+
+on:
+  workflow_call:
+    inputs:
+      only-for-actor:
+        description: Only assign a milestone to pull requests opened by this actor. Leave empty to assign to every pull request.
+        default: dependabot[bot]
+        type: string
+        required: false
+      skip-if-milestone-set:
+        description: Leave the pull request alone when it already carries a milestone.
+        default: true
+        type: boolean
+        required: false
+    secrets:
+      github-token:
+        required: false
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+
+jobs:
+  assign-closest-milestone:
+    runs-on: ubuntu-latest
+    if: inputs.only-for-actor == '' || github.event.pull_request.user.login == inputs.only-for-actor
+    permissions:
+      pull-requests: write
+    env:
+      GH_TOKEN: ${{ secrets.github-token || secrets.GITHUB_TOKEN }}
+      GH_REPO: ${{ github.repository }}
+      PR_NUMBER: ${{ github.event.pull_request.number }}
+    steps:
+      - name: 🗓️ Assign Closest Milestone
+        env:
+          CURRENT_MILESTONE: ${{ github.event.pull_request.milestone.title }}
+          SKIP_IF_MILESTONE_SET: ${{ inputs.skip-if-milestone-set }}
+        run: |
+          #!/usr/bin/env bash
+
+          set -euo pipefail
+
+          if [ "$SKIP_IF_MILESTONE_SET" = 'true' ] && [ -n "$CURRENT_MILESTONE" ]; then
+            echo "🗓️ Already assigned to '$CURRENT_MILESTONE'. Nothing to do."
+            exit 0
+          fi
+
+          # The closest milestone is the open one with the earliest due date that has not yet passed.
+          milestone="$(
+            gh api "repos/$GH_REPO/milestones" --paginate |
+              jq -r '[.[] | select(.state == "open" and .due_on != null and (.due_on | fromdateiso8601) >= now)] | sort_by(.due_on) | .[0].title // empty'
+          )"
+
+          if [ -z "$milestone" ]; then
+            echo '⚠️ No open milestone with a future due date. Leaving the pull request unmilestoned.'
+            exit 0
+          fi
+
+          echo "🗓️ Assigning milestone '$milestone'"
+          gh pr edit "$PR_NUMBER" --milestone "$milestone"


### PR DESCRIPTION
> **History:** extracted from the reusable Dependabot auto-merge workflow (#135), where it originally shipped as an `assign-closest-milestone` input. It was cut from that PR because it solved a different problem, and is **parked here as a draft for future exploration** rather than proposed for merge. Not ready for review.

### Why it was extracted

Woo Android's auto-merge workflow assigns a milestone before merging. Chasing the rationale: their `Dangerfile` reports a missing milestone as an `:error`, so a Dependabot PR never satisfies its required checks and `--auto` never fires. It's a workaround.

That workaround was narrower than it looked:

| Repo | Missing milestone reported as | Blocks auto-merge? |
|---|---|---|
| `woocommerce-android` | `:error` | Yes |
| `woocommerce-ios` | `:error` | Yes |
| `wordpress-ios` | `:warning` (plugin default) | No |
| `pocket-casts-ios` | `:warning` (plugin default) | No |

So milestone assignment was one team's Danger configuration, carried inside a workflow every repo shares. Worse, Woo's `Dangerfile` already offers an escape hatch — it downgrades the report to `:message` when the PR carries `milestone-not-required`, a label Dependabot can apply from `dependabot.yml`. Unblocking doesn't need workflow code at all.

### What's left that might be worth building

Assigning a milestone so a dependency bump is attributable to a release. That's release tracking, not auto-merge, and it's the question this branch exists to answer.

### Open questions

- Is release tracking of Dependabot PRs actually wanted, or was the milestone only ever there to satisfy Danger? If the latter, close this and use the label.
- Should it be a reusable workflow at all, or a Danger rule? Dangermattic already has `milestone_checker`; a plugin that *assigns* rather than *checks* may be a better fit for repos already running Danger.
- "Closest open milestone with a future due date" is inherited from Woo Android. Undated milestones are ignored, and a repo whose milestones have all passed silently gets nothing. Both may be wrong.
- Scoping: `only-for-actor` defaults to `dependabot[bot]`, but nothing about the logic is Dependabot-specific.

### State

The workflow is lifted essentially verbatim, plus a guard against clobbering an existing milestone. YAML parses and `shellcheck` is clean; **it has never been run against a real pull request**, has no tests, and isn't documented in the workflows README.

🤖 Generated with [Claude Code](https://claude.com/claude-code)