### PR TITLE
[DO NOT MERGE] Validate retry-workflow concurrency for #145 (control 1)

### DIFF
--- a/.github/workflows/VALIDATION-NOTES.md
+++ b/.github/workflows/VALIDATION-NOTES.md
@@ -1,0 +1,21 @@
+# [DO NOT MERGE] Concurrency validation notes
+
+Scratch record for the throwaway PR. Deleted with the branch.
+
+Five arms, each fired with five pull request events within about a second.
+
+| Arm | Group | `cancel-in-progress` | Cancelled, before | Cancelled, after |
+| -- | -- | -- | -- | -- |
+| Per-run group | `…-github.run_id` | literal `false` | 0 of 5 | 0 of 5 |
+| Shared group | `…-github.ref` | literal `false` | 3 of 5 | 3 of 5 |
+| Retry workflow, default | `…-github.ref` | `${{ inputs.… }}` | 3 of 6 | 0 of 5 |
+| Retry workflow, explicit `false` | `…-github.ref` | `${{ inputs.… }}` | 2 of 5 | 0 of 5 |
+
+"Before" is the workflow as PR #145 first fixed it, with the input defaulted to `false`.
+"After" is with the concurrency block removed.
+
+The shared-group arm calls nothing and reads no input — it is the same group shape with a
+hardcoded `false` — and it cancels in both columns. That is what rules out `cancel-in-progress`
+as the lever: GitHub cancels a previously pending run in a shared group whatever it says.
+It also stays live in the "after" column, which is what stops the zeroes beside it from being
+an artifact of events that never overlapped.

--- a/.github/workflows/validation-assert-concurrency.yml
+++ b/.github/workflows/validation-assert-concurrency.yml
@@ -1,7 +1,7 @@
 # yaml-language-server: $schema=https://json.schemastore.org/github-workflow.json
 
-# [DO NOT MERGE] Reads back the two arms' run conclusions and fails on either wrong answer.
-# Runs on a push whose commit message contains `[assert]`, once both event storms have been fired.
+# [DO NOT MERGE] Reads back the newest run of each arm and fails on any wrong answer.
+# Runs on a push whose commit message contains `[assert]`, once the event storm has been fired.
 
 name: '[VALIDATION] Assert concurrency outcomes'
 
@@ -15,37 +15,51 @@ jobs:
     if: contains(github.event.head_commit.message, '[assert]')
     runs-on: ubuntu-latest
     steps:
-      - name: Compare cancellations across both arms
+      - name: Compare cancellations across every arm
         env:
           GH_TOKEN: ${{ github.token }}
           BRANCH: ${{ github.ref_name }}
         run: |
