### PR TITLE
Explore Dependabot auto-merge as a Danger plugin

### DIFF
--- a/lib/dangermattic/plugins/dependabot_auto_merger.rb
+++ b/lib/dangermattic/plugins/dependabot_auto_merger.rb
@@ -1,0 +1,154 @@
+# frozen_string_literal: true
+
+require 'json'
+require 'yaml'
+
+module Danger
+  # EXPLORATORY. Approves and enables auto-merge on Dependabot pull requests.
+  #
+  # Unlike the rest of Dangermattic, this plugin acts on the pull request rather than reporting on it.
+  # See the pull request that introduced it for the tradeoffs that entails.
+  #
+  # Patch updates are auto-merged. Minor updates are auto-merged only for dependencies on an allowlist,
+  # and a denylisted dependency is never auto-merged, whatever the update type.
+  #
+  # @example Auto-merge patch updates
+  #
+  #          dependabot_auto_merger.auto_merge_patch_updates
+  #
+  # @example Also auto-merge minor updates to a trusted dependency, and never touch a fragile one
+  #
+  #          dependabot_auto_merger.auto_merge_patch_updates(
+  #            minor_update_allowlist: ['release-toolkit'],
+  #            denylist: ['some-fragile-dependency']
+  #          )
+  #
+  # @see Automattic/dangermattic
+  # @tags dependabot, github, process
+  #
+  class DependabotAutoMerger < Plugin
+    DEPENDABOT_LOGIN = 'dependabot[bot]'
+    PATCH_UPDATE = 'version-update:semver-patch'
+    MINOR_UPDATE = 'version-update:semver-minor'
+    MERGE_METHODS = %w[MERGE SQUASH REBASE].freeze
+
+    # Approves the pull request and enables auto-merge on it, when the update qualifies.
+    #
+    # @param minor_update_allowlist [Array<String>] Dependencies that may also be auto-merged on minor updates.
+    # @param denylist [Array<String>] Dependencies that must never be auto-merged, whatever the update type.
+    # @param merge_method [String] One of `MERGE`, `SQUASH` or `REBASE`.
+    #
+    # @return [String, nil] The reason auto-merge was enabled, or `nil` when the pull request does not qualify.
+    #
+    def auto_merge_patch_updates(minor_update_allowlist: [], denylist: [], merge_method: 'MERGE')
+      raise ArgumentError, "merge_method must be one of #{MERGE_METHODS.join(', ')}" unless MERGE_METHODS.include?(merge_method)
+      return nil unless dependabot_pull_request?
+
+      reason = auto_merge_reason(minor_update_allowlist: minor_update_allowlist, denylist: denylist)
+      return nil if reason.nil?
+
+      approve_pull_request(reason: reason) unless already_approved?
+      enable_auto_merge(merge_method: merge_method)
+
+      reason
+    end
+
+    # The dependencies this pull request updates, as reported by Dependabot in its commit message.
+    #
+    # @return [Array<Hash>] One entry per dependency, with `dependency-name` and `update-type` keys.
+    #
+    def updated_dependencies
+      # Dependabot appends a YAML document to its commit message; it is the same source `dependabot/fetch-metadata` reads.
+      _, _, metadata = dependabot_commit_message.partition(/^---$/)
+      return [] if metadata.strip.empty?
+
+      YAML.safe_load(metadata).to_h.fetch('updated-dependencies', [])
+    rescue Psych::Exception
+      []
+    end
+
+    # Whether the pull request was opened by Dependabot from a branch on the repository itself.
+    #
+    # @return [Boolean]
+    #
+    def dependabot_pull_request?
+      github.pr_author == DEPENDABOT_LOGIN && github.pr_json['head']['repo']['full_name'] == repo_name
+    end
+
+    private
+
+    # Why the pull request qualifies for auto-merge, or `nil` when it doesn't.
+    def auto_merge_reason(minor_update_allowlist:, denylist:)
+      dependencies = updated_dependencies
+      return nil if dependencies.empty?
+
+      names = dependencies.map { |dependency| dependency['dependency-name'] }
+      return nil if names.any? { |name| denylist.include?(name) }
+
+      # Dependabot reports the highest bump across a group, so a patch here means every dependency in the group is a patch.
+      update_types = dependencies.map { |dependency| dependency['update-type'] }.uniq
+      return 'all updates are patch level.' if update_types == [PATCH_UPDATE]
+      return nil unless update_types == [MINOR_UPDATE]
+      return nil unless names.all? { |name| minor_update_allowlist.include?(name) }
+
+      'every dependency in this minor update is on the allowlist.'
+    end
+
+    def dependabot_commit_message
+      github.api.pull_request_commits(repo_name, pr_number).first&.dig(:commit, :message).to_s
+    end
+
+    # Re-approving on every Danger run would spam the pull request, and Danger runs on more events than this plugin cares about.
+    def already_approved?
+      github.api.pull_request_reviews(repo_name, pr_number).any? do |review|
+        review[:state] == 'APPROVED' && review[:user][:login] == authenticated_login
+      end
+    end
+
+    def approve_pull_request(reason:)
+      github.api.create_pull_request_review(
+        repo_name,
+        pr_number,
+        event: 'APPROVE',
+        body: "🤖 Auto-approved by Dangermattic, because #{reason}"
+      )
+    end
+
+    # There is no REST endpoint for auto-merge, so this goes through GraphQL.
+    def enable_auto_merge(merge_method:)
+      mutation = <<~GRAPHQL
+        mutation($pullRequestId: ID!, $mergeMethod: PullRequestMergeMethod!) {
+          enablePullRequestAutoMerge(input: { pullRequestId: $pullRequestId, mergeMethod: $mergeMethod }) {
+            clientMutationId
+          }
+        }
+      GRAPHQL
+
+      graphql(query: mutation, variables: { pullRequestId: pull_request_node_id, mergeMethod: merge_method })
+    end
+
+    def graphql(query:, variables:)
+      response = github.api.post('/graphql', { query: query, variables: variables }.to_json)
+      errors = response[:errors].to_a
+      raise "GraphQL request failed: #{errors.map { |error| error[:message] }.join(', ')}" unless errors.empty?
+
+      response
+    end
+
+    def authenticated_login
+      @authenticated_login ||= github.api.user[:login]
+    end
+
+    def pull_request_node_id
+      github.pr_json['node_id']
+    end
+
+    def repo_name
+      github.pr_json['base']['repo']['full_name']
+    end
+
+    def pr_number
+      github.pr_json['number']
+    end
+  end
+end

