### PR TITLE
Detect team review requests via the reviewers API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ _None_
 
 ### Bug Fixes
 
-_None_
+- `github_utils`: `requested_reviewers?` now detects review requests assigned to a GitHub team when Danger runs with a token that cannot see the organization's teams. [#141]
 
 ### Internal Changes
 

--- a/lib/dangermattic/plugins/common/github_utils.rb
+++ b/lib/dangermattic/plugins/common/github_utils.rb
@@ -27,17 +27,19 @@ module Danger
     #
     # @return [Boolean] True if there are active reviewers, otherwise false.
     def active_reviewers?
-      repo_name = github.pr_json['base']['repo']['full_name']
-      pr_number = github.pr_json['number']
-
-      !github.api.pull_request_reviews(repo_name, pr_number).empty?
+      !github.api.pull_request_reviews(pr_repo_name, pr_number).empty?
     end
 
     # Checks if there are requested teams or reviewers who haven't reacted yet.
     #
     # @return [Boolean] True if there are requested teams or reviewers, otherwise false.
     def requested_reviewers?
-      has_requested_reviews = !github.pr_json['requested_teams'].to_a.empty? || !github.pr_json['requested_reviewers'].to_a.empty?
+      # GitHub strips `requested_teams` from the pull request payload — and therefore from `pr_json` —
+      # for tokens that cannot see the organization's teams, such as a bot account that is only an
+      # outside collaborator. The dedicated endpoint reports them regardless.
+      review_requests = github.api.pull_request_review_requests(pr_repo_name, pr_number)
+      has_requested_reviews = !review_requests['users'].to_a.empty? || !review_requests['teams'].to_a.empty?
+
       has_requested_reviews || active_reviewers?
     end
 
@@ -63,6 +65,16 @@ module Danger
       has_wip_title = github.pr_title.include?('WIP')
 
       has_wip_label || has_wip_title
+    end
+
+    private
+
+    def pr_repo_name
+      github.pr_json['base']['repo']['full_name']
+    end
+
+    def pr_number
+      github.pr_json['number']
     end
   end
 end

--- a/spec/github_utils_spec.rb
+++ b/spec/github_utils_spec.rb
@@ -13,9 +13,7 @@ module Danger
         instance_double(Danger::DangerfileGitHubPlugin, {
                           pr_json: {
                             'base' => { 'repo' => { 'full_name' => 'Automattic/dangermattic' } },
-                            'number' => 42,
-                            'requested_teams' => [],
-                            'requested_reviewers' => []
+                            'number' => 42
                           },
                           api: instance_double(Octokit::Client),
                           branch_for_base: 'main',
@@ -44,8 +42,20 @@ module Danger
       end
 
       describe '#requested_reviewers?' do
-        it 'returns true when there are requested reviewers' do
-          allow(github.pr_json).to receive(:[]).with('requested_teams').and_return(['team1'])
+        before do
+          allow(github.api).to receive_messages(
+            pull_request_review_requests: { 'users' => [], 'teams' => [] },
+            pull_request_reviews: []
+          )
+        end
+
+        it 'returns true when a user has been requested for review' do
+          allow(github.api).to receive(:pull_request_review_requests).and_return({ 'users' => ['user1'], 'teams' => [] })
+          expect(@plugin.requested_reviewers?).to be(true)
+        end
+
+        it 'returns true when only a team has been requested for review' do
+          allow(github.api).to receive(:pull_request_review_requests).and_return({ 'users' => [], 'teams' => ['team1'] })
           expect(@plugin.requested_reviewers?).to be(true)
         end
 
@@ -55,7 +65,6 @@ module Danger
         end
 
         it 'returns false when there are no requested reviewers or active reviewers' do
-          allow(github.api).to receive(:pull_request_reviews).and_return([])
           expect(@plugin.requested_reviewers?).to be(false)
         end
       end


### PR DESCRIPTION
## Rationale

Reported on [wordpress-mobile/release-toolkit#761](https://github.com/wordpress-mobile/release-toolkit/pull/761#issuecomment-5110015828): Danger warned "No reviewers have been set for this PR yet" on a PR whose `apps-infra-tooling` team review request had been pending for three minutes.

`requested_reviewers?` read `requested_teams` off `pr_json`. GitHub strips that field from the pull request payload for tokens that cannot see the organization's teams, and the `dangermattic` bot is an outside collaborator on `wordpress-mobile`, not a member. So on repos where `CODEOWNERS` assigns a team and no individual, the warning fired on every PR until someone (or Copilot) actually reviewed.

`GET /pulls/{n}/requested_reviewers` reports teams regardless of org visibility, so this switches to it.

## Gotchas

The old behaviour was masked in `release-toolkit` by `active_reviewers?`: Copilot's automatic review made the check pass before anyone noticed the team wasn't being seen.

This is not the timing race between PR creation and `CODEOWNERS` assignment that was also suspected on that thread — the failing Danger run happened three minutes after the request was recorded.

## How to test

`bundle exec rake`

Against the live PR that surfaced this, the two sources differ exactly as described — old source empty without org visibility, new source correct either way:

```
[org-visible token] pr_json['requested_teams'] -> ["apps-infra-tooling"]
[org-visible token] review_requests['teams']   -> ["apps-infra-tooling"]

[no org visibility] pr_json['requested_teams'] -> []
[no org visibility] review_requests['teams']   -> ["apps-infra-tooling"]
```