-          # Fails loudly rather than returning an empty list, which would read as "no cancellations"
-          conclusions() {
+          # One storm fires 5 events per arm, and the API returns newest first
+          cancelled_count() {
             local RUNS
-            RUNS=$(gh api "repos/$GITHUB_REPOSITORY/actions/workflows/$1/runs?branch=$BRANCH&per_page=100") || {
+            RUNS=$(gh api "repos/$GITHUB_REPOSITORY/actions/workflows/$1/runs?branch=$BRANCH&per_page=5") || {
               echo "::error::Could not read runs for $1 — the arm never ran, so there is nothing to compare." >&2
               return 1
             }
-            echo "$RUNS" | jq -r '.workflow_runs[] | .conclusion // "in_progress"'
+            echo "$RUNS" | jq -r '[.workflow_runs[] | select(.conclusion == "cancelled")] | length'
           }
 
-          CONTROL=$(conclusions validation-retry-concurrency-cancel-enabled.yml) || exit 1
-          TREATMENT=$(conclusions validation-retry-concurrency-default.yml) || exit 1
+          PER_RUN_GROUP=$(cancelled_count validation-group-per-run.yml) || exit 1
+          SHARED_GROUP=$(cancelled_count validation-group-shared-literal-false.yml) || exit 1
+          RETRY_DEFAULT=$(cancelled_count validation-retry-concurrency-default.yml) || exit 1
+          RETRY_EXPLICIT=$(cancelled_count validation-retry-concurrency-explicit-false.yml) || exit 1
 
-          echo "Control arm (cancel-running-github-jobs: true):"
-          echo "$CONTROL" | sort | uniq -c
-          echo "Treatment arm (default):"
-          echo "$TREATMENT" | sort | uniq -c
+          echo "Cancelled runs, newest storm, out of 5 per arm:"
+          echo "  per-run group, literal false:  $PER_RUN_GROUP"
+          echo "  shared group, literal false:   $SHARED_GROUP"
+          echo "  retry workflow, default:       $RETRY_DEFAULT"
+          echo "  retry workflow, explicit false:$RETRY_EXPLICIT"
 
-          if ! echo "$CONTROL" | grep -qx cancelled; then
-            echo "::error::Control arm cancelled nothing, so the events never overlapped and the treatment arm proves nothing. Re-fire them closer together."
-            exit 1
+          FAILED=0
+
+          # The positive control. Without a live cancellation the other arms' zeroes mean nothing,
+          # because events that never overlap also cancel nothing.
+          if [ "$SHARED_GROUP" -eq 0 ]; then
+            echo "::error::A shared group with cancel-in-progress:false cancelled nothing, so the events never overlapped and every other arm here is unfalsifiable. Re-fire them closer together."
+            FAILED=1
           fi
 
-          if echo "$TREATMENT" | grep -qx cancelled; then
-            echo "::error::Treatment arm has a cancelled run — defaulting cancel-running-github-jobs to false did not take effect."
-            exit 1
+          if [ "$PER_RUN_GROUP" -ne 0 ]; then
+            echo "::error::A per-run group cancelled $PER_RUN_GROUP runs, which should be impossible. The experiment is measuring something other than concurrency."
+            FAILED=1
           fi
 
-          echo "✅ The control arm cancelled its own runs and the treatment arm did not."
+          if [ "$RETRY_DEFAULT" -ne 0 ] || [ "$RETRY_EXPLICIT" -ne 0 ]; then
+            echo "::error::The retry workflow still cancels its own runs ($RETRY_DEFAULT by default, $RETRY_EXPLICIT with the input passed explicitly). Removing the concurrency group did not fix the red checks."
+            FAILED=1
+          fi
+
+          [ "$FAILED" -eq 0 ] || exit 1
+
+          echo "✅ A shared group still cancels $SHARED_GROUP of 5 while the retry workflow now cancels none."

--- a/.github/workflows/validation-assert-concurrency.yml
+++ b/.github/workflows/validation-assert-concurrency.yml
@@ -1,0 +1,51 @@
+# yaml-language-server: $schema=https://json.schemastore.org/github-workflow.json
+
+# [DO NOT MERGE] Reads back the two arms' run conclusions and fails on either wrong answer.
+# Runs on a push whose commit message contains `[assert]`, once both event storms have been fired.
+
+name: '[VALIDATION] Assert concurrency outcomes'
+
+on: push
+
+permissions:
+  actions: read
+
+jobs:
+  assert:
+    if: contains(github.event.head_commit.message, '[assert]')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Compare cancellations across both arms
+        env:
+          GH_TOKEN: ${{ github.token }}
+          BRANCH: ${{ github.ref_name }}
+        run: |
+          # Fails loudly rather than returning an empty list, which would read as "no cancellations"
+          conclusions() {
+            local RUNS
+            RUNS=$(gh api "repos/$GITHUB_REPOSITORY/actions/workflows/$1/runs?branch=$BRANCH&per_page=100") || {
+              echo "::error::Could not read runs for $1 — the arm never ran, so there is nothing to compare." >&2
+              return 1
+            }
+            echo "$RUNS" | jq -r '.workflow_runs[] | .conclusion // "in_progress"'
+          }
+
+          CONTROL=$(conclusions validation-retry-concurrency-cancel-enabled.yml) || exit 1
+          TREATMENT=$(conclusions validation-retry-concurrency-default.yml) || exit 1
+
+          echo "Control arm (cancel-running-github-jobs: true):"
+          echo "$CONTROL" | sort | uniq -c
+          echo "Treatment arm (default):"
+          echo "$TREATMENT" | sort | uniq -c
+
+          if ! echo "$CONTROL" | grep -qx cancelled; then
+            echo "::error::Control arm cancelled nothing, so the events never overlapped and the treatment arm proves nothing. Re-fire them closer together."
+            exit 1
+          fi
+
+          if echo "$TREATMENT" | grep -qx cancelled; then
+            echo "::error::Treatment arm has a cancelled run — defaulting cancel-running-github-jobs to false did not take effect."
+            exit 1
+          fi
+
+          echo "✅ The control arm cancelled its own runs and the treatment arm did not."

--- a/.github/workflows/validation-group-per-run.yml
+++ b/.github/workflows/validation-group-per-run.yml
@@ -1,0 +1,20 @@
+# yaml-language-server: $schema=https://json.schemastore.org/github-workflow.json
+
+# [DO NOT MERGE] Arm E: identical to arm D except the group is unique per run.
+# If D cancels and E does not, the group is the cause and a per-run group is the cure.
+
+name: '[VALIDATION] Per-run group'
+
+on:
+  pull_request:
+    types: [labeled, unlabeled]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.run_id }}
+  cancel-in-progress: false
+
+jobs:
+  hold:
+    runs-on: ubuntu-latest
+    steps:
+      - run: sleep 25