--- a/spec/dependabot_auto_merger_spec.rb
+++ b/spec/dependabot_auto_merger_spec.rb
@@ -1,0 +1,235 @@
+# frozen_string_literal: true
+
+require_relative 'spec_helper'
+
+module Danger
+  describe Danger::DependabotAutoMerger do
+    it 'is a plugin' do
+      expect(described_class.new(nil)).to be_a Danger::Plugin
+    end
+
+    describe 'with Dangerfile' do
+      let(:api) { instance_double(Octokit::Client) }
+      let(:pr_json) do
+        {
+          'number' => 42,
+          'node_id' => 'PR_kwDOABCD',
+          'base' => { 'repo' => { 'full_name' => 'Automattic/dangermattic' } },
+          'head' => { 'repo' => { 'full_name' => 'Automattic/dangermattic' } }
+        }
+      end
+      let(:commit_message) { dependabot_commit(['okhttp'], 'version-update:semver-patch') }
+
+      before do
+        @dangerfile = testing_dangerfile
+        @plugin = @dangerfile.dependabot_auto_merger
+
+        allow(@plugin.github).to receive_messages(pr_author: 'dependabot[bot]', api: api, pr_json: pr_json)
+        allow(api).to receive_messages(
+          user: { login: 'dangermattic[bot]' },
+          pull_request_reviews: [],
+          pull_request_commits: [{ commit: { message: commit_message } }],
+          create_pull_request_review: nil,
+          post: { data: {} }
+        )
+      end
+
+      # Mirrors the YAML document Dependabot appends to its commit message, terminator and sign-off included.
+      def dependabot_commit(names, update_type)
+        entries = names.map do |name|
+          "- dependency-name: #{name}\n  dependency-type: direct:production\n  update-type: #{update_type}\n"
+        end
+
+        <<~MESSAGE
+          Bump #{names.join(' and ')}
+
+          ---
+          updated-dependencies:
+          #{entries.join}...
+
+          Signed-off-by: dependabot[bot] <support@github.com>
+        MESSAGE
+      end
+
+      describe '#updated_dependencies' do
+        context 'with a real grouped update captured from Dependabot' do
+          let(:commit_message) { fixture('dependabot', 'grouped_minor_update.txt') }
+
+          it 'reads every dependency out of the commit message' do
+            expect(@plugin.updated_dependencies.map { |dependency| dependency['dependency-name'] })
+              .to eq(['com.stripe:stripeterminal-taptopay', 'com.stripe:stripeterminal-core', 'com.stripe:stripeterminal-ktx'])
+          end
+
+          it 'reads the update type' do
+            expect(@plugin.updated_dependencies.map { |dependency| dependency['update-type'] }.uniq).to eq(['version-update:semver-minor'])
+          end
+        end
+
+        context 'when the commit carries no Dependabot metadata' do
+          let(:commit_message) { 'Bump okhttp from 1.0.0 to 1.0.1' }
+
+          it 'reports no dependencies' do
+            expect(@plugin.updated_dependencies).to be_empty
+          end
+        end
+      end
+
+      describe '#auto_merge_patch_updates' do
+        context 'with a patch update' do
+          it 'approves the pull request, saying why' do
+            @plugin.auto_merge_patch_updates
+
+            expect(api).to have_received(:create_pull_request_review)
+              .with('Automattic/dangermattic', 42, hash_including(event: 'APPROVE', body: a_string_including('all updates are patch level.')))
+          end
+
+          it 'enables auto-merge through the GraphQL mutation' do
+            @plugin.auto_merge_patch_updates
+
+            expect(api).to have_received(:post).with('/graphql', a_string_including('enablePullRequestAutoMerge'))
+          end
+
+          it 'passes the pull request node id and merge method to the mutation' do
+            @plugin.auto_merge_patch_updates(merge_method: 'SQUASH')
+
+            expect(api).to have_received(:post).with('/graphql', a_string_including('"pullRequestId":"PR_kwDOABCD"', '"mergeMethod":"SQUASH"'))
+          end
+
+          it 'returns the reason it enabled auto-merge' do
+            expect(@plugin.auto_merge_patch_updates).to eq('all updates are patch level.')
+          end
+        end
+
+        context 'when the pull request is already approved by this account' do
+          before do
+            allow(api).to receive(:pull_request_reviews).and_return(
+              [{ state: 'APPROVED', user: { login: 'dangermattic[bot]' } }]
+            )
+          end
+
+          # Danger reruns on `labeled`, `synchronize` and friends, none of which should trigger a second review.
+          it 'does not approve a second time' do
+            @plugin.auto_merge_patch_updates
+
+            expect(api).not_to have_received(:create_pull_request_review)
+          end
+
+          it 'still enables auto-merge, which is idempotent' do
+            @plugin.auto_merge_patch_updates
+
+            expect(api).to have_received(:post)
+          end
+        end
+
+        context 'when somebody else approved the pull request' do
+          before do
+            allow(api).to receive(:pull_request_reviews).and_return(
+              [{ state: 'APPROVED', user: { login: 'mokagio' } }]
+            )
+          end
+
+          it 'still leaves its own approval' do
+            @plugin.auto_merge_patch_updates
+
+            expect(api).to have_received(:create_pull_request_review)
+          end
+        end
+
+        context 'with a minor update' do
+          let(:commit_message) { dependabot_commit(['release-toolkit'], 'version-update:semver-minor') }
+
+          it 'does nothing by default' do
+            expect(@plugin.auto_merge_patch_updates).to be_nil
+          end
+
+          it 'auto-merges an allowlisted dependency' do
+            expect(@plugin.auto_merge_patch_updates(minor_update_allowlist: ['release-toolkit'])).to eq('every dependency in this minor update is on the allowlist.')
+          end
+
+          it 'says why it auto-merged an allowlisted dependency' do
+            @plugin.auto_merge_patch_updates(minor_update_allowlist: ['release-toolkit'])
+
+            expect(api).to have_received(:create_pull_request_review)
+              .with(anything, anything, hash_including(body: a_string_including('on the allowlist.')))
+          end
+        end
+
+        context 'with a major update' do
+          let(:commit_message) { dependabot_commit(['okhttp'], 'version-update:semver-major') }
+
+          it 'does nothing, even for an allowlisted dependency' do
+            expect(@plugin.auto_merge_patch_updates(minor_update_allowlist: ['okhttp'])).to be_nil
+          end
+        end
+
+        context 'with a grouped update' do
+          let(:commit_message) { dependabot_commit(%w[okhttp retrofit], 'version-update:semver-patch') }
+
+          it 'auto-merges when every dependency is a patch' do
+            expect(@plugin.auto_merge_patch_updates).to eq('all updates are patch level.')
+          end
+
+          it 'does nothing when one dependency is denylisted' do
+            expect(@plugin.auto_merge_patch_updates(denylist: ['retrofit'])).to be_nil
+          end
+
+          context 'with a minor bump' do
+            let(:commit_message) { dependabot_commit(%w[okhttp retrofit], 'version-update:semver-minor') }
+
+            it 'does nothing when only some dependencies are allowlisted' do
+              expect(@plugin.auto_merge_patch_updates(minor_update_allowlist: ['okhttp'])).to be_nil
+            end
+          end
+        end
+
+        context 'with a denylisted dependency' do
+          it 'does nothing, even on a patch update' do
+            expect(@plugin.auto_merge_patch_updates(denylist: ['okhttp'])).to be_nil
+          end
+
+          it 'matches dependency names exactly rather than by prefix' do
+            expect(@plugin.auto_merge_patch_updates(denylist: ['okhttp-urlconnection'])).to eq('all updates are patch level.')
+          end
+
+          it 'takes precedence over the minor update allowlist' do
+            expect(@plugin.auto_merge_patch_updates(denylist: ['okhttp'], minor_update_allowlist: ['okhttp'])).to be_nil
+          end
+        end
+
+        context 'when the pull request is not from Dependabot' do
+          before { allow(@plugin.github).to receive(:pr_author).and_return('mokagio') }
+
+          it 'does nothing' do
+            expect(@plugin.auto_merge_patch_updates).to be_nil
+          end
+        end
+
+        context 'when the pull request comes from a fork' do
+          let(:pr_json) do
+            super().merge('head' => { 'repo' => { 'full_name' => 'someone-else/dangermattic' } })
+          end
+
+          it 'does nothing' do
+            expect(@plugin.auto_merge_patch_updates).to be_nil
+          end
+        end
+
+        context 'with an unsupported merge method' do
+          it 'raises rather than sending it to GitHub' do
+            expect { @plugin.auto_merge_patch_updates(merge_method: 'FAST_FORWARD') }.to raise_error(ArgumentError, /MERGE, SQUASH, REBASE/)
+          end
+        end
+
+        context 'when GitHub rejects the mutation' do
+          before do
+            allow(api).to receive(:post).and_return({ errors: [{ message: 'Auto-merge is not allowed for this repository' }] })
+          end
+
+          it 'surfaces the error rather than reporting success' do
+            expect { @plugin.auto_merge_patch_updates }.to raise_error(/Auto-merge is not allowed/)
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/fixtures/dependabot/grouped_minor_update.txt
+++ b/spec/fixtures/dependabot/grouped_minor_update.txt
@@ -1,0 +1,36 @@
+Bump stripe-terminal from 5.1.1 to 5.6.0
+
+Bumps `stripe-terminal` from 5.1.1 to 5.6.0.
+
+Updates `com.stripe:stripeterminal-taptopay` from 5.1.1 to 5.6.0
+- [Release notes](https://github.com/stripe/stripe-terminal-android/releases)
+- [Changelog](https://github.com/stripe/stripe-terminal-android/blob/master/CHANGELOG.md)
+- [Commits](https://github.com/stripe/stripe-terminal-android/compare/v5.1.1...v5.6.0)
+
+Updates `com.stripe:stripeterminal-core` from 5.1.1 to 5.6.0
+- [Release notes](https://github.com/stripe/stripe-terminal-android/releases)
+- [Changelog](https://github.com/stripe/stripe-terminal-android/blob/master/CHANGELOG.md)
+- [Commits](https://github.com/stripe/stripe-terminal-android/compare/v5.1.1...v5.6.0)
+
+Updates `com.stripe:stripeterminal-ktx` from 5.1.1 to 5.6.0
+- [Release notes](https://github.com/stripe/stripe-terminal-android/releases)
+- [Changelog](https://github.com/stripe/stripe-terminal-android/blob/master/CHANGELOG.md)
+- [Commits](https://github.com/stripe/stripe-terminal-android/compare/v5.1.1...v5.6.0)
+
+---
+updated-dependencies:
+- dependency-name: com.stripe:stripeterminal-taptopay
+  dependency-version: 5.6.0
+  dependency-type: direct:production
+  update-type: version-update:semver-minor
+- dependency-name: com.stripe:stripeterminal-core
+  dependency-version: 5.6.0
+  dependency-type: direct:production
+  update-type: version-update:semver-minor
+- dependency-name: com.stripe:stripeterminal-ktx
+  dependency-version: 5.6.0
+  dependency-type: direct:production
+  update-type: version-update:semver-minor
+...
+
+Signed-off-by: dependabot[bot] <support@github.com>


### PR DESCRIPTION
> **Exploration, per @AliSoftware's suggestion on #135** that auto-merge might fit Dangermattic better as a plugin than as a reusable workflow. Draft, not proposed for merge. Same rules as #135, different front-end.

### It works

- **Update type** comes from the YAML document Dependabot appends to its commit message — the same source `dependabot/fetch-metadata` parses. No Action needed. Tested against a real grouped update captured from `woocommerce-android#16232`.
- **Approving** is `github.api.create_pull_request_review`. `github.api` is an Octokit client and `github_utils` already reaches for it.
- **Enabling auto-merge** has no REST endpoint, so it goes through the `enablePullRequestAutoMerge` GraphQL mutation via `Octokit::Client#post('/graphql', …)`.

Where Danger runs matters: every mobile repo triggers Danger on Buildkite with a write-scoped PAT, so the plugin can act. (`reusable-run-danger.yml` forces read-only for Dependabot PRs, but nothing calls it.)

### Tradeoffs, which are the point of this PR

**Danger is a reporter; this makes it an actuator.** Every other plugin observes a PR and leaves a message. This one approves and merges. That's a genuine change in what Dangermattic is, and the strongest argument against.

**Danger runs on events auto-merge doesn't care about** — `labeled`, `milestoned`, `synchronize`. So the plugin needs an idempotency guard, and it has one: it skips approving when it already approved. Enabling auto-merge is idempotent, so that's left unguarded. Not a race so much as noise avoidance, but it is complexity the workflow doesn't carry.

**It only serves repos that run Danger.** Fine for the mobile apps. It does nothing for AutoProxxy, hostmgr, or apps-infra-toolbox, which have no Ruby.

### What I'd conclude

These aren't competing implementations; they're two front-ends onto one rule. The workflow reaches repos with no Ruby. The plugin fits repos that already run Danger and would rather not add a workflow. If both live, the thing worth sharing is the decision logic, not the plumbing — and neither this branch nor #135 does that yet.

I lean toward shipping #135 and treating this as the answer to "could we?" rather than "should we?".

### State

Complete enough to judge, not to merge: 25 examples, `bundle exec rake` green (339 total), `danger plugins lint` passes. **It has never run against a real pull request** — the GitHub calls are all verified doubles, so the shapes are right but the round-trip is unproven. Not documented in the README, and there's no `Dangerfile` example.

I checked the tests bite by mutating the plugin four ways — dropping the already-approved guard, ignoring the allowlist, ignoring the denylist, and dropping the fork check. Each failed at least one example.

🤖 Generated with [Claude Code](https://claude.com/claude-code)