### PR TITLE
Failing specs demonstrating two defects in #112

### DIFF
--- a/spec/translation_context_checker_spec.rb
+++ b/spec/translation_context_checker_spec.rb
@@ -829,6 +829,56 @@ module Danger
           end
         end
 
+        context 'when the changed entry carries a same-line translator comment' do
+          let(:description) { 'Button that saves the edited settings.' }
+
+          def stub_single_line_entry(path, entry)
+            allow(@plugin.git).to receive(:modified_files).and_return([path])
+            allow(@plugin.git).to receive(:diff_for_file).with(path).and_return(
+              GitDiffStruct.new('modified', path, added_file_diff(path, [entry]))
+            )
+            allow(File).to receive(:exist?).with(path).and_return(true)
+            allow(File).to receive(:readlines).with(path).and_return([entry])
+            allow(@plugin).to receive(:run_extraction).and_return(
+              [
+                build_extraction_result(
+                  key: 'save.button',
+                  description: description,
+                  changed_translation_locations: ["#{path}:1"]
+                )
+              ]
+            )
+          end
+
+          it 'keeps the .strings entry in the apply-ready suggestion' do
+            strings_path = 'Localizable.strings'
+            stub_single_line_entry(strings_path, %("save.button" = "Save"; /* Old context */\n))
+
+            @plugin.check_context_suggestions(
+              source_paths: 'Sources',
+              translation_paths: strings_path,
+              discovery_mode: :translations,
+              inline_mode: :translation_suggestion
+            )
+
+            expect(status_markdowns.fetch(0).message).to include('"save.button" = "Save";')
+          end
+
+          it 'keeps the strings.xml entry in the apply-ready suggestion' do
+            xml_path = 'app/src/main/res/values/strings.xml'
+            stub_single_line_entry(xml_path, %(  <string name="save">Save</string> <!-- Old context -->\n))
+
+            @plugin.check_context_suggestions(
+              source_paths: 'app/src/main/java',
+              translation_paths: xml_path,
+              discovery_mode: :translations,
+              inline_mode: :translation_suggestion
+            )
+
+            expect(status_markdowns.fetch(0).message).to include('<string name="save">Save</string>')
+          end
+        end
+
         context 'with an Android collection child' do
           let(:xml_path) { 'app/src/main/res/values/strings.xml' }
 

--- a/spec/translation_context_checker_spec.rb
+++ b/spec/translation_context_checker_spec.rb
@@ -1465,6 +1465,28 @@ module Danger
 
           expect(added).to eq([['+new line', 9], ['+another line', 10]])
         end
+
+        it 'numbers added lines correctly when an added line begins with a plus' do
+          path = 'Sources/View.swift'
+          patch = <<~DIFF
+            diff --git a/#{path} b/#{path}
+            --- a/#{path}
+            +++ b/#{path}
+            @@ -1,1 +1,4 @@
+             first
+            +++ shell style marker
+            +second added
+            +third added
+          DIFF
+          allow(@plugin.danger.git).to receive(:diff_for_file).with(path).and_return(
+            GitDiffStruct.new('modified', path, patch)
+          )
+
+          added = []
+          @plugin.send(:each_added_diff_line, path) { |line, number| added << [line.chomp, number] }
+
+          expect(added).to eq([['+++ shell style marker', 2], ['+second added', 3], ['+third added', 4]])
+        end
       end
 
       describe 'suggestion escaping' do


### PR DESCRIPTION
This PR adds tests to demonstrate possible issues in #112. The tests are obviously failing, as the issues are yet to be addressed. If some or all the issues identified here are worth addressing, the PR can be merged on its base, and the code updated to fix the issues.

1. **A trailing translator comment makes the suggestion delete the string.** `comment_block_containing` (`location_resolver.rb:84`) counts a line that merely *contains* a complete comment as a comment block containing the location, so `start_line == end_line`, `replace_comment` turns on, and the emitted suggestion body is only the new comment. Applying it drops the entry.

2. **An added line starting with `++` shifts every line number after it.** `each_added_diff_line` (`location_resolver.rb:41`) runs its `'+++ '` header filter after the `@@` header is seen, so such a line is skipped without incrementing the counter.

---

*Posted by Claude Code (Opus 5) on behalf of @mokagio with approval.*