--- a/.github/workflows/validation-group-shared-literal-false.yml
+++ b/.github/workflows/validation-group-shared-literal-false.yml
@@ -1,0 +1,22 @@
+# yaml-language-server: $schema=https://json.schemastore.org/github-workflow.json
+
+# [DO NOT MERGE] Arm D: the reusable workflow's concurrency shape with a hardcoded
+# `cancel-in-progress: false`, and no reusable call at all.
+# Isolates the group from the input: if this still cancels, `cancel-in-progress` is not
+# what cancels these runs, and flipping it can never have fixed the red checks.
+
+name: '[VALIDATION] Shared group, literal false'
+
+on:
+  pull_request:
+    types: [labeled, unlabeled]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  hold:
+    runs-on: ubuntu-latest
+    steps:
+      - run: sleep 25

--- a/.github/workflows/validation-retry-concurrency-cancel-enabled.yml
+++ b/.github/workflows/validation-retry-concurrency-cancel-enabled.yml
@@ -1,0 +1,23 @@
+# yaml-language-server: $schema=https://json.schemastore.org/github-workflow.json
+
+# [DO NOT MERGE] Control arm: same call with `cancel-running-github-jobs: true`, the old default.
+# Rapid `edited` events on this PR MUST cancel each other — that is what proves the experiment
+# can detect a cancellation at all, and so that the treatment arm's silence means something.
+
+name: '[VALIDATION] Retry concurrency (cancel enabled)'
+
+on:
+  pull_request:
+    types: [edited]
+
+jobs:
+  retry:
+    uses: ./.github/workflows/reusable-retry-buildkite-step-on-events.yml
+    with:
+      org-slug: automattic
+      pipeline-slug: dangermattic
+      retry-step-key: rubocop
+      build-commit-sha: ${{ github.event.pull_request.head.sha }}
+      cancel-running-github-jobs: true
+    secrets:
+      buildkite-api-token: no-token-available-in-this-repo

--- a/.github/workflows/validation-retry-concurrency-default.yml
+++ b/.github/workflows/validation-retry-concurrency-default.yml
@@ -1,0 +1,21 @@
+# yaml-language-server: $schema=https://json.schemastore.org/github-workflow.json
+
+# [DO NOT MERGE] Treatment arm: calls the reusable workflow with the new default for
+# `cancel-running-github-jobs`. Rapid label events on this PR must NOT cancel each other.
+
+name: '[VALIDATION] Retry concurrency (default)'
+
+on:
+  pull_request:
+    types: [labeled, unlabeled]
+
+jobs:
+  retry:
+    uses: ./.github/workflows/reusable-retry-buildkite-step-on-events.yml
+    with:
+      org-slug: automattic
+      pipeline-slug: dangermattic
+      retry-step-key: rubocop
+      build-commit-sha: ${{ github.event.pull_request.head.sha }}
+    secrets:
+      buildkite-api-token: no-token-available-in-this-repo

--- a/.github/workflows/validation-retry-concurrency-explicit-false.yml
+++ b/.github/workflows/validation-retry-concurrency-explicit-false.yml
@@ -1,0 +1,22 @@
+# yaml-language-server: $schema=https://json.schemastore.org/github-workflow.json
+
+# [DO NOT MERGE] Arm C: passes `cancel-running-github-jobs: false` explicitly, to tell apart
+# "the new default is not being applied" from "the input does not control cancellation at all".
+
+name: '[VALIDATION] Retry concurrency (explicit false)'
+
+on:
+  pull_request:
+    types: [assigned, unassigned]
+
+jobs:
+  retry:
+    uses: ./.github/workflows/reusable-retry-buildkite-step-on-events.yml
+    with:
+      org-slug: automattic
+      pipeline-slug: dangermattic
+      retry-step-key: rubocop
+      build-commit-sha: ${{ github.event.pull_request.head.sha }}
+      cancel-running-github-jobs: false
+    secrets:
+      buildkite-api-token: no-token-available-in-this-repo


