### PR TITLE
Release 1.4.1 into trunk

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,11 +14,17 @@ _None_
 
 ### Bug Fixes
 
-- `github_utils`: `requested_reviewers?` now detects review requests assigned to a GitHub team when Danger runs with a token that cannot see the organization's teams. [#141]
+_None_
 
 ### Internal Changes
 
 _None_
+
+## 1.4.1
+
+### Bug Fixes
+
+- `github_utils`: `requested_reviewers?` now detects review requests assigned to a GitHub team when Danger runs with a token that cannot see the organization's teams. [#141]
 
 ## 1.4.0
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    danger-dangermattic (1.4.0)
+    danger-dangermattic (1.4.1)
       danger (~> 9.5, >= 9.5.3)
       danger-plugin-api (~> 1.0)
       danger-rubocop (~> 0.13)

--- a/lib/dangermattic/gem_version.rb
+++ b/lib/dangermattic/gem_version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Dangermattic
-  VERSION = '1.4.0'
+  VERSION = '1.4.1'
 end


### PR DESCRIPTION
Releasing new version 1.4.1.

# What's Next

PR Author: Be sure to create and publish a GitHub Release pointing to `trunk` once this PR gets merged,
copy/pasting the following text as the GitHub Release's description:
```
### Bug Fixes

- `github_utils`: `requested_reviewers?` now detects review requests assigned to a GitHub team when Danger runs with a token that cannot see the organization's teams. [#141]
```