### PR DESCRIPTION
## Answered — closing

**It found a real defect.** Defaulting `cancel-running-github-jobs` to `false` did not stop the cancellations. Cancelled runs out of five, per arm:

| Arm | Group | `cancel-in-progress` | Before | After |
| -- | -- | -- | -- | -- |
| Per-run group | `…-github.run_id` | literal `false` | 0 | 0 |
| Shared group | `…-github.ref` | literal `false` | **3** | **3** |
| Retry workflow, default | `…-github.ref` | `${{ inputs.… }}` | **3 of 6** | **0** |
| Retry workflow, explicit `false` | `…-github.ref` | `${{ inputs.… }}` | **2** | **0** |

The shared-group arm calls nothing and reads no input, and still cancels — GitHub cancels a previously *pending* run in a shared group whatever `cancel-in-progress` says. The group was the cause; the flag was never the lever.

Fixed in [`78c44a7`](https://github.com/Automattic/dangermattic/commit/78c44a7) on #145 by removing the concurrency block. The "after" column is that commit. Assert step: [run 33468956760](https://github.com/Automattic/dangermattic/actions/runs/33468956760).

Full write-up on [#145](https://github.com/Automattic/dangermattic/pull/145#issuecomment-5488782778). Nothing here is worth keeping.

*Posted by Claude Code (Opus 5) on behalf of @mokagio with approval.*

---

## Validation only — do not merge

Stacked on [#145](https://github.com/Automattic/dangermattic/pull/145), branched from its head so the arms call the reusable workflow **as that PR changes it**.
This branch is a throwaway instrument. It will be closed once it has answered, not merged.

## Why #145's own checks cannot answer this

`reusable-retry-buildkite-step-on-events.yml` has **never been invoked in this repository** — `actions/workflows/reusable-retry-buildkite-step-on-events.yml/runs` reports `total_count: 0`, and nothing in `.github/workflows/` calls it. Dangermattic's CI is Buildkite; its GitHub Actions runs are Dependabot and Copilot only.

So on #145: RSpec executes the step's shell against a stubbed `curl`, which covers the parsing defects, but nothing hands the file to GitHub's parser and nothing exercises `concurrency`. The headline fix is pinned there only as a YAML literal — the spec asserts `default: false`, not that GitHub honours it.

## What to read, and what should fail

| Workflow | Fires on | Expected |
| -- | -- | -- |
| `[VALIDATION] Retry concurrency (default)` | `labeled`, `unlabeled` | every run reaches `failure`, **none `cancelled`** |
| `[VALIDATION] Retry concurrency (cancel enabled)` | `edited` | at least one run **`cancelled`** |
| `[VALIDATION] Assert concurrency outcomes` | push with `[assert]` | green |

**Every retry run here is expected to fail, and that is not the finding.** This repo has no Actions secrets, so the callers pass a placeholder Buildkite token and the first `curl` gets a 401. Please do not "fix" them.

The measurement is `cancelled` versus `failure` — precisely the distinction that made 107 PRs across 8 repos permanently red. A cancelled run is what GitHub renders as non-success forever.

## What each assertion proves

- **Control arm cancels** — the experiment can detect a cancellation at all. Without this, the treatment arm's silence would be indistinguishable from events that never overlapped, and the assert step fails on exactly that.
- **Treatment arm does not cancel** — defaulting `cancel-running-github-jobs` to `false` takes effect in GitHub, not just in the file.
- **Either arm's runs existing at all** — GitHub accepts the changed workflow as callable and resolves its inputs.
- Separate event types per arm keep them from confounding each other whichever way `github.workflow` resolves inside a called workflow.

## What this still cannot answer

The empty-build-list and missing-step-key paths need a `200` from Buildkite, and there is no API token available to Actions in this repo. Those stay covered by `spec/github_workflows/`, which runs the identical shell — verified against Debian bash 5.2.37 and jq 1.7.1, the same pairing `ubuntu-latest` provides.

Whether the check goes green on a real consumer can only be answered after `v1` moves, on a repo that pins it.

*Posted by Claude Code (Opus 5) on behalf of @mokagio with approval.*
